### PR TITLE
Code quality cleanup: unused deps, div_ceil, workspace deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,17 +102,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "askama_axum"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41603f7cdbf5ac4af60760f17253eb6adf6ec5b6f14a7ed830cf687d375f163"
-dependencies = [
- "askama",
- "axum-core 0.4.5",
- "http",
-]
-
-[[package]]
 name = "askama_derive"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,17 +142,6 @@ dependencies = [
  "compression-core",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "async-trait"
-version = "0.1.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -236,7 +214,7 @@ version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
- "axum-core 0.5.6",
+ "axum-core",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -261,26 +239,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -517,15 +475,12 @@ name = "cr-infra"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "chrono",
  "cr-app",
  "cr-domain",
  "csv",
  "dotenvy",
  "serde",
- "serde_json",
  "sqlx",
- "thiserror",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -537,7 +492,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "askama",
- "askama_axum",
  "axum",
  "chrono",
  "cr-app",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,12 @@ tower-http = { version = "0.6", features = ["cors", "compression-gzip", "trace",
 
 # Templates
 askama = "0.12"
-askama_axum = "0.4"
+
+# Image processing
+image = "0.25"
+
+# HTTP client
+reqwest = { version = "0.12", features = ["rustls-tls"], default-features = false }
 
 # Database
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "uuid", "chrono", "migrate"] }

--- a/cr-infra/Cargo.toml
+++ b/cr-infra/Cargo.toml
@@ -11,11 +11,8 @@ cr-domain = { workspace = true }
 cr-app = { workspace = true }
 sqlx = { workspace = true }
 tokio = { workspace = true }
-thiserror = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
-chrono = { workspace = true }
 csv = { workspace = true }
 tracing = { workspace = true }
 dotenvy = { workspace = true }

--- a/cr-web/Cargo.toml
+++ b/cr-web/Cargo.toml
@@ -15,7 +15,6 @@ tokio = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true }
 askama = { workspace = true }
-askama_axum = { workspace = true }
 sqlx = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -25,5 +24,5 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 chrono = { workspace = true }
 dotenvy = { workspace = true }
-image = "0.25"
-reqwest = { version = "0.12", features = ["rustls-tls"], default-features = false }
+image = { workspace = true }
+reqwest = { workspace = true }

--- a/cr-web/src/handlers/landmarks.rs
+++ b/cr-web/src/handlers/landmarks.rs
@@ -194,7 +194,7 @@ pub async fn landmarks_by_type(
         count: type_row.count,
     };
 
-    let total_pages = (type_info.count + LANDMARKS_PER_PAGE - 1) / LANDMARKS_PER_PAGE;
+    let total_pages = (type_info.count as u64).div_ceil(LANDMARKS_PER_PAGE as u64) as i64;
 
     let landmarks = sqlx::query_as::<_, LandmarkRow>(
         "SELECT l.id, l.name, l.slug, l.latitude, l.longitude, l.description, \

--- a/cr-web/src/handlers/mod.rs
+++ b/cr-web/src/handlers/mod.rs
@@ -1,3 +1,4 @@
+// Allow manual_div_ceil in askama-generated derive code (askama 0.12 issue, fixed in 0.15+)
 #![allow(clippy::manual_div_ceil)]
 use askama::Template;
 use axum::extract::{Path, State};

--- a/cr-web/src/handlers/pools.rs
+++ b/cr-web/src/handlers/pools.rs
@@ -77,7 +77,7 @@ pub async fn pools_by_category(
                 .await?
         }
     };
-    let total_pages = (total_count + per_page - 1) / per_page;
+    let total_pages = (total_count as u64).div_ceil(per_page as u64) as i64;
     let offset = (page - 1) * per_page;
 
     let base_query = "SELECT p.name, p.slug, p.description, m.name as municipality_name, \


### PR DESCRIPTION
## Summary
- Replace manual `(a + b - 1) / b` with `.div_ceil()` (via u64 cast, i64 method still unstable)
- Move `image` and `reqwest` to workspace dependencies
- Remove unused dependencies: `askama_axum`, `serde_json`/`chrono`/`thiserror` from cr-infra
- All clippy warnings resolved

## Related Issues
Closes #63

## Test plan
- [ ] `cargo clippy --workspace -- -D warnings` passes
- [ ] `cargo test --workspace` passes (14 tests)
- [ ] CI passes all checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)