### PR TITLE
Fix: 3-segment landmark photo resolution for main municipality

### DIFF
--- a/cr-web/src/img_proxy.rs
+++ b/cr-web/src/img_proxy.rs
@@ -362,8 +362,11 @@ async fn resolve_seo_path(db: &sqlx::PgPool, path: &str) -> String {
                 Ok(None) if segments.len() == 3 => {
                     // 3 segments but middle is not a municipality — try as landmark photo:
                     // /{orp}/{landmark-slug}/{photo-slug}.webp (main municipality)
-                    let landmark_slug = segments[1];
-                    let photo_slug = slug;
+                    let lm_slug = segments[1];
+                    let lp_slug = file_with_ext
+                        .rsplit_once('.')
+                        .map(|(s, _)| s)
+                        .unwrap_or(file_with_ext);
                     let lp_r2 = sqlx::query_scalar::<_, String>(
                         "SELECT lp.r2_key FROM landmark_photos lp \
                          JOIN landmarks l ON l.npu_catalog_id = lp.npu_catalog_id \
@@ -372,13 +375,17 @@ async fn resolve_seo_path(db: &sqlx::PgPool, path: &str) -> String {
                          WHERE o.slug = $1 AND m.slug = $1 AND l.slug = $2 AND lp.slug = $3",
                     )
                     .bind(orp_slug)
-                    .bind(landmark_slug)
-                    .bind(photo_slug)
+                    .bind(lm_slug)
+                    .bind(lp_slug)
                     .fetch_optional(db)
                     .await;
                     match lp_r2 {
                         Ok(Some(key)) if !key.contains("..") => key,
-                        _ => path.to_string(),
+                        Ok(_) => path.to_string(),
+                        Err(e) => {
+                            tracing::error!("DB error resolving 3-seg landmark path '{path}': {e}");
+                            path.to_string()
+                        }
                     }
                 }
                 Ok(None) => path.to_string(),


### PR DESCRIPTION
## Summary
Fix landmark hero photos for regions where orp slug = municipality slug (e.g. Jihočeský kraj → Jindřichův Hradec). URL becomes 3 segments `/{orp}/{landmark}/{photo}.webp` which resolve_seo_path didn't handle.

Added fallback: when 3-segment path doesn't match a municipality, try landmark_photos lookup for main municipality.

## Verified locally (Playwright)
All 14 regions tested — all return 200 with correct photos. Jihočeský kraj confirmed showing zámek Jindřichův Hradec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)