### PR TITLE
feat: dynamic quality selector from API response

### DIFF
--- a/cr-web/templates/download_video.html
+++ b/cr-web/templates/download_video.html
@@ -495,7 +495,29 @@
     }
 
     function updateQualityButtons(formats) {
-        // Future: dynamically populate quality options from API response
+        var container = document.getElementById('quality-selector');
+        container.innerHTML = '';
+
+        formats.forEach(function(fmt) {
+            var btn = document.createElement('button');
+            btn.className = 'quality-btn';
+            btn.setAttribute('data-quality', fmt.format_id);
+            btn.textContent = fmt.resolution;
+            btn.addEventListener('click', function() {
+                document.querySelectorAll('.quality-btn').forEach(function(b) { b.classList.remove('active'); });
+                btn.classList.add('active');
+                selectedQuality = fmt.format_id;
+            });
+            container.appendChild(btn);
+        });
+
+        // Select the best quality by default (last = highest)
+        var buttons = container.querySelectorAll('.quality-btn');
+        if (buttons.length > 0) {
+            var best = buttons[buttons.length - 1];
+            best.classList.add('active');
+            selectedQuality = best.getAttribute('data-quality');
+        }
     }
 })();
 </script>


### PR DESCRIPTION
## Summary
- Replace hardcoded quality buttons with dynamically generated ones from `/api/video/info` response
- Selects highest quality by default (1080p when available)
- Buttons update each time new video info is fetched

Closes #190

## Test plan
- [ ] Playwright: paste Novinky.cz URL → click "Načíst info" → verify quality buttons show 144p, 240p, 360p, 480p, 720p, 1080p (from API)
- [ ] Verify 1080p is selected by default (highest quality)
- [ ] Click different quality → verify selection changes
- [ ] Paste different URL → verify buttons update

🤖 Generated with [Claude Code](https://claude.com/claude-code)