### PR TITLE
Wire cr-web handlers to use cr-infra repositories

### DIFF
--- a/cr-web/src/handlers/landmarks.rs
+++ b/cr-web/src/handlers/landmarks.rs
@@ -89,14 +89,7 @@ pub(crate) async fn render_landmark(
         return not_found(&state.image_base_url);
     };
 
-    let photos = fetch_photos(
-        &state.db,
-        &state.image_base_url,
-        "landmark",
-        landmark.id,
-        &landmark.slug,
-    )
-    .await;
+    let photos = fetch_photos(state, "landmark", landmark.id, &landmark.slug).await;
 
     let tmpl = LandmarkDetailTemplate {
         img: state.image_base_url.clone(),

--- a/cr-web/src/handlers/mod.rs
+++ b/cr-web/src/handlers/mod.rs
@@ -4,6 +4,7 @@ use askama::Template;
 use axum::extract::{Path, State};
 use axum::http::{StatusCode, Uri, header};
 use axum::response::{Html, IntoResponse, Response};
+use cr_domain::repository::{PhotoRepository, RegionRepository};
 
 use crate::error::WebResult;
 use crate::state::AppState;
@@ -117,42 +118,34 @@ pub(crate) struct PhotoInfo {
     pub(crate) height: i16,
 }
 
-#[derive(sqlx::FromRow)]
-struct PhotoMetadataRow {
-    r2_key: String,
-    width: i16,
-    height: i16,
-}
-
 pub(crate) async fn fetch_photos(
-    db: &sqlx::PgPool,
-    img_base: &str,
+    state: &AppState,
     entity_type: &str,
     entity_id: i32,
     slug: &str,
 ) -> Vec<PhotoInfo> {
-    let rows = sqlx::query_as::<_, PhotoMetadataRow>(
-        "SELECT r2_key, width, height FROM photo_metadata \
-         WHERE entity_type = $1 AND entity_id = $2 ORDER BY photo_index",
-    )
-    .bind(entity_type)
-    .bind(entity_id)
-    .fetch_all(db)
-    .await
-    .unwrap_or_else(|e| {
-        tracing::error!("fetch_photos query failed: {e}");
-        Vec::new()
-    });
+    let records = state
+        .photo_repo
+        .find_by_entity(entity_type, entity_id)
+        .await
+        .unwrap_or_else(|e| {
+            tracing::error!("fetch_photos query failed: {e}");
+            Vec::new()
+        });
 
-    rows.into_iter()
+    records
+        .into_iter()
         .map(|r| {
             let url = if entity_type == "landmark" {
                 // SEO URL: /img/landmarks/{slug}-{r2_filename}
                 let filename = r.r2_key.strip_prefix("landmarks/").unwrap_or(&r.r2_key);
-                format!("{}/img/landmarks/{}-{}", img_base, slug, filename)
+                format!(
+                    "{}/img/landmarks/{}-{}",
+                    state.image_base_url, slug, filename
+                )
             } else {
                 // Pools: /img/{r2_key} (slug already in filename)
-                format!("{}/img/{}", img_base, r.r2_key)
+                format!("{}/img/{}", state.image_base_url, r.r2_key)
             };
             let thumb_url = format!("{}?w=360", &url);
             PhotoInfo {
@@ -484,9 +477,13 @@ pub async fn health() -> &'static str {
 }
 
 pub async fn homepage(State(state): State<AppState>) -> WebResult<impl IntoResponse> {
-    let regions = sqlx::query_as::<_, RegionRow>("SELECT id, name, slug, region_code, latitude, longitude, coat_of_arms_ext, flag_ext, description FROM regions ORDER BY name")
-        .fetch_all(&state.db)
-        .await?;
+    let regions: Vec<RegionRow> = state
+        .region_repo
+        .find_all()
+        .await?
+        .into_iter()
+        .map(RegionRow::from)
+        .collect();
 
     let tmpl = HomepageTemplate {
         img: state.image_base_url.clone(),

--- a/cr-web/src/handlers/pools.rs
+++ b/cr-web/src/handlers/pools.rs
@@ -168,14 +168,7 @@ pub(crate) async fn render_pool(
         return not_found(&state.image_base_url);
     };
 
-    let photos = fetch_photos(
-        &state.db,
-        &state.image_base_url,
-        "pool",
-        pool.id,
-        &pool.slug,
-    )
-    .await;
+    let photos = fetch_photos(state, "pool", pool.id, &pool.slug).await;
 
     let tmpl = PoolDetailTemplate {
         img: state.image_base_url.clone(),

--- a/cr-web/src/handlers/regions.rs
+++ b/cr-web/src/handlers/regions.rs
@@ -1,33 +1,68 @@
+use cr_domain::id::RegionId;
+use cr_domain::repository::{OrpRepository, RegionRepository};
+
 use super::*;
+
+impl From<cr_domain::repository::RegionRecord> for RegionRow {
+    fn from(r: cr_domain::repository::RegionRecord) -> Self {
+        Self {
+            id: r.id,
+            name: r.name,
+            slug: r.slug,
+            region_code: r.region_code,
+            latitude: r.latitude,
+            longitude: r.longitude,
+            coat_of_arms_ext: r.coat_of_arms_ext,
+            flag_ext: r.flag_ext,
+            description: r.description,
+        }
+    }
+}
+
+impl From<cr_domain::repository::OrpRecord> for OrpRow {
+    fn from(r: cr_domain::repository::OrpRecord) -> Self {
+        Self {
+            id: r.id,
+            name: r.name,
+            slug: r.slug,
+            orp_code: r.orp_code,
+            latitude: r.latitude,
+            longitude: r.longitude,
+        }
+    }
+}
 
 pub(crate) async fn render_region(
     state: &AppState,
     region_slug: &str,
 ) -> (StatusCode, Html<String>) {
-    let region = sqlx::query_as::<_, RegionRow>(
-        "SELECT id, name, slug, region_code, latitude, longitude, coat_of_arms_ext, flag_ext, description FROM regions WHERE slug = $1",
-    )
-    .bind(region_slug)
-    .fetch_optional(&state.db)
-    .await
-    .unwrap_or_else(|e| { tracing::error!("render_region region query failed: {e}"); None });
+    let region = state
+        .region_repo
+        .find_by_slug(region_slug)
+        .await
+        .unwrap_or_else(|e| {
+            tracing::error!("render_region region query failed: {e}");
+            None
+        });
 
     let Some(region) = region else {
         return not_found(&state.image_base_url);
     };
 
-    let orps = sqlx::query_as::<_, OrpRow>(
-        "SELECT o.id, o.name, o.slug, o.orp_code, o.latitude, o.longitude FROM orp o \
-         JOIN districts d ON o.district_id = d.id \
-         WHERE d.region_id = $1 ORDER BY o.name",
-    )
-    .bind(region.id)
-    .fetch_all(&state.db)
-    .await
-    .unwrap_or_else(|e| {
-        tracing::error!("render_region orps query failed: {e}");
-        Vec::new()
-    });
+    let region_id = region.id;
+    let region_row: RegionRow = region.into();
+
+    let orps: Vec<OrpRow> = state
+        .orp_repo
+        .find_by_region(RegionId::from(region_id))
+        .await
+        .unwrap_or_else(|e| {
+            tracing::error!("render_region orps query failed: {e}");
+            Vec::new()
+        })
+        .into_iter()
+        .map(OrpRow::from)
+        .collect();
 
     // Special case: region with single ORP (e.g. Praha) — render ORP page directly
     if orps.len() == 1 {
@@ -36,7 +71,7 @@ pub(crate) async fn render_region(
 
     let tmpl = RegionTemplate {
         img: state.image_base_url.clone(),
-        region,
+        region: region_row,
         orps,
     };
     match tmpl.render() {

--- a/cr-web/src/main.rs
+++ b/cr-web/src/main.rs
@@ -3,6 +3,10 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use axum::Router;
+use cr_infra::repositories::{
+    PgLandmarkRepository, PgMunicipalityRepository, PgOrpRepository, PgPhotoRepository,
+    PgPoolRepository, PgRegionRepository,
+};
 use sqlx::postgres::PgPoolOptions;
 use tower_http::compression::CompressionLayer;
 use tower_http::cors::{Any, CorsLayer};
@@ -48,6 +52,12 @@ async fn main() -> Result<()> {
     }
 
     let state = AppState {
+        region_repo: Arc::new(PgRegionRepository::new(pool.clone())),
+        orp_repo: Arc::new(PgOrpRepository::new(pool.clone())),
+        municipality_repo: Arc::new(PgMunicipalityRepository::new(pool.clone())),
+        landmark_repo: Arc::new(PgLandmarkRepository::new(pool.clone())),
+        pool_repo: Arc::new(PgPoolRepository::new(pool.clone())),
+        photo_repo: Arc::new(PgPhotoRepository::new(pool.clone())),
         db: pool,
         geojson_index: Arc::new(geojson_index),
         image_base_url,

--- a/cr-web/src/state.rs
+++ b/cr-web/src/state.rs
@@ -1,6 +1,10 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use cr_infra::repositories::{
+    PgLandmarkRepository, PgMunicipalityRepository, PgOrpRepository, PgPhotoRepository,
+    PgPoolRepository, PgRegionRepository,
+};
 use sqlx::PgPool;
 
 #[derive(Clone)]
@@ -12,6 +16,16 @@ pub struct AppState {
     pub image_base_url: String,
     /// Shared HTTP client for image proxy (reuse connections).
     pub http_client: reqwest::Client,
+    // Repositories (cr-infra) — used progressively as handlers are refactored
+    pub region_repo: Arc<PgRegionRepository>,
+    pub orp_repo: Arc<PgOrpRepository>,
+    #[allow(dead_code)]
+    pub municipality_repo: Arc<PgMunicipalityRepository>,
+    #[allow(dead_code)]
+    pub landmark_repo: Arc<PgLandmarkRepository>,
+    #[allow(dead_code)]
+    pub pool_repo: Arc<PgPoolRepository>,
+    pub photo_repo: Arc<PgPhotoRepository>,
 }
 
 /// In-memory index of GeoJSON features for fast API lookups.


### PR DESCRIPTION
## Summary
Pilot refactoring proving the Clean Architecture pattern works end-to-end:
- Repository instances (`Arc<PgXxxRepo>`) added to `AppState`
- `regions.rs` handler: replaced direct sqlx with `RegionRepository` + `OrpRepository`
- `homepage` handler: uses `RegionRepository.find_all()`
- `fetch_photos`: uses `PhotoRepository.find_by_entity()`
- `From<Record> for Row` conversions bridge domain records to template types
- Other handlers (orp, landmarks, pools) left for incremental follow-up

## Related Issues
Partially addresses #74

## Test plan
- [ ] Homepage renders correctly (regions from repository)
- [ ] Region detail page works (ORP list from repository)
- [ ] Photo gallery still works (photos from repository)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)