### PR TITLE
fix: Playwright browser path accessible by appuser in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,9 +43,13 @@ RUN apt-get update && \
     useradd -r -s /bin/false appuser
 
 # Install Playwright in a venv (avoids PEP 668 externally-managed error)
+# Set PLAYWRIGHT_BROWSERS_PATH so browsers are installed in a shared location
+# accessible by appuser (not in /root/.cache which is inaccessible)
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers
 RUN python3 -m venv /opt/playwright-venv && \
     /opt/playwright-venv/bin/pip install --no-cache-dir playwright requests && \
-    /opt/playwright-venv/bin/playwright install --with-deps chromium
+    /opt/playwright-venv/bin/playwright install --with-deps chromium && \
+    chmod -R o+rx /opt/pw-browsers
 ENV PATH="/opt/playwright-venv/bin:$PATH"
 
 WORKDIR /app


### PR DESCRIPTION
## Summary
- Fix Playwright Chromium not found when running as `appuser` in Docker
- Set `PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers` so browsers install to a shared location
- Add `chmod -R o+rx` to ensure appuser can execute Chromium

## Root cause
`playwright install` puts browsers in `/root/.cache/ms-playwright/` by default, but the app runs as `appuser` which has no access to `/root/`.

## Test plan
- [ ] `POST /api/video/info` with Novinky.cz URL returns video info (not browser-not-found error)
- [ ] Video download works end-to-end on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)