### PR TITLE
feat: Cloudflare WARP proxy for YouTube/Instagram support (#223)

### DIFF
--- a/cr-infra/src/video/mod.rs
+++ b/cr-infra/src/video/mod.rs
@@ -73,7 +73,7 @@ pub async fn extract_audio(
     let input_str = input_path.to_str().context("Invalid input path")?;
     let output_str = output_path.to_str().context("Invalid output path")?;
 
-    let output = tokio::process::Command::new("yt-dlp")
+    let output = ytdlp_command()
         .args(["-x", "--audio-format", "mp3", "-o", output_str, input_str])
         .output()
         .await
@@ -121,7 +121,10 @@ struct YtDlpFormat {
 fn ytdlp_command() -> tokio::process::Command {
     let mut cmd = tokio::process::Command::new("yt-dlp");
     if let Ok(proxy) = std::env::var("YTDLP_PROXY") {
-        cmd.arg("--proxy").arg(proxy);
+        let proxy = proxy.trim();
+        if !proxy.is_empty() {
+            cmd.arg("--proxy").arg(proxy);
+        }
     }
     cmd
 }


### PR DESCRIPTION
## Summary
- Read `YTDLP_PROXY` env var and pass as `--proxy` to all yt-dlp calls
- With Cloudflare WARP configured on VPS, YouTube and Instagram now work
- Server setup: WARP proxy mode + socat bridge + UFW rule (already configured on VPS)

Closes #223

## How it works
```
Docker container → host.docker.internal:40001 (socat bridge)
    → 127.0.0.1:40000 (Cloudflare WARP SOCKS5)
    → Cloudflare IP (104.28.x.x) → YouTube/Instagram
```

## Test plan
- [ ] Playwright: paste YouTube URL → verify preview appears with title + formats
- [ ] Playwright: paste Novinky.cz URL → verify still works (not through proxy)
- [ ] Playwright: paste Stream.cz URL → verify works (through proxy)
- [ ] Zero console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)