### PR TITLE
Add photo gallery slideshow on landmark detail pages

### DIFF
--- a/cr-web/src/handlers/landmarks.rs
+++ b/cr-web/src/handlers/landmarks.rs
@@ -88,6 +88,7 @@ pub(crate) async fn render_landmark(
         &landmark_row.slug,
         Some(&orp_row.slug),
         landmark_row.municipality_slug.as_deref(),
+        landmark_row.npu_catalog_id.as_deref(),
     )
     .await;
 

--- a/cr-web/src/handlers/mod.rs
+++ b/cr-web/src/handlers/mod.rs
@@ -210,6 +210,7 @@ pub(crate) async fn fetch_photos(
     slug: &str,
     orp_slug: Option<&str>,
     municipality_slug: Option<&str>,
+    npu_catalog_id: Option<&str>,
 ) -> Vec<PhotoInfo> {
     let records = state
         .photo_repo
@@ -220,7 +221,7 @@ pub(crate) async fn fetch_photos(
             Vec::new()
         });
 
-    records
+    let mut photos: Vec<PhotoInfo> = records
         .into_iter()
         .map(|r| {
             let url = if entity_type == "landmark" {
@@ -250,6 +251,67 @@ pub(crate) async fn fetch_photos(
                 thumb_url,
                 width: r.width,
                 height: r.height,
+            }
+        })
+        .collect();
+
+    // Fetch additional landmark photos from landmark_photos table (index 2+)
+    if entity_type == "landmark"
+        && let Some(catalog_id) = npu_catalog_id
+    {
+        let extra =
+            fetch_landmark_additional_photos(state, catalog_id, slug, orp_slug, municipality_slug)
+                .await;
+        photos.extend(extra);
+    }
+
+    photos
+}
+
+#[derive(sqlx::FromRow)]
+struct LandmarkPhotoRow {
+    slug: String,
+    width: Option<i16>,
+    height: Option<i16>,
+}
+
+async fn fetch_landmark_additional_photos(
+    state: &AppState,
+    npu_catalog_id: &str,
+    landmark_slug: &str,
+    orp_slug: Option<&str>,
+    municipality_slug: Option<&str>,
+) -> Vec<PhotoInfo> {
+    let rows = sqlx::query_as::<_, LandmarkPhotoRow>(
+        "SELECT slug, width, height FROM landmark_photos \
+         WHERE npu_catalog_id = $1 ORDER BY photo_index",
+    )
+    .bind(npu_catalog_id)
+    .fetch_all(&state.db)
+    .await
+    .unwrap_or_else(|e| {
+        tracing::error!("fetch_landmark_additional_photos query failed: {e}");
+        Vec::new()
+    });
+
+    rows.into_iter()
+        .map(|r| {
+            let url = if let (Some(orp), Some(muni)) = (orp_slug, municipality_slug) {
+                // SEO URL: /{orp}/{landmark}/{photo}.webp or /{orp}/{muni}/{landmark}/{photo}.webp
+                if orp == muni {
+                    format!("/{}/{}/{}.webp", orp, landmark_slug, r.slug)
+                } else {
+                    format!("/{}/{}/{}/{}.webp", orp, muni, landmark_slug, r.slug)
+                }
+            } else {
+                format!("/{}/{}.webp", landmark_slug, r.slug)
+            };
+            let thumb_url = format!("{}?w=360", &url);
+            PhotoInfo {
+                url,
+                thumb_url,
+                width: r.width.unwrap_or(0),
+                height: r.height.unwrap_or(0),
             }
         })
         .collect()

--- a/cr-web/src/handlers/pools.rs
+++ b/cr-web/src/handlers/pools.rs
@@ -168,7 +168,7 @@ pub(crate) async fn render_pool(
 
     let pool_row: PoolDetailRow = pool.into();
 
-    let photos = fetch_photos(state, "pool", pool_row.id, &pool_row.slug, None, None).await;
+    let photos = fetch_photos(state, "pool", pool_row.id, &pool_row.slug, None, None, None).await;
 
     let tmpl = PoolDetailTemplate {
         img: state.image_base_url.clone(),


### PR DESCRIPTION
## Summary
- Fetch additional landmark photos from `landmark_photos` table (index 2+) by `npu_catalog_id`
- Generate SEO-friendly URLs for gallery photos (3-segment and 4-segment patterns)
- Template already had slideshow code — this connects the data layer

## Changes
- `cr-web/src/handlers/mod.rs`: Added `npu_catalog_id` param to `fetch_photos`, new `fetch_landmark_additional_photos` function querying `landmark_photos` table
- `cr-web/src/handlers/landmarks.rs`: Pass `npu_catalog_id` from landmark record
- `cr-web/src/handlers/pools.rs`: Pass `None` (no additional photos)

## Test plan
- [ ] Visit `/beroun/karlstejn/hrad-karlstejn/` — verify slideshow with 2+ photos
- [ ] Click primary photo — lightbox shows ALL photos (primary + gallery)
- [ ] Slideshow prev/next navigation works
- [ ] Landmarks with only 1 photo display as before (no empty gallery)
- [ ] Pool detail pages still work correctly

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)