### PR TITLE
Implement repository traits in cr-infra with SQLx

### DIFF
--- a/cr-infra/src/lib.rs
+++ b/cr-infra/src/lib.rs
@@ -5,8 +5,11 @@
 //! Implements persistence (SQLx/PostgreSQL), CSV data import,
 //! and external service integrations.
 //!
-//! ## Modules (planned)
+//! ## Modules
 //!
-//! - `db` - SQLx queries, migrations
-//! - `import` - CSV importer for ČSÚ territorial data
-//! - `github` - GitHub integration (Octocrab)
+//! - `repositories` - SQLx-based repository implementations
+//! - `db` (planned) - SQLx queries, migrations
+//! - `import` (planned) - CSV importer for ČSÚ territorial data
+//! - `github` (planned) - GitHub integration (Octocrab)
+
+pub mod repositories;

--- a/cr-infra/src/repositories/landmark.rs
+++ b/cr-infra/src/repositories/landmark.rs
@@ -1,0 +1,138 @@
+use cr_domain::id::OrpId;
+use cr_domain::repository::{LandmarkRecord, LandmarkRepository, LandmarkSummary};
+
+/// PostgreSQL implementation of [`LandmarkRepository`].
+pub struct PgLandmarkRepository {
+    pool: sqlx::PgPool,
+}
+
+impl PgLandmarkRepository {
+    pub fn new(pool: sqlx::PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct LandmarkRow {
+    id: i32,
+    name: String,
+    slug: String,
+    latitude: Option<f64>,
+    longitude: Option<f64>,
+    description: Option<String>,
+    wikipedia_url: Option<String>,
+    image_ext: Option<String>,
+    npu_catalog_id: Option<String>,
+    type_slug: String,
+    type_name: String,
+    municipality_name: Option<String>,
+    municipality_slug: Option<String>,
+    orp_slug: Option<String>,
+    region_slug: Option<String>,
+}
+
+impl From<LandmarkRow> for LandmarkRecord {
+    fn from(r: LandmarkRow) -> Self {
+        Self {
+            id: r.id,
+            name: r.name,
+            slug: r.slug,
+            latitude: r.latitude,
+            longitude: r.longitude,
+            description: r.description,
+            wikipedia_url: r.wikipedia_url,
+            image_ext: r.image_ext,
+            npu_catalog_id: r.npu_catalog_id,
+            type_slug: r.type_slug,
+            type_name: r.type_name,
+            municipality_name: r.municipality_name,
+            municipality_slug: r.municipality_slug,
+            orp_slug: r.orp_slug,
+            region_slug: r.region_slug,
+        }
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct LandmarkSummaryRow {
+    name: String,
+    slug: String,
+    type_name: String,
+    municipality_name: String,
+    municipality_slug: String,
+    is_main: bool,
+}
+
+impl From<LandmarkSummaryRow> for LandmarkSummary {
+    fn from(r: LandmarkSummaryRow) -> Self {
+        Self {
+            name: r.name,
+            slug: r.slug,
+            type_name: r.type_name,
+            municipality_name: r.municipality_name,
+            municipality_slug: r.municipality_slug,
+            is_main: r.is_main,
+        }
+    }
+}
+
+impl LandmarkRepository for PgLandmarkRepository {
+    type Error = sqlx::Error;
+
+    async fn find_by_slug_and_orp(
+        &self,
+        slug: &str,
+        orp_id: OrpId,
+    ) -> Result<Option<LandmarkRecord>, Self::Error> {
+        let row = sqlx::query_as::<_, LandmarkRow>(
+            "SELECT l.id, l.name, l.slug, l.latitude, l.longitude, l.description, \
+             l.wikipedia_url, l.image_ext, l.npu_catalog_id, \
+             lt.slug as type_slug, lt.name as type_name, \
+             m.name as municipality_name, m.slug as municipality_slug, \
+             o2.slug as orp_slug, r2.slug as region_slug \
+             FROM landmarks l \
+             JOIN landmark_types lt ON l.type_id = lt.id \
+             LEFT JOIN municipalities m ON l.municipality_id = m.id \
+             LEFT JOIN orp o2 ON m.orp_id = o2.id \
+             LEFT JOIN districts d2 ON o2.district_id = d2.id \
+             LEFT JOIN regions r2 ON d2.region_id = r2.id \
+             WHERE l.slug = $1 AND m.orp_id = $2",
+        )
+        .bind(slug)
+        .bind(orp_id.value())
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row.map(LandmarkRecord::from))
+    }
+
+    async fn find_by_orp(&self, orp_id: OrpId) -> Result<Vec<LandmarkSummary>, Self::Error> {
+        let rows = sqlx::query_as::<_, LandmarkSummaryRow>(
+            "SELECT l.name, l.slug, lt.name as type_name, m.name as municipality_name, \
+             m.slug as municipality_slug, false as is_main \
+             FROM landmarks l \
+             JOIN landmark_types lt ON l.type_id = lt.id \
+             JOIN municipalities m ON l.municipality_id = m.id \
+             WHERE m.orp_id = $1 \
+             ORDER BY lt.name, l.name",
+        )
+        .bind(orp_id.value())
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows.into_iter().map(LandmarkSummary::from).collect())
+    }
+
+    async fn count_by_type(&self, type_slug: &str) -> Result<i64, Self::Error> {
+        let count = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM landmarks l \
+             JOIN landmark_types lt ON l.type_id = lt.id \
+             WHERE lt.slug = $1",
+        )
+        .bind(type_slug)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(count)
+    }
+}

--- a/cr-infra/src/repositories/mod.rs
+++ b/cr-infra/src/repositories/mod.rs
@@ -1,0 +1,18 @@
+//! SQLx-based repository implementations for PostgreSQL.
+//!
+//! Each struct wraps a `sqlx::PgPool` and implements the corresponding
+//! trait from `cr_domain::repository`.
+
+mod landmark;
+mod municipality;
+mod orp;
+mod photo;
+mod pool;
+mod region;
+
+pub use landmark::PgLandmarkRepository;
+pub use municipality::PgMunicipalityRepository;
+pub use orp::PgOrpRepository;
+pub use photo::PgPhotoRepository;
+pub use pool::PgPoolRepository;
+pub use region::PgRegionRepository;

--- a/cr-infra/src/repositories/municipality.rs
+++ b/cr-infra/src/repositories/municipality.rs
@@ -1,0 +1,85 @@
+use cr_domain::id::OrpId;
+use cr_domain::repository::{MunicipalityRecord, MunicipalityRepository};
+
+/// PostgreSQL implementation of [`MunicipalityRepository`].
+pub struct PgMunicipalityRepository {
+    pool: sqlx::PgPool,
+}
+
+impl PgMunicipalityRepository {
+    pub fn new(pool: sqlx::PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct MunicipalityRow {
+    id: i32,
+    name: String,
+    slug: String,
+    municipality_code: String,
+    pou_code: String,
+    latitude: Option<f64>,
+    longitude: Option<f64>,
+    wikipedia_url: Option<String>,
+    official_website: Option<String>,
+    coat_of_arms_ext: Option<String>,
+    flag_ext: Option<String>,
+    population: Option<i32>,
+    elevation: Option<f64>,
+}
+
+impl From<MunicipalityRow> for MunicipalityRecord {
+    fn from(r: MunicipalityRow) -> Self {
+        Self {
+            id: r.id,
+            name: r.name,
+            slug: r.slug,
+            municipality_code: r.municipality_code,
+            pou_code: r.pou_code,
+            latitude: r.latitude,
+            longitude: r.longitude,
+            wikipedia_url: r.wikipedia_url,
+            official_website: r.official_website,
+            coat_of_arms_ext: r.coat_of_arms_ext,
+            flag_ext: r.flag_ext,
+            population: r.population,
+            elevation: r.elevation,
+        }
+    }
+}
+
+impl MunicipalityRepository for PgMunicipalityRepository {
+    type Error = sqlx::Error;
+
+    async fn find_by_slug_and_orp(
+        &self,
+        slug: &str,
+        orp_id: OrpId,
+    ) -> Result<Option<MunicipalityRecord>, Self::Error> {
+        let row = sqlx::query_as::<_, MunicipalityRow>(
+            "SELECT id, name, slug, municipality_code, pou_code, latitude, longitude, \
+             wikipedia_url, official_website, coat_of_arms_ext, flag_ext, population, elevation \
+             FROM municipalities WHERE orp_id = $1 AND slug = $2",
+        )
+        .bind(orp_id.value())
+        .bind(slug)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row.map(MunicipalityRecord::from))
+    }
+
+    async fn find_by_orp(&self, orp_id: OrpId) -> Result<Vec<MunicipalityRecord>, Self::Error> {
+        let rows = sqlx::query_as::<_, MunicipalityRow>(
+            "SELECT id, name, slug, municipality_code, pou_code, latitude, longitude, \
+             wikipedia_url, official_website, coat_of_arms_ext, flag_ext, population, elevation \
+             FROM municipalities WHERE orp_id = $1 ORDER BY name",
+        )
+        .bind(orp_id.value())
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows.into_iter().map(MunicipalityRecord::from).collect())
+    }
+}

--- a/cr-infra/src/repositories/orp.rs
+++ b/cr-infra/src/repositories/orp.rs
@@ -1,0 +1,78 @@
+use cr_domain::id::RegionId;
+use cr_domain::repository::{OrpRecord, OrpRepository};
+
+/// PostgreSQL implementation of [`OrpRepository`].
+pub struct PgOrpRepository {
+    pool: sqlx::PgPool,
+}
+
+impl PgOrpRepository {
+    pub fn new(pool: sqlx::PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct OrpRow {
+    id: i32,
+    name: String,
+    slug: String,
+    orp_code: String,
+    latitude: Option<f64>,
+    longitude: Option<f64>,
+}
+
+impl From<OrpRow> for OrpRecord {
+    fn from(r: OrpRow) -> Self {
+        Self {
+            id: r.id,
+            name: r.name,
+            slug: r.slug,
+            orp_code: r.orp_code,
+            latitude: r.latitude,
+            longitude: r.longitude,
+        }
+    }
+}
+
+impl OrpRepository for PgOrpRepository {
+    type Error = sqlx::Error;
+
+    async fn find_by_slug(&self, slug: &str) -> Result<Option<OrpRecord>, Self::Error> {
+        let row = sqlx::query_as::<_, OrpRow>(
+            "SELECT o.id, o.name, o.slug, o.orp_code, o.latitude, o.longitude \
+             FROM orp o \
+             JOIN districts d ON o.district_id = d.id \
+             WHERE o.slug = $1",
+        )
+        .bind(slug)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row.map(OrpRecord::from))
+    }
+
+    async fn find_by_region(&self, region_id: RegionId) -> Result<Vec<OrpRecord>, Self::Error> {
+        let rows = sqlx::query_as::<_, OrpRow>(
+            "SELECT o.id, o.name, o.slug, o.orp_code, o.latitude, o.longitude \
+             FROM orp o \
+             JOIN districts d ON o.district_id = d.id \
+             WHERE d.region_id = $1 ORDER BY o.name",
+        )
+        .bind(region_id.value())
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows.into_iter().map(OrpRecord::from).collect())
+    }
+
+    async fn exists_by_slug(&self, slug: &str) -> Result<bool, Self::Error> {
+        let exists =
+            sqlx::query_scalar::<_, bool>("SELECT EXISTS(SELECT 1 FROM orp WHERE slug = $1)")
+                .bind(slug)
+                .fetch_one(&self.pool)
+                .await?;
+
+        Ok(exists)
+    }
+}

--- a/cr-infra/src/repositories/photo.rs
+++ b/cr-infra/src/repositories/photo.rs
@@ -1,0 +1,50 @@
+use cr_domain::repository::{PhotoRecord, PhotoRepository};
+
+/// PostgreSQL implementation of [`PhotoRepository`].
+pub struct PgPhotoRepository {
+    pool: sqlx::PgPool,
+}
+
+impl PgPhotoRepository {
+    pub fn new(pool: sqlx::PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct PhotoRow {
+    r2_key: String,
+    width: i16,
+    height: i16,
+}
+
+impl From<PhotoRow> for PhotoRecord {
+    fn from(r: PhotoRow) -> Self {
+        Self {
+            r2_key: r.r2_key,
+            width: r.width,
+            height: r.height,
+        }
+    }
+}
+
+impl PhotoRepository for PgPhotoRepository {
+    type Error = sqlx::Error;
+
+    async fn find_by_entity(
+        &self,
+        entity_type: &str,
+        entity_id: i32,
+    ) -> Result<Vec<PhotoRecord>, Self::Error> {
+        let rows = sqlx::query_as::<_, PhotoRow>(
+            "SELECT r2_key, width, height FROM photo_metadata \
+             WHERE entity_type = $1 AND entity_id = $2 ORDER BY photo_index",
+        )
+        .bind(entity_type)
+        .bind(entity_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows.into_iter().map(PhotoRecord::from).collect())
+    }
+}

--- a/cr-infra/src/repositories/pool.rs
+++ b/cr-infra/src/repositories/pool.rs
@@ -1,0 +1,123 @@
+use cr_domain::id::OrpId;
+use cr_domain::repository::{PoolRecord, PoolRepository, PoolSummary};
+
+/// PostgreSQL implementation of [`PoolRepository`].
+pub struct PgPoolRepository {
+    pool: sqlx::PgPool,
+}
+
+impl PgPoolRepository {
+    pub fn new(pool: sqlx::PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct PoolDetailRow {
+    id: i32,
+    name: String,
+    slug: String,
+    description: Option<String>,
+    address: Option<String>,
+    latitude: Option<f64>,
+    longitude: Option<f64>,
+    website: Option<String>,
+    email: Option<String>,
+    phone: Option<String>,
+    facebook: Option<String>,
+    facilities: Option<String>,
+    pool_length_m: Option<i32>,
+    is_aquapark: bool,
+    is_indoor: bool,
+    is_outdoor: bool,
+    is_natural: bool,
+    photo_count: i16,
+    municipality_name: Option<String>,
+}
+
+impl From<PoolDetailRow> for PoolRecord {
+    fn from(r: PoolDetailRow) -> Self {
+        Self {
+            id: r.id,
+            name: r.name,
+            slug: r.slug,
+            description: r.description,
+            address: r.address,
+            latitude: r.latitude,
+            longitude: r.longitude,
+            website: r.website,
+            email: r.email,
+            phone: r.phone,
+            facebook: r.facebook,
+            facilities: r.facilities,
+            pool_length_m: r.pool_length_m,
+            is_aquapark: r.is_aquapark,
+            is_indoor: r.is_indoor,
+            is_outdoor: r.is_outdoor,
+            is_natural: r.is_natural,
+            photo_count: r.photo_count,
+            municipality_name: r.municipality_name,
+        }
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct PoolSummaryRow {
+    name: String,
+    slug: String,
+    is_aquapark: bool,
+    is_indoor: bool,
+    is_outdoor: bool,
+    is_natural: bool,
+}
+
+impl From<PoolSummaryRow> for PoolSummary {
+    fn from(r: PoolSummaryRow) -> Self {
+        Self {
+            name: r.name,
+            slug: r.slug,
+            is_aquapark: r.is_aquapark,
+            is_indoor: r.is_indoor,
+            is_outdoor: r.is_outdoor,
+            is_natural: r.is_natural,
+        }
+    }
+}
+
+impl PoolRepository for PgPoolRepository {
+    type Error = sqlx::Error;
+
+    async fn find_by_slug_and_orp(
+        &self,
+        slug: &str,
+        orp_id: OrpId,
+    ) -> Result<Option<PoolRecord>, Self::Error> {
+        let row = sqlx::query_as::<_, PoolDetailRow>(
+            "SELECT p.id, p.name, p.slug, p.description, p.address, p.latitude, p.longitude, \
+             p.website, p.email, p.phone, p.facebook, p.facilities, p.pool_length_m, \
+             p.is_aquapark, p.is_indoor, p.is_outdoor, p.is_natural, p.photo_count, \
+             m.name as municipality_name \
+             FROM pools p \
+             LEFT JOIN municipalities m ON p.municipality_id = m.id \
+             WHERE p.slug = $1 AND p.orp_id = $2",
+        )
+        .bind(slug)
+        .bind(orp_id.value())
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row.map(PoolRecord::from))
+    }
+
+    async fn find_by_orp(&self, orp_id: OrpId) -> Result<Vec<PoolSummary>, Self::Error> {
+        let rows = sqlx::query_as::<_, PoolSummaryRow>(
+            "SELECT name, slug, is_aquapark, is_indoor, is_outdoor, is_natural \
+             FROM pools WHERE orp_id = $1 ORDER BY name",
+        )
+        .bind(orp_id.value())
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows.into_iter().map(PoolSummary::from).collect())
+    }
+}

--- a/cr-infra/src/repositories/region.rs
+++ b/cr-infra/src/repositories/region.rs
@@ -1,0 +1,70 @@
+use cr_domain::repository::{RegionRecord, RegionRepository};
+
+/// PostgreSQL implementation of [`RegionRepository`].
+pub struct PgRegionRepository {
+    pool: sqlx::PgPool,
+}
+
+impl PgRegionRepository {
+    pub fn new(pool: sqlx::PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct RegionRow {
+    id: i32,
+    name: String,
+    slug: String,
+    region_code: String,
+    latitude: Option<f64>,
+    longitude: Option<f64>,
+    coat_of_arms_ext: Option<String>,
+    flag_ext: Option<String>,
+    description: Option<String>,
+}
+
+impl From<RegionRow> for RegionRecord {
+    fn from(r: RegionRow) -> Self {
+        Self {
+            id: r.id,
+            name: r.name,
+            slug: r.slug,
+            region_code: r.region_code,
+            latitude: r.latitude,
+            longitude: r.longitude,
+            coat_of_arms_ext: r.coat_of_arms_ext,
+            flag_ext: r.flag_ext,
+            description: r.description,
+        }
+    }
+}
+
+impl RegionRepository for PgRegionRepository {
+    type Error = sqlx::Error;
+
+    async fn find_all(&self) -> Result<Vec<RegionRecord>, Self::Error> {
+        let rows = sqlx::query_as::<_, RegionRow>(
+            "SELECT id, name, slug, region_code, latitude, longitude, \
+             coat_of_arms_ext, flag_ext, description \
+             FROM regions ORDER BY name",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows.into_iter().map(RegionRecord::from).collect())
+    }
+
+    async fn find_by_slug(&self, slug: &str) -> Result<Option<RegionRecord>, Self::Error> {
+        let row = sqlx::query_as::<_, RegionRow>(
+            "SELECT id, name, slug, region_code, latitude, longitude, \
+             coat_of_arms_ext, flag_ext, description \
+             FROM regions WHERE slug = $1",
+        )
+        .bind(slug)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row.map(RegionRecord::from))
+    }
+}


### PR DESCRIPTION
## Summary
- 6 PostgreSQL repository implementations: Region, Orp, Municipality, Landmark, Pool, Photo
- Internal `sqlx::FromRow` row types mapped to domain record types via `From` impls
- SQL queries copied from existing proven handler queries
- `Error = sqlx::Error` for all repositories
- Foundation for #74 (cr-web handler refactoring)

## Related Issues
Closes #73

## Test plan
- [ ] `cargo check --workspace` passes
- [ ] `cargo test --workspace` passes (33 tests)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)