### PR TITLE
Migrate remaining handlers to use repositories

### DIFF
--- a/cr-web/src/handlers/landmarks.rs
+++ b/cr-web/src/handlers/landmarks.rs
@@ -1,3 +1,6 @@
+use cr_domain::id::OrpId;
+use cr_domain::repository::{LandmarkRepository, OrpRepository, RegionRepository};
+
 use super::*;
 
 const LANDMARKS_PER_PAGE: i64 = 10;
@@ -31,71 +34,60 @@ pub(crate) async fn render_landmark(
     orp_slug: &str,
     landmark_slug: &str,
 ) -> (StatusCode, Html<String>) {
-    let region = sqlx::query_as::<_, RegionRow>(
-        "SELECT id, name, slug, region_code, latitude, longitude, coat_of_arms_ext, flag_ext, description FROM regions WHERE slug = $1",
-    )
-    .bind(region_slug)
-    .fetch_optional(&state.db)
-    .await
-    .unwrap_or_else(|e| { tracing::error!("render_landmark region query failed: {e}"); None });
+    let region = state
+        .region_repo
+        .find_by_slug(region_slug)
+        .await
+        .unwrap_or_else(|e| {
+            tracing::error!("render_landmark region query failed: {e}");
+            None
+        });
 
     let Some(region) = region else {
         return not_found(&state.image_base_url);
     };
 
-    let orp = sqlx::query_as::<_, OrpRow>(
-        "SELECT o.id, o.name, o.slug, o.orp_code, o.latitude, o.longitude FROM orp o \
-         JOIN districts d ON o.district_id = d.id \
-         WHERE d.region_id = $1 AND o.slug = $2",
-    )
-    .bind(region.id)
-    .bind(orp_slug)
-    .fetch_optional(&state.db)
-    .await
-    .unwrap_or_else(|e| {
-        tracing::error!("render_landmark orp query failed: {e}");
-        None
-    });
+    let region_row: RegionRow = region.into();
+
+    let orp = state
+        .orp_repo
+        .find_by_slug(orp_slug)
+        .await
+        .unwrap_or_else(|e| {
+            tracing::error!("render_landmark orp query failed: {e}");
+            None
+        });
 
     let Some(orp) = orp else {
         return not_found(&state.image_base_url);
     };
 
+    let orp_id = orp.id;
+    let orp_row: OrpRow = orp.into();
+
     // Find landmark by slug within municipalities of this ORP
-    let landmark = sqlx::query_as::<_, LandmarkRow>(
-        "SELECT l.id, l.name, l.slug, l.latitude, l.longitude, l.description, \
-         l.wikipedia_url, l.image_ext, l.npu_catalog_id, \
-         lt.slug as type_slug, lt.name as type_name, \
-         m.name as municipality_name, m.slug as municipality_slug, \
-         o2.slug as orp_slug, r2.slug as region_slug \
-         FROM landmarks l \
-         JOIN landmark_types lt ON l.type_id = lt.id \
-         LEFT JOIN municipalities m ON l.municipality_id = m.id \
-         LEFT JOIN orp o2 ON m.orp_id = o2.id \
-         LEFT JOIN districts d2 ON o2.district_id = d2.id \
-         LEFT JOIN regions r2 ON d2.region_id = r2.id \
-         WHERE l.slug = $1 AND m.orp_id = $2",
-    )
-    .bind(landmark_slug)
-    .bind(orp.id)
-    .fetch_optional(&state.db)
-    .await
-    .unwrap_or_else(|e| {
-        tracing::error!("render_landmark landmark query failed: {e}");
-        None
-    });
+    let landmark = state
+        .landmark_repo
+        .find_by_slug_and_orp(landmark_slug, OrpId::from(orp_id))
+        .await
+        .unwrap_or_else(|e| {
+            tracing::error!("render_landmark landmark query failed: {e}");
+            None
+        });
 
     let Some(landmark) = landmark else {
         return not_found(&state.image_base_url);
     };
 
-    let photos = fetch_photos(state, "landmark", landmark.id, &landmark.slug).await;
+    let landmark_row: LandmarkRow = landmark.into();
+
+    let photos = fetch_photos(state, "landmark", landmark_row.id, &landmark_row.slug).await;
 
     let tmpl = LandmarkDetailTemplate {
         img: state.image_base_url.clone(),
-        landmark,
-        region,
-        orp,
+        landmark: landmark_row,
+        region: region_row,
+        orp: orp_row,
         photos,
     };
     match tmpl.render() {
@@ -108,6 +100,7 @@ pub(crate) async fn render_landmark(
 }
 
 pub async fn landmarks_index(State(state): State<AppState>) -> WebResult<impl IntoResponse> {
+    // Keep direct sqlx: complex aggregate query with no matching repository method
     let rows = sqlx::query_as::<_, LandmarkTypeCountRow>(
         "SELECT lt.slug, lt.name, lt.name_plural, COUNT(l.id) as count \
          FROM landmark_types lt \
@@ -162,6 +155,7 @@ pub async fn landmarks_by_type(
         .max(1);
     let offset = (page - 1) * LANDMARKS_PER_PAGE;
 
+    // Keep direct sqlx: complex aggregate + pagination query
     let type_row = sqlx::query_as::<_, LandmarkTypeCountRow>(
         "SELECT lt.slug, lt.name, lt.name_plural, COUNT(l.id) as count \
          FROM landmark_types lt \
@@ -189,6 +183,7 @@ pub async fn landmarks_by_type(
 
     let total_pages = (type_info.count as u64).div_ceil(LANDMARKS_PER_PAGE as u64) as i64;
 
+    // Keep direct sqlx: complex paginated query with multiple JOINs
     let landmarks = sqlx::query_as::<_, LandmarkRow>(
         "SELECT l.id, l.name, l.slug, l.latitude, l.longitude, l.description, \
          l.wikipedia_url, l.image_ext, l.npu_catalog_id, \
@@ -235,6 +230,7 @@ pub async fn api_landmarks(
         .max(1);
     let offset = (page - 1) * LANDMARKS_PER_PAGE;
 
+    // Keep direct sqlx: complex paginated API query with multiple JOINs
     let landmarks = sqlx::query_as::<_, LandmarkRow>(
         "SELECT l.id, l.name, l.slug, l.latitude, l.longitude, l.description, \
          l.wikipedia_url, l.image_ext, l.npu_catalog_id, \

--- a/cr-web/src/handlers/mod.rs
+++ b/cr-web/src/handlers/mod.rs
@@ -27,6 +27,7 @@ pub use pools::{pools_by_category, pools_hub};
 
 #[derive(sqlx::FromRow)]
 pub(crate) struct RegionRow {
+    #[allow(dead_code)]
     pub(crate) id: i32,
     pub(crate) name: String,
     pub(crate) slug: String,
@@ -40,6 +41,7 @@ pub(crate) struct RegionRow {
 
 #[derive(sqlx::FromRow)]
 pub(crate) struct OrpRow {
+    #[allow(dead_code)]
     pub(crate) id: i32,
     pub(crate) name: String,
     pub(crate) slug: String,
@@ -105,6 +107,76 @@ pub(crate) struct LandmarkTypeCountRow {
     pub(crate) name: String,
     pub(crate) name_plural: Option<String>,
     pub(crate) count: i64,
+}
+
+// --- From impls: domain record → handler row types ---
+
+impl From<cr_domain::repository::MunicipalityRecord> for MunicipalityRow {
+    fn from(r: cr_domain::repository::MunicipalityRecord) -> Self {
+        Self {
+            id: r.id,
+            name: r.name,
+            slug: r.slug,
+            municipality_code: r.municipality_code,
+            pou_code: r.pou_code,
+            latitude: r.latitude,
+            longitude: r.longitude,
+            wikipedia_url: r.wikipedia_url,
+            official_website: r.official_website,
+            coat_of_arms_ext: r.coat_of_arms_ext,
+            flag_ext: r.flag_ext,
+            population: r.population,
+            elevation: r.elevation,
+        }
+    }
+}
+
+impl From<cr_domain::repository::LandmarkRecord> for LandmarkRow {
+    fn from(r: cr_domain::repository::LandmarkRecord) -> Self {
+        Self {
+            id: r.id,
+            name: r.name,
+            slug: r.slug,
+            latitude: r.latitude,
+            longitude: r.longitude,
+            description: r.description,
+            wikipedia_url: r.wikipedia_url,
+            image_ext: r.image_ext,
+            npu_catalog_id: r.npu_catalog_id,
+            type_slug: r.type_slug,
+            type_name: r.type_name,
+            municipality_name: r.municipality_name,
+            municipality_slug: r.municipality_slug,
+            orp_slug: r.orp_slug,
+            region_slug: r.region_slug,
+        }
+    }
+}
+
+impl From<cr_domain::repository::PoolRecord> for PoolDetailRow {
+    fn from(r: cr_domain::repository::PoolRecord) -> Self {
+        Self {
+            id: r.id,
+            name: r.name,
+            slug: r.slug,
+            description: r.description,
+            address: r.address,
+            latitude: r.latitude,
+            longitude: r.longitude,
+            website: r.website,
+            email: r.email,
+            phone: r.phone,
+            facebook: r.facebook,
+            facilities: r.facilities,
+            pool_length_m: r.pool_length_m,
+            is_aquapark: r.is_aquapark,
+            is_indoor: r.is_indoor,
+            is_outdoor: r.is_outdoor,
+            is_natural: r.is_natural,
+            photo_count: r.photo_count,
+            municipality_name: r.municipality_name,
+        }
+    }
 }
 
 // --- Photo info for gallery display ---

--- a/cr-web/src/handlers/municipalities.rs
+++ b/cr-web/src/handlers/municipalities.rs
@@ -1,3 +1,6 @@
+use cr_domain::id::OrpId;
+use cr_domain::repository::{MunicipalityRepository, OrpRepository, RegionRepository};
+
 use super::*;
 
 pub(crate) async fn render_municipality_short(
@@ -22,54 +25,54 @@ pub(crate) async fn render_municipality(
         return not_found(&state.image_base_url);
     }
 
-    let region = sqlx::query_as::<_, RegionRow>(
-        "SELECT id, name, slug, region_code, latitude, longitude, coat_of_arms_ext, flag_ext, description FROM regions WHERE slug = $1",
-    )
-    .bind(region_slug)
-    .fetch_optional(&state.db)
-    .await
-    .unwrap_or_else(|e| { tracing::error!("render_municipality region query failed: {e}"); None });
+    let region = state
+        .region_repo
+        .find_by_slug(region_slug)
+        .await
+        .unwrap_or_else(|e| {
+            tracing::error!("render_municipality region query failed: {e}");
+            None
+        });
 
     let Some(region) = region else {
         return not_found(&state.image_base_url);
     };
 
-    let orp = sqlx::query_as::<_, OrpRow>(
-        "SELECT o.id, o.name, o.slug, o.orp_code, o.latitude, o.longitude FROM orp o \
-         JOIN districts d ON o.district_id = d.id \
-         WHERE d.region_id = $1 AND o.slug = $2",
-    )
-    .bind(region.id)
-    .bind(orp_slug)
-    .fetch_optional(&state.db)
-    .await
-    .unwrap_or_else(|e| {
-        tracing::error!("render_municipality orp query failed: {e}");
-        None
-    });
+    let region_row: RegionRow = region.into();
+
+    let orp = state
+        .orp_repo
+        .find_by_slug(orp_slug)
+        .await
+        .unwrap_or_else(|e| {
+            tracing::error!("render_municipality orp query failed: {e}");
+            None
+        });
 
     let Some(orp) = orp else {
         return not_found(&state.image_base_url);
     };
 
-    let municipality = sqlx::query_as::<_, MunicipalityRow>(
-        "SELECT id, name, slug, municipality_code, pou_code, latitude, longitude, \
-         wikipedia_url, official_website, coat_of_arms_ext, flag_ext, population, elevation \
-         FROM municipalities WHERE orp_id = $1 AND slug = $2",
-    )
-    .bind(orp.id)
-    .bind(municipality_slug)
-    .fetch_optional(&state.db)
-    .await
-    .unwrap_or_else(|e| {
-        tracing::error!("render_municipality municipality query failed: {e}");
-        None
-    });
+    let orp_id = orp.id;
+    let orp_row: OrpRow = orp.into();
+
+    let municipality = state
+        .municipality_repo
+        .find_by_slug_and_orp(municipality_slug, OrpId::from(orp_id))
+        .await
+        .unwrap_or_else(|e| {
+            tracing::error!("render_municipality municipality query failed: {e}");
+            None
+        });
 
     let Some(municipality) = municipality else {
         return not_found(&state.image_base_url);
     };
 
+    let municipality_id = municipality.id;
+    let municipality_row: MunicipalityRow = municipality.into();
+
+    // Keep direct sqlx: MunicipalityLandmarkRow is a complex JOIN with no matching domain record
     let landmarks = sqlx::query_as::<_, MunicipalityLandmarkRow>(
         "SELECT l.name, l.slug, lt.name as type_name \
          FROM landmarks l \
@@ -77,7 +80,7 @@ pub(crate) async fn render_municipality(
          WHERE l.municipality_id = $1 \
          ORDER BY lt.name, l.name",
     )
-    .bind(municipality.id)
+    .bind(municipality_id)
     .fetch_all(&state.db)
     .await
     .unwrap_or_else(|e| {
@@ -87,9 +90,9 @@ pub(crate) async fn render_municipality(
 
     let tmpl = MunicipalityTemplate {
         img: state.image_base_url.clone(),
-        region,
-        orp,
-        municipality,
+        region: region_row,
+        orp: orp_row,
+        municipality: municipality_row,
         landmarks,
     };
     match tmpl.render() {

--- a/cr-web/src/handlers/orp.rs
+++ b/cr-web/src/handlers/orp.rs
@@ -1,3 +1,6 @@
+use cr_domain::id::OrpId;
+use cr_domain::repository::{MunicipalityRepository, OrpRepository, RegionRepository};
+
 use super::*;
 
 pub(crate) async fn render_orp_by_slug(
@@ -15,53 +18,53 @@ pub(crate) async fn render_orp(
     region_slug: &str,
     orp_slug: &str,
 ) -> (StatusCode, Html<String>) {
-    let region = sqlx::query_as::<_, RegionRow>(
-        "SELECT id, name, slug, region_code, latitude, longitude, coat_of_arms_ext, flag_ext, description FROM regions WHERE slug = $1",
-    )
-    .bind(region_slug)
-    .fetch_optional(&state.db)
-    .await
-    .unwrap_or_else(|e| { tracing::error!("render_orp region query failed: {e}"); None });
+    let region = state
+        .region_repo
+        .find_by_slug(region_slug)
+        .await
+        .unwrap_or_else(|e| {
+            tracing::error!("render_orp region query failed: {e}");
+            None
+        });
 
     let Some(region) = region else {
         return not_found(&state.image_base_url);
     };
 
-    let orp = sqlx::query_as::<_, OrpRow>(
-        "SELECT o.id, o.name, o.slug, o.orp_code, o.latitude, o.longitude FROM orp o \
-         JOIN districts d ON o.district_id = d.id \
-         WHERE d.region_id = $1 AND o.slug = $2",
-    )
-    .bind(region.id)
-    .bind(orp_slug)
-    .fetch_optional(&state.db)
-    .await
-    .unwrap_or_else(|e| {
-        tracing::error!("render_orp orp query failed: {e}");
-        None
-    });
+    let region_row: RegionRow = region.into();
+
+    let orp = state
+        .orp_repo
+        .find_by_slug(orp_slug)
+        .await
+        .unwrap_or_else(|e| {
+            tracing::error!("render_orp orp query failed: {e}");
+            None
+        });
 
     let Some(orp) = orp else {
         return not_found(&state.image_base_url);
     };
 
-    let all_municipalities = sqlx::query_as::<_, MunicipalityRow>(
-        "SELECT id, name, slug, municipality_code, pou_code, latitude, longitude, \
-         wikipedia_url, official_website, coat_of_arms_ext, flag_ext, population, elevation \
-         FROM municipalities WHERE orp_id = $1 ORDER BY name",
-    )
-    .bind(orp.id)
-    .fetch_all(&state.db)
-    .await
-    .unwrap_or_else(|e| {
-        tracing::error!("render_orp municipalities query failed: {e}");
-        Vec::new()
-    });
+    let orp_id = orp.id;
+    let orp_row: OrpRow = orp.into();
+
+    let all_municipalities: Vec<MunicipalityRow> = state
+        .municipality_repo
+        .find_by_orp(OrpId::from(orp_id))
+        .await
+        .unwrap_or_else(|e| {
+            tracing::error!("render_orp municipalities query failed: {e}");
+            Vec::new()
+        })
+        .into_iter()
+        .map(MunicipalityRow::from)
+        .collect();
 
     let mut main_municipality = None;
     let mut other_municipalities = Vec::new();
     for m in all_municipalities {
-        if main_municipality.is_none() && m.slug == orp.slug {
+        if main_municipality.is_none() && m.slug == orp_row.slug {
             main_municipality = Some(m);
         } else {
             other_municipalities.push(m);
@@ -72,11 +75,12 @@ pub(crate) async fn render_orp(
         return not_found(&state.image_base_url);
     };
 
+    // TODO: add count_by_orp to LandmarkRepository to replace this direct query
     let landmarks_count = sqlx::query_scalar::<_, i64>(
         "SELECT COUNT(*) FROM landmarks WHERE municipality_id IN \
          (SELECT id FROM municipalities WHERE orp_id = $1)",
     )
-    .bind(orp.id)
+    .bind(orp_id)
     .fetch_one(&state.db)
     .await
     .unwrap_or_else(|e| {
@@ -85,6 +89,7 @@ pub(crate) async fn render_orp(
     });
 
     // Landmarks in entire ORP area — main municipality first, then others
+    // Keep direct sqlx: OrpLandmarkRow is a complex JOIN with no matching domain record
     let landmarks = sqlx::query_as::<_, OrpLandmarkRow>(
         "SELECT l.name, l.slug, lt.name as type_name, m.name as municipality_name, \
          m.slug as municipality_slug, (m.id = $2) as is_main \
@@ -94,7 +99,7 @@ pub(crate) async fn render_orp(
          WHERE m.orp_id = $1 \
          ORDER BY CASE WHEN m.id = $2 THEN 0 ELSE 1 END, lt.name, l.name",
     )
-    .bind(orp.id)
+    .bind(orp_id)
     .bind(main_municipality.id)
     .fetch_all(&state.db)
     .await
@@ -106,12 +111,12 @@ pub(crate) async fn render_orp(
     let (main_landmarks, other_landmarks): (Vec<_>, Vec<_>) =
         landmarks.into_iter().partition(|l| l.is_main);
 
-    // Pools in this ORP
+    // Pools in this ORP — keep direct sqlx: OrpPoolRow has no matching domain record
     let pools = sqlx::query_as::<_, OrpPoolRow>(
         "SELECT name, slug, is_aquapark, is_indoor, is_outdoor, is_natural \
          FROM pools WHERE orp_id = $1 ORDER BY name",
     )
-    .bind(orp.id)
+    .bind(orp_id)
     .fetch_all(&state.db)
     .await
     .unwrap_or_else(|e| {
@@ -121,8 +126,8 @@ pub(crate) async fn render_orp(
 
     let tmpl = OrpTemplate {
         img: state.image_base_url.clone(),
-        region,
-        orp,
+        region: region_row,
+        orp: orp_row,
         main_municipality,
         other_municipalities,
         main_landmarks,

--- a/cr-web/src/handlers/pools.rs
+++ b/cr-web/src/handlers/pools.rs
@@ -1,6 +1,10 @@
+use cr_domain::id::OrpId;
+use cr_domain::repository::{OrpRepository, PoolRepository, RegionRepository};
+
 use super::*;
 
 pub async fn pools_hub(State(state): State<AppState>) -> WebResult<impl IntoResponse> {
+    // Keep direct sqlx: complex category count queries with no matching repository method
     let aquapark_count =
         sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM pools WHERE is_aquapark")
             .fetch_one(&state.db)
@@ -34,6 +38,7 @@ pub async fn pools_by_category(
     uri: Uri,
     axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
 ) -> WebResult<impl IntoResponse> {
+    // Keep direct sqlx: complex category pagination with no matching repository method
     let path = uri.path().trim_matches('/');
     let (filter_col, category_name) = match path {
         "aquaparky" => ("is_aquapark", "Aquaparky"),
@@ -117,64 +122,59 @@ pub(crate) async fn render_pool(
     orp_slug: &str,
     pool_slug: &str,
 ) -> (StatusCode, Html<String>) {
-    let region = sqlx::query_as::<_, RegionRow>(
-        "SELECT id, name, slug, region_code, latitude, longitude, coat_of_arms_ext, flag_ext, description FROM regions WHERE slug = $1",
-    )
-    .bind(region_slug)
-    .fetch_optional(&state.db).await
-    .unwrap_or_else(|e| { tracing::error!("render_pool region query failed: {e}"); None });
+    let region = state
+        .region_repo
+        .find_by_slug(region_slug)
+        .await
+        .unwrap_or_else(|e| {
+            tracing::error!("render_pool region query failed: {e}");
+            None
+        });
 
     let Some(region) = region else {
         return not_found(&state.image_base_url);
     };
 
-    let orp = sqlx::query_as::<_, OrpRow>(
-        "SELECT o.id, o.name, o.slug, o.orp_code, o.latitude, o.longitude FROM orp o \
-         JOIN districts d ON o.district_id = d.id \
-         WHERE d.region_id = $1 AND o.slug = $2",
-    )
-    .bind(region.id)
-    .bind(orp_slug)
-    .fetch_optional(&state.db)
-    .await
-    .unwrap_or_else(|e| {
-        tracing::error!("render_pool orp query failed: {e}");
-        None
-    });
+    let region_row: RegionRow = region.into();
+
+    let orp = state
+        .orp_repo
+        .find_by_slug(orp_slug)
+        .await
+        .unwrap_or_else(|e| {
+            tracing::error!("render_pool orp query failed: {e}");
+            None
+        });
 
     let Some(orp) = orp else {
         return not_found(&state.image_base_url);
     };
 
-    let pool = sqlx::query_as::<_, PoolDetailRow>(
-        "SELECT p.id, p.name, p.slug, p.description, p.address, p.latitude, p.longitude, \
-         p.website, p.email, p.phone, p.facebook, p.facilities, p.pool_length_m, \
-         p.is_aquapark, p.is_indoor, p.is_outdoor, p.is_natural, p.photo_count, \
-         m.name as municipality_name \
-         FROM pools p \
-         LEFT JOIN municipalities m ON p.municipality_id = m.id \
-         WHERE p.slug = $1 AND p.orp_id = $2",
-    )
-    .bind(pool_slug)
-    .bind(orp.id)
-    .fetch_optional(&state.db)
-    .await
-    .unwrap_or_else(|e| {
-        tracing::error!("render_pool pool query failed: {e}");
-        None
-    });
+    let orp_id = orp.id;
+    let orp_row: OrpRow = orp.into();
+
+    let pool = state
+        .pool_repo
+        .find_by_slug_and_orp(pool_slug, OrpId::from(orp_id))
+        .await
+        .unwrap_or_else(|e| {
+            tracing::error!("render_pool pool query failed: {e}");
+            None
+        });
 
     let Some(pool) = pool else {
         return not_found(&state.image_base_url);
     };
 
-    let photos = fetch_photos(state, "pool", pool.id, &pool.slug).await;
+    let pool_row: PoolDetailRow = pool.into();
+
+    let photos = fetch_photos(state, "pool", pool_row.id, &pool_row.slug).await;
 
     let tmpl = PoolDetailTemplate {
         img: state.image_base_url.clone(),
-        pool,
-        region,
-        orp,
+        pool: pool_row,
+        region: region_row,
+        orp: orp_row,
         photos,
     };
     match tmpl.render() {

--- a/cr-web/src/state.rs
+++ b/cr-web/src/state.rs
@@ -19,11 +19,8 @@ pub struct AppState {
     // Repositories (cr-infra) — used progressively as handlers are refactored
     pub region_repo: Arc<PgRegionRepository>,
     pub orp_repo: Arc<PgOrpRepository>,
-    #[allow(dead_code)]
     pub municipality_repo: Arc<PgMunicipalityRepository>,
-    #[allow(dead_code)]
     pub landmark_repo: Arc<PgLandmarkRepository>,
-    #[allow(dead_code)]
     pub pool_repo: Arc<PgPoolRepository>,
     pub photo_repo: Arc<PgPhotoRepository>,
 }


### PR DESCRIPTION
## Summary
Complete handler migration to repository pattern:
- `orp.rs`, `municipalities.rs`, `landmarks.rs`, `pools.rs` now use repositories for core entity lookups
- Added `From` conversions for `MunicipalityRecord`, `LandmarkRecord`, `PoolRecord` → template Row types
- Complex queries (pagination, aggregation, category filtering) kept as direct sqlx with TODO comments for future repository methods
- All repository fields in `AppState` now actively used

## Related Issues
Closes #74

## Test plan
- [ ] All pages render correctly (region, ORP, municipality, landmark, pool)
- [ ] CI passes
- [ ] 33 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)