### PR TITLE
Fix: region hero photo clickable with lightbox

### DIFF
--- a/cr-web/templates/region.html
+++ b/cr-web/templates/region.html
@@ -38,7 +38,7 @@
     <div class="active-left">
         {% match region.hero_photo_url %}
         {% when Some with (photo_url) %}
-        <div class="photo-inline">
+        <div class="photo-inline" data-gallery-open="region" data-index="0" data-gallery-photos="[&quot;{{ photo_url }}&quot;]">
             <img src="{{ photo_url }}?w=360" alt="{{ region.name }}" loading="lazy">
         </div>
         {% when None %}


### PR DESCRIPTION
## Summary
- Add `data-gallery-open` and `data-gallery-photos` attributes to region hero photo
- Clicking the hero photo now opens lightbox with full-size image

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)