### PR TITLE
feat: testing workflow — recent downloads + cleanup endpoint (#230)

### DIFF
--- a/cr-web/src/handlers/mod.rs
+++ b/cr-web/src/handlers/mod.rs
@@ -25,7 +25,7 @@ pub use download_video::download_video;
 pub use geojson::{geojson_municipality, geojson_orp};
 pub use landmarks::{api_landmarks, landmarks_by_url, landmarks_index};
 pub use pools::{pools_by_category, pools_hub};
-pub use video_api::{video_file, video_info, video_prepare};
+pub use video_api::{video_cleanup, video_file, video_info, video_prepare, video_recent};
 
 // --- DB row types ---
 

--- a/cr-web/src/handlers/video_api.rs
+++ b/cr-web/src/handlers/video_api.rs
@@ -249,6 +249,87 @@ pub async fn video_file(
         .into_response()
 }
 
+// --- Recent downloads + Cleanup ---
+
+#[derive(Serialize)]
+pub struct RecentFile {
+    filename: String,
+    size_mb: f64,
+    created: String,
+}
+
+#[derive(Serialize)]
+pub struct CleanupResponse {
+    deleted: usize,
+    freed_mb: f64,
+}
+
+pub async fn video_recent(State(state): State<AppState>) -> Json<Vec<RecentFile>> {
+    let downloads = state.video_downloads.lock().await;
+    let mut files = Vec::new();
+
+    let tmp_dir = std::path::PathBuf::from("/tmp/cr-videos");
+    if let Ok(mut entries) = tokio::fs::read_dir(&tmp_dir).await {
+        while let Ok(Some(entry)) = entries.next_entry().await {
+            if let Ok(meta) = entry.metadata().await {
+                let filename = downloads
+                    .values()
+                    .find(|p| p.file_path == entry.path())
+                    .map(|p| p.filename.clone())
+                    .unwrap_or_else(|| entry.file_name().to_string_lossy().to_string());
+
+                let size_mb = meta.len() as f64 / (1024.0 * 1024.0);
+                let created = meta
+                    .created()
+                    .ok()
+                    .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                    .map(|d| {
+                        chrono::DateTime::from_timestamp(d.as_secs() as i64, 0)
+                            .map(|dt| dt.format("%H:%M:%S").to_string())
+                            .unwrap_or_default()
+                    })
+                    .unwrap_or_default();
+
+                files.push(RecentFile {
+                    filename,
+                    size_mb: (size_mb * 10.0).round() / 10.0,
+                    created,
+                });
+            }
+        }
+    }
+
+    Json(files)
+}
+
+pub async fn video_cleanup(State(state): State<AppState>) -> Json<CleanupResponse> {
+    let mut downloads = state.video_downloads.lock().await;
+    downloads.clear();
+
+    let tmp_dir = std::path::PathBuf::from("/tmp/cr-videos");
+    let mut deleted = 0;
+    let mut freed: u64 = 0;
+
+    if let Ok(mut entries) = tokio::fs::read_dir(&tmp_dir).await {
+        while let Ok(Some(entry)) = entries.next_entry().await {
+            if let Ok(meta) = entry.metadata().await {
+                freed += meta.len();
+            }
+            if tokio::fs::remove_file(entry.path()).await.is_ok() {
+                deleted += 1;
+            }
+        }
+    }
+
+    let freed_mb = freed as f64 / (1024.0 * 1024.0);
+    tracing::info!("Cleanup: deleted {deleted} files, freed {freed_mb:.1} MB");
+
+    Json(CleanupResponse {
+        deleted,
+        freed_mb: (freed_mb * 10.0).round() / 10.0,
+    })
+}
+
 /// Sanitize yt-dlp error messages into user-friendly Czech text.
 fn sanitize_error(raw: &str) -> String {
     if raw.contains("Sign in to confirm")

--- a/cr-web/src/main.rs
+++ b/cr-web/src/main.rs
@@ -89,6 +89,11 @@ async fn main() -> Result<()> {
             "/video/file/{token}",
             axum::routing::get(handlers::video_file),
         )
+        .route("/video/recent", axum::routing::get(handlers::video_recent))
+        .route(
+            "/video/cleanup",
+            axum::routing::delete(handlers::video_cleanup),
+        )
         .layer(cors);
 
     let app = Router::new()

--- a/cr-web/templates/download_video.html
+++ b/cr-web/templates/download_video.html
@@ -297,6 +297,11 @@
     </div>
 </div>
 
+<div class="recent-downloads" id="recent-downloads" style="display:none;">
+    <h3 style="font-size:0.95rem;font-weight:600;color:var(--color-black);margin-bottom:0.5rem;">Naposledy stažené</h3>
+    <ul id="recent-list" style="list-style:none;padding:0;margin:0;font-size:0.85rem;color:#555;"></ul>
+</div>
+
 <div class="supported-services">
     <a href="https://www.seznamzpravy.cz" target="_blank" rel="nofollow noopener noreferrer" class="service-link supported">
         <img src="/static/img/services/seznam-zpravy.svg" alt="Logo Seznam Zprávy" title="Seznam Zprávy" class="service-logo" height="20">
@@ -437,6 +442,7 @@
         .then(function(data) {
             showStatus('Stahování začíná\u2026 (' + (data.size_mb || '?') + ' MB)', false);
             window.location.href = '/api/video/file/' + data.token;
+            setTimeout(loadRecent, 2000);
         })
         .catch(function(err) {
             showStatus('Stažení se nezdařilo: ' + err.message, true);
@@ -513,6 +519,31 @@
             selectedQuality = best.getAttribute('data-quality');
         }
     }
+
+    function loadRecent() {
+        fetch('/api/video/recent')
+            .then(function(r) { return r.json(); })
+            .then(function(files) {
+                var container = document.getElementById('recent-downloads');
+                var list = document.getElementById('recent-list');
+                if (!files || files.length === 0) {
+                    container.style.display = 'none';
+                    return;
+                }
+                list.innerHTML = '';
+                files.forEach(function(f) {
+                    var li = document.createElement('li');
+                    li.style.padding = '0.3rem 0';
+                    li.style.borderBottom = '1px solid var(--color-gray-border)';
+                    li.textContent = f.filename + ' (' + f.size_mb + ' MB, ' + f.created + ')';
+                    list.appendChild(li);
+                });
+                container.style.display = 'block';
+            })
+            .catch(function() {});
+    }
+
+    loadRecent();
 })();
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- **#231**: GET `/api/video/recent` — list downloaded files with name, size, time
- **#232**: DELETE `/api/video/cleanup` — delete all temp videos, free disk space
- Display "Naposledy stažené" section on page (loads on pageload, refreshes after download)

Closes #231, closes #232

## Test plan
- [ ] Download a video → verify it appears in "Naposledy stažené" list
- [ ] Call DELETE /api/video/cleanup → verify list becomes empty
- [ ] Page load with no videos → list is hidden
- [ ] Zero console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)