### PR TITLE
Fix: cache-bust map.css v4 for ORP SVG styles

### DIFF
--- a/cr-web/templates/base.html
+++ b/cr-web/templates/base.html
@@ -6,7 +6,7 @@
     <title>{% block title %}Česká republika{% endblock %} | ceskarepublika.wiki</title>
     <meta name="description" content="{% block meta_description %}Encyklopedický portál o České republice — kraje, obce, památky, koupání a další.{% endblock %}">
     <link rel="stylesheet" href="/static/css/index.css">
-    <link rel="stylesheet" href="/static/css/map.css?v=3">
+    <link rel="stylesheet" href="/static/css/map.css?v=4">
     <link rel="stylesheet" href="/static/css/lightbox.css?v=2">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>


### PR DESCRIPTION
CDN cached old CSS without .orp class. Bump to ?v=4.