### PR TITLE
Remove ?v=2 cache-bust from coat-of-arms and flag URLs

### DIFF
--- a/cr-web/templates/landmark_detail.html
+++ b/cr-web/templates/landmark_detail.html
@@ -9,7 +9,7 @@
         {% when Some with (ext) %}
         {% match landmark.municipality_slug %}
         {% when Some with (mslug) %}
-        <img src="/{{ orp.slug }}/{{ mslug }}/znak-{{ mslug }}.{{ ext }}?v=2" alt="Znak {% match landmark.municipality_name %}{% when Some with (mname) %}{{ mname }}{% when None %}obce{% endmatch %}" title="Znak {% match landmark.municipality_name %}{% when Some with (mname) %}{{ mname }}{% when None %}obce{% endmatch %}" class="header-emblem">
+        <img src="/{{ orp.slug }}/{{ mslug }}/znak-{{ mslug }}.{{ ext }}" alt="Znak {% match landmark.municipality_name %}{% when Some with (mname) %}{{ mname }}{% when None %}obce{% endmatch %}" title="Znak {% match landmark.municipality_name %}{% when Some with (mname) %}{{ mname }}{% when None %}obce{% endmatch %}" class="header-emblem">
         {% when None %}
         {% endmatch %}
         {% when None %}
@@ -25,7 +25,7 @@
 {% match region.flag_ext %}
 {% when Some with (ext) %}
 <div class="context-emblem">
-    <img src="/{{ region.slug }}/vlajka-{{ region.slug }}.{{ ext }}?v=2" alt="Vlajka {{ region.name }}" title="Vlajka {{ region.name }}" class="context-emblem-img">
+    <img src="/{{ region.slug }}/vlajka-{{ region.slug }}.{{ ext }}" alt="Vlajka {{ region.name }}" title="Vlajka {{ region.name }}" class="context-emblem-img">
 </div>
 {% when None %}
 {% endmatch %}

--- a/cr-web/templates/municipality.html
+++ b/cr-web/templates/municipality.html
@@ -7,7 +7,7 @@
     <div style="display:flex;align-items:center;gap:0.5rem;">
         {% match municipality.coat_of_arms_ext %}
         {% when Some with (ext) %}
-        <img src="/{{ orp.slug }}/{{ municipality.slug }}/znak-{{ municipality.slug }}.{{ ext }}?v=2" alt="Znak {{ municipality.name }}" title="Znak {{ municipality.name }}" class="header-emblem">
+        <img src="/{{ orp.slug }}/{{ municipality.slug }}/znak-{{ municipality.slug }}.{{ ext }}" alt="Znak {{ municipality.name }}" title="Znak {{ municipality.name }}" class="header-emblem">
         {% when None %}
         {% endmatch %}
         <h1>{{ municipality.name }}</h1>
@@ -21,7 +21,7 @@
 {% match municipality.flag_ext %}
 {% when Some with (ext) %}
 <div class="context-emblem">
-    <img src="/{{ orp.slug }}/{{ municipality.slug }}/vlajka-{{ municipality.slug }}.{{ ext }}?v=2" alt="Vlajka {{ municipality.name }}" title="Vlajka {{ municipality.name }}" class="context-emblem-img">
+    <img src="/{{ orp.slug }}/{{ municipality.slug }}/vlajka-{{ municipality.slug }}.{{ ext }}" alt="Vlajka {{ municipality.name }}" title="Vlajka {{ municipality.name }}" class="context-emblem-img">
 </div>
 {% when None %}
 {% endmatch %}

--- a/cr-web/templates/orp.html
+++ b/cr-web/templates/orp.html
@@ -7,7 +7,7 @@
     <div style="display:flex;align-items:center;gap:0.5rem;">
         {% match main_municipality.coat_of_arms_ext %}
         {% when Some with (ext) %}
-        <img src="/{{ orp.slug }}/znak-{{ orp.slug }}.{{ ext }}?v=2" alt="Znak {{ orp.name }}" title="Znak {{ orp.name }}" class="header-emblem">
+        <img src="/{{ orp.slug }}/znak-{{ orp.slug }}.{{ ext }}" alt="Znak {{ orp.name }}" title="Znak {{ orp.name }}" class="header-emblem">
         {% when None %}
         {% endmatch %}
         <h1>{{ orp.name }}</h1>
@@ -21,7 +21,7 @@
 {% match main_municipality.flag_ext %}
 {% when Some with (ext) %}
 <div class="context-emblem">
-    <img src="/{{ orp.slug }}/vlajka-{{ orp.slug }}.{{ ext }}?v=2" alt="Vlajka {{ orp.name }}" title="Vlajka {{ orp.name }}" class="context-emblem-img">
+    <img src="/{{ orp.slug }}/vlajka-{{ orp.slug }}.{{ ext }}" alt="Vlajka {{ orp.name }}" title="Vlajka {{ orp.name }}" class="context-emblem-img">
 </div>
 {% when None %}
 {% endmatch %}

--- a/cr-web/templates/region.html
+++ b/cr-web/templates/region.html
@@ -7,7 +7,7 @@
     <div style="display:flex;align-items:center;gap:0.5rem;">
         {% match region.coat_of_arms_ext %}
         {% when Some with (ext) %}
-        <img src="/{{ region.slug }}/znak-{{ region.slug }}.{{ ext }}?v=2" alt="Znak {{ region.name }}" title="Znak {{ region.name }}" class="header-emblem">
+        <img src="/{{ region.slug }}/znak-{{ region.slug }}.{{ ext }}" alt="Znak {{ region.name }}" title="Znak {{ region.name }}" class="header-emblem">
         {% when None %}
         {% endmatch %}
         <h1>{{ region.name }}</h1>
@@ -21,7 +21,7 @@
 {% match region.flag_ext %}
 {% when Some with (ext) %}
 <div class="context-emblem">
-    <img src="/{{ region.slug }}/vlajka-{{ region.slug }}.{{ ext }}?v=2" alt="Vlajka {{ region.name }}" title="Vlajka {{ region.name }}" class="context-emblem-img">
+    <img src="/{{ region.slug }}/vlajka-{{ region.slug }}.{{ ext }}" alt="Vlajka {{ region.name }}" title="Vlajka {{ region.name }}" class="context-emblem-img">
 </div>
 {% when None %}
 {% endmatch %}


### PR DESCRIPTION
## Summary
- Remove `?v=2` query parameter from all coat-of-arms and flag image URLs
- URLs should be clean SEO paths: `/jihomoravsky-kraj/vlajka-jihomoravsky-kraj.svg`
- The `?v=2` was a workaround for stale Cloudflare CDN cache, not a proper solution

## Test plan
- [ ] Playwright: verify coat-of-arms and flag render on region, ORP, municipality pages
- [ ] Verify no `?v=2` in any image URL source

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)