### PR TITLE
Add automated deployment to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,10 +51,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Validate secrets
+        run: |
+          if [ -z "${{ secrets.VPS_HOST }}" ] || [ -z "${{ secrets.VPS_SSH_KEY }}" ] || [ -z "${{ secrets.VPS_SSH_PORT }}" ]; then
+            echo "::error::Missing required secrets: VPS_HOST, VPS_SSH_KEY, VPS_SSH_PORT"
+            exit 1
+          fi
+
       - name: Sync to server
         uses: burnett01/rsync-deployments@7.0.1
         with:
-          switches: -avz --delete --exclude='target/' --exclude='.git/' --exclude='*.png' --exclude='.env' --exclude='data/images/' --exclude='data/porovnani/'
+          switches: -avz --delete --exclude='target/' --exclude='.git/' --exclude='.env' --exclude='data/images/' --exclude='data/porovnani/'
           path: ./
           remote_path: /opt/cr/
           remote_host: ${{ secrets.VPS_HOST }}
@@ -62,7 +69,7 @@ jobs:
           remote_user: root
           remote_key: ${{ secrets.VPS_SSH_KEY }}
 
-      - name: Build and restart
+      - name: Build, restart and health check
         uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.VPS_HOST }}
@@ -74,18 +81,15 @@ jobs:
             docker compose build web
             docker compose up -d web
 
-      - name: Health check
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.VPS_HOST }}
-          port: ${{ secrets.VPS_SSH_PORT }}
-          username: root
-          key: ${{ secrets.VPS_SSH_KEY }}
-          script: |
-            sleep 15
-            STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:80/health)
-            if [ "$STATUS" != "200" ]; then
-              echo "Health check failed: HTTP $STATUS"
-              exit 1
-            fi
-            echo "Health check passed: HTTP $STATUS"
+            # Health check with retry (up to 60 seconds)
+            for i in $(seq 1 12); do
+              sleep 5
+              STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 http://localhost:80/health)
+              if [ "$STATUS" = "200" ]; then
+                echo "Health check passed: HTTP $STATUS"
+                exit 0
+              fi
+              echo "Attempt $i: HTTP $STATUS, retrying..."
+            done
+            echo "Health check failed after 60 seconds"
+            exit 1


### PR DESCRIPTION
## Summary
- New `deploy` job in GitHub Actions runs after all CI checks pass
- Only triggers on push to main (not on PRs)
- Rsync source to server → docker compose build → restart → health check
- Uses `environment: production` for deployment protection
- GitHub Secrets configured: VPS_HOST, VPS_SSH_PORT, VPS_SSH_KEY

## Related Issues
Closes #95

## Test plan
- [ ] PR CI runs check/fmt/test jobs (no deploy on PR)
- [ ] After merge to main, deploy job triggers automatically
- [ ] Source is synced to server, app rebuilt and restarted
- [ ] Health check verifies HTTP 200 on /health endpoint
- [ ] If secrets are missing, deploy fails with clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)