### PR TITLE
Fix region SVG map sizing — proper aspect ratio

### DIFF
--- a/cr-web/static/css/map.css
+++ b/cr-web/static/css/map.css
@@ -7,10 +7,14 @@
     height: 100%;
 }
 
-#map-cr,
-#map-region {
+#map-cr {
     width: 100%;
     height: 100%;
+}
+
+#map-region {
+    width: 100%;
+    height: auto;
 }
 
 /* Homepage region paths */

--- a/cr-web/templates/region.html
+++ b/cr-web/templates/region.html
@@ -84,7 +84,7 @@
     </div>
     <aside class="content-right" style="padding-top: 1rem;">
         <div class="map-card-premium">
-            <div class="map-container-svg" style="min-height:300px;">
+            <div class="map-container-svg">
                 {% if region.slug == "jihocesky-kraj" %}{% include "includes/map_jihocesky_kraj.html" %}
                 {% else if region.slug == "jihomoravsky-kraj" %}{% include "includes/map_jihomoravsky_kraj.html" %}
                 {% else if region.slug == "karlovarsky-kraj" %}{% include "includes/map_karlovarsky_kraj.html" %}


### PR DESCRIPTION
## Summary
Map was squished — `#map-region` had `height:100%`, changed to `height:auto` so SVG viewBox preserves natural aspect ratio. Tested locally — Středočeský kraj (26 ORP) renders correctly.

## Test plan
- [ ] Region maps display with correct proportions
- [ ] Labels are readable
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)