### PR TITLE
fix: YouTube downloads missing audio — merge video+audio streams

### DIFF
--- a/cr-infra/src/video/mod.rs
+++ b/cr-infra/src/video/mod.rs
@@ -48,10 +48,10 @@ pub async fn download_video(
     client: &reqwest::Client,
     url: &str,
     format_id: &str,
+    resolution: &str,
     output_path: &std::path::Path,
 ) -> Result<u64> {
     if is_seznam_url(url) {
-        // For Seznam: extract info to get the direct MP4 URL, then download
         let info = seznam_extract_info(client, url).await?;
         let fmt = info
             .formats
@@ -61,7 +61,7 @@ pub async fn download_video(
             .context("No format available")?;
         download_direct(client, &fmt.url, output_path).await
     } else {
-        ytdlp_download(url, format_id, output_path).await
+        ytdlp_download(url, resolution, output_path).await
     }
 }
 
@@ -212,23 +212,23 @@ async fn ytdlp_extract_info(url: &str) -> Result<VideoInfo> {
 
 /// Download a video using yt-dlp subprocess.
 /// Uses format selector that merges video+audio (YouTube serves them separately).
-async fn ytdlp_download(url: &str, format_id: &str, output_path: &std::path::Path) -> Result<u64> {
+async fn ytdlp_download(url: &str, resolution: &str, output_path: &std::path::Path) -> Result<u64> {
     let output_str = output_path.to_str().context("Invalid output path")?;
 
     // YouTube splits video and audio into separate streams.
     // Use a format selector that downloads both and merges via ffmpeg.
-    // Extract height from format_id (e.g., "1080p-mp4" → 1080, "480p" → 480)
-    let height = format_id
+    // Extract height from resolution (e.g., "1080p" → 1080, "720p" → 720)
+    let height: String = resolution
         .chars()
         .take_while(|c| c.is_ascii_digit())
-        .collect::<String>();
+        .collect();
 
     let format_selector = if !height.is_empty() {
         format!(
             "bestvideo[height<={height}][ext=mp4]+bestaudio[ext=m4a]/best[height<={height}][ext=mp4]/best"
         )
     } else {
-        format_id.to_string()
+        "best".to_string()
     };
 
     let output = ytdlp_command()

--- a/cr-web/src/handlers/video_api.rs
+++ b/cr-web/src/handlers/video_api.rs
@@ -176,18 +176,23 @@ pub async fn video_prepare(
     let file_path = tmp_dir.join(format!("{token}.{}", format.ext));
 
     // Download the video
-    let size =
-        cr_infra::video::download_video(&state.http_client, &url, &format.format_id, &file_path)
-            .await
-            .map_err(|e| {
-                tracing::error!("Video download failed: {e}");
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(VideoErrorResponse {
-                        error: format!("Stažení se nezdařilo: {e}"),
-                    }),
-                )
-            })?;
+    let size = cr_infra::video::download_video(
+        &state.http_client,
+        &url,
+        &format.format_id,
+        &format.resolution,
+        &file_path,
+    )
+    .await
+    .map_err(|e| {
+        tracing::error!("Video download failed: {e}");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(VideoErrorResponse {
+                error: format!("Stažení se nezdařilo: {e}"),
+            }),
+        )
+    })?;
 
     let size_mb = size as f64 / (1024.0 * 1024.0);
 


### PR DESCRIPTION
## Summary
YouTube serves video and audio as separate streams. Our downloads had only video (no sound) because we passed a single format ID which selected a video-only stream.

## Root cause
YouTube format IDs like `137` (1080p) are "video only". Audio is in separate streams (`139`, `140`). yt-dlp needs to download both and merge via ffmpeg.

## Fix
Replace `-f format_id` with:
```
-f "bestvideo[height<=1080][ext=mp4]+bestaudio[ext=m4a]/best[height<=1080][ext=mp4]/best"
--merge-output-format mp4
```

This downloads best video at requested quality + best audio, then ffmpeg merges them into one MP4 file with both streams.

## Test plan
- [ ] Playwright: download YouTube video, verify file has both video AND audio streams (ffprobe)
- [ ] Novinky.cz download still works (no change for Seznam extractor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)