### PR TITLE
fix: strip SEC1 geo-token to bypass video geo-restriction

### DIFF
--- a/cr-infra/src/video/mod.rs
+++ b/cr-infra/src/video/mod.rs
@@ -190,10 +190,32 @@ fn extract_sdn_url(html: &str) -> Option<String> {
     let url = &html[start..end];
 
     if url.contains("vmd") {
-        Some(url.to_string())
+        Some(strip_sec1_prefix(url))
     } else {
         None
     }
+}
+
+/// Strip SEC1 token prefix from SDN URL.
+///
+/// Some videos have geo-restricted SEC1 tokens (e.g. `~geo-cz~`) that block
+/// access from non-Czech IPs. The SDN manifest and MP4 files work without
+/// the SEC1 prefix, so we strip it to avoid geo-restriction issues.
+///
+/// Before: `https://v39-a.sdn.cz/~SEC1~expire-...~scope-video~.../v_39/vmd/...`
+/// After:  `https://v39-a.sdn.cz/v_39/vmd/...`
+fn strip_sec1_prefix(url: &str) -> String {
+    if let Some(sec1_start) = url.find("/~SEC1~") {
+        // Find the end of SEC1 token (next path segment after the token)
+        // Pattern: /~SEC1~...~.../rest_of_path
+        let after_sec1 = &url[sec1_start + 1..]; // skip the leading /
+        if let Some(slash_pos) = after_sec1.find('/') {
+            let host = &url[..sec1_start];
+            let path = &after_sec1[slash_pos..];
+            return format!("{host}{path}");
+        }
+    }
+    url.to_string()
 }
 
 /// Extract page title.


### PR DESCRIPTION
## Summary
- Strip SEC1 prefix from SDN video URLs to bypass geo-restriction (`~geo-cz~`)
- SDN manifest and MP4 files work without SEC1 token from any IP
- No proxy needed — just URL rewriting

Fixes #213

## Root cause
SDN URLs in page HTML contain SEC1 tokens with geo-restriction: `~SEC1~expire-...~geo-cz~scope-video~.../v_39/vmd/...`. Our VPS in Germany gets empty response for these URLs. Without SEC1 prefix, the same manifest returns valid JSON from any location.

## Test plan
- [ ] Playwright: paste failing URL (Šojgu article) → verify preview appears with title + thumbnail
- [ ] Playwright: paste working URL (Agenda article) → verify still works
- [ ] Both tests on production after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)