### PR TITLE
Add SEO-friendly URLs for coat-of-arms and flag images

### DIFF
--- a/cr-web/src/handlers/mod.rs
+++ b/cr-web/src/handlers/mod.rs
@@ -31,6 +31,7 @@ pub(crate) struct RegionRow {
     pub(crate) id: i32,
     pub(crate) name: String,
     pub(crate) slug: String,
+    #[allow(dead_code)]
     pub(crate) region_code: String,
     #[allow(dead_code)]
     pub(crate) latitude: Option<f64>,
@@ -98,6 +99,7 @@ pub(crate) struct LandmarkRow {
     pub(crate) orp_slug: Option<String>,
     #[allow(dead_code)]
     pub(crate) region_slug: Option<String>,
+    #[allow(dead_code)]
     #[sqlx(default)]
     pub(crate) municipality_code: Option<String>,
     #[sqlx(default)]
@@ -747,6 +749,7 @@ pub async fn resolve_path(State(state): State<AppState>, uri: Uri) -> WebResult<
         || path.ends_with(".jpg")
         || path.ends_with(".jpeg")
         || path.ends_with(".png")
+        || path.ends_with(".svg")
     {
         let width: Option<u32> = uri.query().unwrap_or("").split('&').find_map(|param| {
             let (k, v) = param.split_once('=')?;

--- a/cr-web/src/img_proxy.rs
+++ b/cr-web/src/img_proxy.rs
@@ -325,6 +325,11 @@ async fn resolve_seo_path(db: &sqlx::PgPool, path: &str) -> String {
                 (segments[0], segments[1], segments[2])
             };
 
+            // Check for coat-of-arms/flag SEO URLs: znak-{slug}.ext or vlajka-{slug}.ext
+            if let Some(r2_path) = resolve_coat_flag(db, &segments, file_with_ext, path).await {
+                return r2_path;
+            }
+
             let slug = file_with_ext
                 .rsplit_once('.')
                 .map(|(s, _)| s)
@@ -397,4 +402,81 @@ async fn resolve_seo_path(db: &sqlx::PgPool, path: &str) -> String {
         }
         _ => path.to_string(),
     }
+}
+
+/// Resolve coat-of-arms/flag SEO URLs to R2 keys.
+///
+/// Patterns:
+/// - 2 seg: `/{slug}/znak-{slug}.ext` → region or ORP main municipality
+/// - 3 seg: `/{orp}/{muni}/znak-{muni}.ext` → municipality
+async fn resolve_coat_flag(
+    db: &sqlx::PgPool,
+    segments: &[&str],
+    file_with_ext: &str,
+    path: &str,
+) -> Option<String> {
+    let (file_stem, ext) = file_with_ext.rsplit_once('.')?;
+    let image_type = if file_stem.starts_with("znak-") {
+        "coat-of-arms"
+    } else if file_stem.starts_with("vlajka-") {
+        "flag"
+    } else {
+        return None;
+    };
+
+    if segments.len() == 2 {
+        // Try region first: /jihomoravsky-kraj/znak-jihomoravsky-kraj.svg
+        let region_code =
+            sqlx::query_scalar::<_, String>("SELECT region_code FROM regions WHERE slug = $1")
+                .bind(segments[0])
+                .fetch_optional(db)
+                .await
+                .unwrap_or_else(|e| {
+                    tracing::error!("DB error resolving coat/flag region '{path}': {e}");
+                    None
+                });
+
+        if let Some(code) = region_code {
+            return Some(format!("regions/{code}/{image_type}.{ext}"));
+        }
+
+        // Try ORP (main municipality): /benesov/znak-benesov.svg
+        let muni_code = sqlx::query_scalar::<_, String>(
+            "SELECT m.municipality_code FROM municipalities m \
+             JOIN orp o ON m.orp_id = o.id \
+             WHERE o.slug = $1 AND m.slug = $1",
+        )
+        .bind(segments[0])
+        .fetch_optional(db)
+        .await
+        .unwrap_or_else(|e| {
+            tracing::error!("DB error resolving coat/flag ORP '{path}': {e}");
+            None
+        });
+
+        if let Some(code) = muni_code {
+            return Some(format!("municipalities/{code}/{image_type}.{ext}"));
+        }
+    } else {
+        // 3 segments: /votice/olbramovice/znak-olbramovice.webp
+        let muni_code = sqlx::query_scalar::<_, String>(
+            "SELECT m.municipality_code FROM municipalities m \
+             JOIN orp o ON m.orp_id = o.id \
+             WHERE o.slug = $1 AND m.slug = $2",
+        )
+        .bind(segments[0])
+        .bind(segments[1])
+        .fetch_optional(db)
+        .await
+        .unwrap_or_else(|e| {
+            tracing::error!("DB error resolving coat/flag municipality '{path}': {e}");
+            None
+        });
+
+        if let Some(code) = muni_code {
+            return Some(format!("municipalities/{code}/{image_type}.{ext}"));
+        }
+    }
+
+    None
 }

--- a/cr-web/templates/landmark_detail.html
+++ b/cr-web/templates/landmark_detail.html
@@ -7,9 +7,9 @@
     <div style="display:flex;align-items:center;gap:0.5rem;">
         {% match landmark.municipality_coat_of_arms_ext %}
         {% when Some with (ext) %}
-        {% match landmark.municipality_code %}
-        {% when Some with (code) %}
-        <img src="{{ img }}/img/municipalities/{{ code }}/coat-of-arms.{{ ext }}" alt="Znak {% match landmark.municipality_name %}{% when Some with (mname) %}{{ mname }}{% when None %}obce{% endmatch %}" class="header-emblem">
+        {% match landmark.municipality_slug %}
+        {% when Some with (mslug) %}
+        <img src="/{{ orp.slug }}/{{ mslug }}/znak-{{ mslug }}.{{ ext }}" alt="Znak {% match landmark.municipality_name %}{% when Some with (mname) %}{{ mname }}{% when None %}obce{% endmatch %}" title="Znak {% match landmark.municipality_name %}{% when Some with (mname) %}{{ mname }}{% when None %}obce{% endmatch %}" class="header-emblem">
         {% when None %}
         {% endmatch %}
         {% when None %}
@@ -25,7 +25,7 @@
 {% match region.flag_ext %}
 {% when Some with (ext) %}
 <div class="context-emblem">
-    <img src="{{ img }}/img/regions/{{ region.region_code }}/flag.{{ ext }}" alt="Vlajka {{ region.name }}" class="context-emblem-img">
+    <img src="/{{ region.slug }}/vlajka-{{ region.slug }}.{{ ext }}" alt="Vlajka {{ region.name }}" title="Vlajka {{ region.name }}" class="context-emblem-img">
 </div>
 {% when None %}
 {% endmatch %}

--- a/cr-web/templates/municipality.html
+++ b/cr-web/templates/municipality.html
@@ -7,7 +7,7 @@
     <div style="display:flex;align-items:center;gap:0.5rem;">
         {% match municipality.coat_of_arms_ext %}
         {% when Some with (ext) %}
-        <img src="{{ img }}/img/municipalities/{{ municipality.municipality_code }}/coat-of-arms.{{ ext }}" alt="Znak {{ municipality.name }}" class="header-emblem">
+        <img src="/{{ orp.slug }}/{{ municipality.slug }}/znak-{{ municipality.slug }}.{{ ext }}" alt="Znak {{ municipality.name }}" title="Znak {{ municipality.name }}" class="header-emblem">
         {% when None %}
         {% endmatch %}
         <h1>{{ municipality.name }}</h1>
@@ -21,7 +21,7 @@
 {% match municipality.flag_ext %}
 {% when Some with (ext) %}
 <div class="context-emblem">
-    <img src="{{ img }}/img/municipalities/{{ municipality.municipality_code }}/flag.{{ ext }}" alt="Vlajka {{ municipality.name }}" class="context-emblem-img">
+    <img src="/{{ orp.slug }}/{{ municipality.slug }}/vlajka-{{ municipality.slug }}.{{ ext }}" alt="Vlajka {{ municipality.name }}" title="Vlajka {{ municipality.name }}" class="context-emblem-img">
 </div>
 {% when None %}
 {% endmatch %}

--- a/cr-web/templates/orp.html
+++ b/cr-web/templates/orp.html
@@ -7,7 +7,7 @@
     <div style="display:flex;align-items:center;gap:0.5rem;">
         {% match main_municipality.coat_of_arms_ext %}
         {% when Some with (ext) %}
-        <img src="{{ img }}/img/municipalities/{{ main_municipality.municipality_code }}/coat-of-arms.{{ ext }}" alt="Znak {{ orp.name }}" class="header-emblem">
+        <img src="/{{ orp.slug }}/znak-{{ orp.slug }}.{{ ext }}" alt="Znak {{ orp.name }}" title="Znak {{ orp.name }}" class="header-emblem">
         {% when None %}
         {% endmatch %}
         <h1>{{ orp.name }}</h1>
@@ -21,7 +21,7 @@
 {% match main_municipality.flag_ext %}
 {% when Some with (ext) %}
 <div class="context-emblem">
-    <img src="{{ img }}/img/municipalities/{{ main_municipality.municipality_code }}/flag.{{ ext }}" alt="Vlajka {{ orp.name }}" class="context-emblem-img">
+    <img src="/{{ orp.slug }}/vlajka-{{ orp.slug }}.{{ ext }}" alt="Vlajka {{ orp.name }}" title="Vlajka {{ orp.name }}" class="context-emblem-img">
 </div>
 {% when None %}
 {% endmatch %}

--- a/cr-web/templates/region.html
+++ b/cr-web/templates/region.html
@@ -7,7 +7,7 @@
     <div style="display:flex;align-items:center;gap:0.5rem;">
         {% match region.coat_of_arms_ext %}
         {% when Some with (ext) %}
-        <img src="{{ img }}/img/regions/{{ region.region_code }}/coat-of-arms.{{ ext }}" alt="Znak {{ region.name }}" class="header-emblem">
+        <img src="/{{ region.slug }}/znak-{{ region.slug }}.{{ ext }}" alt="Znak {{ region.name }}" title="Znak {{ region.name }}" class="header-emblem">
         {% when None %}
         {% endmatch %}
         <h1>{{ region.name }}</h1>
@@ -21,7 +21,7 @@
 {% match region.flag_ext %}
 {% when Some with (ext) %}
 <div class="context-emblem">
-    <img src="{{ img }}/img/regions/{{ region.region_code }}/flag.{{ ext }}" alt="Vlajka {{ region.name }}" class="context-emblem-img">
+    <img src="/{{ region.slug }}/vlajka-{{ region.slug }}.{{ ext }}" alt="Vlajka {{ region.name }}" title="Vlajka {{ region.name }}" class="context-emblem-img">
 </div>
 {% when None %}
 {% endmatch %}


### PR DESCRIPTION
## Summary
- Replace numeric ID-based image URLs with slug-based SEO URLs for coat-of-arms and flags
- Add `title` attributes to all coat-of-arms and flag `<img>` tags
- Add `.svg` support to image detection in `resolve_path`
- New `resolve_coat_flag` function in `img_proxy` handles `znak-`/`vlajka-` prefix → R2 key mapping

## Changes
- `cr-web/src/img_proxy.rs`: New `resolve_coat_flag()` function resolves SEO URLs to R2 keys (region → `regions/{code}/coat-of-arms.ext`, ORP/municipality → `municipalities/{code}/coat-of-arms.ext`)
- `cr-web/src/handlers/mod.rs`: Add `.svg` to image extension detection
- `cr-web/templates/region.html`: Use `/{slug}/znak-{slug}.ext` and `vlajka-` URLs + title
- `cr-web/templates/orp.html`: Use `/{orp-slug}/znak-{slug}.ext` + title
- `cr-web/templates/municipality.html`: Use `/{orp}/{muni}/znak-{muni}.ext` + title
- `cr-web/templates/landmark_detail.html`: Use municipality slug-based coat URL + region flag URL + title

## Test plan
- [ ] Region page (e.g., `/jihomoravsky-kraj/`) shows coat-of-arms and flag with SEO URLs
- [ ] ORP page (e.g., `/beroun/`) shows coat-of-arms and flag
- [ ] Municipality page (e.g., `/beroun/karlstejn/`) shows coat-of-arms and flag
- [ ] Landmark page shows municipality coat-of-arms and region flag
- [ ] All img tags have `alt` and `title` attributes
- [ ] No broken images on any page
- [ ] SVG images render correctly

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)