### PR TITLE
Create query services in cr-app with AppError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,10 +454,7 @@ dependencies = [
 name = "cr-app"
 version = "0.1.0"
 dependencies = [
- "anyhow",
- "chrono",
  "cr-domain",
- "serde",
  "thiserror",
 ]
 

--- a/cr-app/Cargo.toml
+++ b/cr-app/Cargo.toml
@@ -9,6 +9,3 @@ license.workspace = true
 [dependencies]
 cr-domain = { workspace = true }
 thiserror = { workspace = true }
-anyhow = { workspace = true }
-serde = { workspace = true }
-chrono = { workspace = true }

--- a/cr-app/src/error.rs
+++ b/cr-app/src/error.rs
@@ -1,0 +1,14 @@
+//! Application-layer error type.
+
+/// Errors that can occur in the application layer.
+#[derive(Debug, thiserror::Error)]
+pub enum AppError {
+    #[error("not found")]
+    NotFound,
+
+    #[error("repository error: {0}")]
+    Repository(String),
+
+    #[error("domain error: {0}")]
+    Domain(#[from] cr_domain::DomainError),
+}

--- a/cr-app/src/lib.rs
+++ b/cr-app/src/lib.rs
@@ -2,11 +2,13 @@
 //!
 //! Application layer for the Czech Republic portal.
 //!
-//! Contains use-cases, query/command functions, and DTOs.
+//! Contains use-cases, query functions, and DTOs.
 //! Orchestrates between domain logic and infrastructure.
 //!
-//! ## Modules (planned)
+//! ## Modules
 //!
-//! - `queries` - Read operations (get_kraj_by_slug, list_okresy, etc.)
-//! - `commands` - Write operations (import_regions, etc.)
-//! - `dto` - Data Transfer Objects for API/view responses
+//! - `error` - Application-layer error types
+//! - `queries` - Read operations (homepage, region detail, etc.)
+
+pub mod error;
+pub mod queries;

--- a/cr-app/src/queries.rs
+++ b/cr-app/src/queries.rs
@@ -1,0 +1,130 @@
+//! Query (read) use-cases.
+//!
+//! Each function takes repository trait references and returns data.
+//! No framework dependencies — pure business logic orchestration.
+
+use crate::error::AppError;
+use cr_domain::repository::*;
+
+/// Get all regions for the homepage.
+pub async fn get_all_regions<R: RegionRepository>(repo: &R) -> Result<Vec<RegionRecord>, AppError> {
+    repo.find_all()
+        .await
+        .map_err(|e| AppError::Repository(format!("{e:?}")))
+}
+
+/// Get a region by slug.
+pub async fn get_region_by_slug<R: RegionRepository>(
+    repo: &R,
+    slug: &str,
+) -> Result<RegionRecord, AppError> {
+    repo.find_by_slug(slug)
+        .await
+        .map_err(|e| AppError::Repository(format!("{e:?}")))?
+        .ok_or(AppError::NotFound)
+}
+
+/// Get ORP list for a region.
+pub async fn get_orps_by_region<O: OrpRepository>(
+    repo: &O,
+    region_id: cr_domain::RegionId,
+) -> Result<Vec<OrpRecord>, AppError> {
+    repo.find_by_region(region_id)
+        .await
+        .map_err(|e| AppError::Repository(format!("{e:?}")))
+}
+
+/// Get ORP by slug.
+pub async fn get_orp_by_slug<O: OrpRepository>(
+    repo: &O,
+    slug: &str,
+) -> Result<OrpRecord, AppError> {
+    repo.find_by_slug(slug)
+        .await
+        .map_err(|e| AppError::Repository(format!("{e:?}")))?
+        .ok_or(AppError::NotFound)
+}
+
+/// Check if a slug is an ORP.
+pub async fn is_orp_slug<O: OrpRepository>(repo: &O, slug: &str) -> Result<bool, AppError> {
+    repo.exists_by_slug(slug)
+        .await
+        .map_err(|e| AppError::Repository(format!("{e:?}")))
+}
+
+/// Get municipality by slug within an ORP.
+pub async fn get_municipality<M: MunicipalityRepository>(
+    repo: &M,
+    slug: &str,
+    orp_id: cr_domain::OrpId,
+) -> Result<MunicipalityRecord, AppError> {
+    repo.find_by_slug_and_orp(slug, orp_id)
+        .await
+        .map_err(|e| AppError::Repository(format!("{e:?}")))?
+        .ok_or(AppError::NotFound)
+}
+
+/// Get municipalities for an ORP.
+pub async fn get_municipalities_by_orp<M: MunicipalityRepository>(
+    repo: &M,
+    orp_id: cr_domain::OrpId,
+) -> Result<Vec<MunicipalityRecord>, AppError> {
+    repo.find_by_orp(orp_id)
+        .await
+        .map_err(|e| AppError::Repository(format!("{e:?}")))
+}
+
+/// Get landmark detail by slug within an ORP.
+pub async fn get_landmark<L: LandmarkRepository>(
+    repo: &L,
+    slug: &str,
+    orp_id: cr_domain::OrpId,
+) -> Result<LandmarkRecord, AppError> {
+    repo.find_by_slug_and_orp(slug, orp_id)
+        .await
+        .map_err(|e| AppError::Repository(format!("{e:?}")))?
+        .ok_or(AppError::NotFound)
+}
+
+/// Get landmarks for an ORP.
+pub async fn get_landmarks_by_orp<L: LandmarkRepository>(
+    repo: &L,
+    orp_id: cr_domain::OrpId,
+) -> Result<Vec<LandmarkSummary>, AppError> {
+    repo.find_by_orp(orp_id)
+        .await
+        .map_err(|e| AppError::Repository(format!("{e:?}")))
+}
+
+/// Get pool detail by slug within an ORP.
+pub async fn get_pool<P: PoolRepository>(
+    repo: &P,
+    slug: &str,
+    orp_id: cr_domain::OrpId,
+) -> Result<PoolRecord, AppError> {
+    repo.find_by_slug_and_orp(slug, orp_id)
+        .await
+        .map_err(|e| AppError::Repository(format!("{e:?}")))?
+        .ok_or(AppError::NotFound)
+}
+
+/// Get pools for an ORP.
+pub async fn get_pools_by_orp<P: PoolRepository>(
+    repo: &P,
+    orp_id: cr_domain::OrpId,
+) -> Result<Vec<PoolSummary>, AppError> {
+    repo.find_by_orp(orp_id)
+        .await
+        .map_err(|e| AppError::Repository(format!("{e:?}")))
+}
+
+/// Get photos for an entity.
+pub async fn get_photos<Ph: PhotoRepository>(
+    repo: &Ph,
+    entity_type: &str,
+    entity_id: i32,
+) -> Result<Vec<PhotoRecord>, AppError> {
+    repo.find_by_entity(entity_type, entity_id)
+        .await
+        .map_err(|e| AppError::Repository(format!("{e:?}")))
+}

--- a/cr-domain/src/repository.rs
+++ b/cr-domain/src/repository.rs
@@ -8,7 +8,7 @@ use crate::id::*;
 /// Repository for region queries.
 #[allow(async_fn_in_trait)]
 pub trait RegionRepository {
-    type Error;
+    type Error: std::fmt::Debug;
     async fn find_all(&self) -> Result<Vec<RegionRecord>, Self::Error>;
     async fn find_by_slug(&self, slug: &str) -> Result<Option<RegionRecord>, Self::Error>;
 }
@@ -16,7 +16,7 @@ pub trait RegionRepository {
 /// Repository for ORP queries.
 #[allow(async_fn_in_trait)]
 pub trait OrpRepository {
-    type Error;
+    type Error: std::fmt::Debug;
     async fn find_by_slug(&self, slug: &str) -> Result<Option<OrpRecord>, Self::Error>;
     async fn find_by_region(&self, region_id: RegionId) -> Result<Vec<OrpRecord>, Self::Error>;
     async fn exists_by_slug(&self, slug: &str) -> Result<bool, Self::Error>;
@@ -25,7 +25,7 @@ pub trait OrpRepository {
 /// Repository for municipality queries.
 #[allow(async_fn_in_trait)]
 pub trait MunicipalityRepository {
-    type Error;
+    type Error: std::fmt::Debug;
     async fn find_by_slug_and_orp(
         &self,
         slug: &str,
@@ -37,7 +37,7 @@ pub trait MunicipalityRepository {
 /// Repository for landmark queries.
 #[allow(async_fn_in_trait)]
 pub trait LandmarkRepository {
-    type Error;
+    type Error: std::fmt::Debug;
     async fn find_by_slug_and_orp(
         &self,
         slug: &str,
@@ -50,7 +50,7 @@ pub trait LandmarkRepository {
 /// Repository for pool queries.
 #[allow(async_fn_in_trait)]
 pub trait PoolRepository {
-    type Error;
+    type Error: std::fmt::Debug;
     async fn find_by_slug_and_orp(
         &self,
         slug: &str,
@@ -62,7 +62,7 @@ pub trait PoolRepository {
 /// Repository for photo metadata queries.
 #[allow(async_fn_in_trait)]
 pub trait PhotoRepository {
-    type Error;
+    type Error: std::fmt::Debug;
     async fn find_by_entity(
         &self,
         entity_type: &str,


### PR DESCRIPTION
## Summary
- `AppError` enum: `NotFound`, `Repository`, `Domain` variants
- Query functions using repository traits: `get_all_regions`, `get_region_by_slug`, `get_orp_by_slug`, etc.
- Covers all current use-cases: homepage, region, ORP, municipality, landmark, pool, photos
- Remove unused `serde`/`anyhow`/`chrono` from cr-app deps
- Add `Debug` bound to repository `Error` associated types

## Related Issues
Closes #72

## Test plan
- [ ] `cargo check --workspace` passes
- [ ] `cargo test --workspace` passes (33 tests)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)