### PR TITLE
fix: support Facebook + Dailymotion video downloads (#235)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ FROM debian:bookworm-slim
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates python3 python3-pip ffmpeg && \
-    pip install --no-cache-dir --break-system-packages yt-dlp && \
+    pip install --no-cache-dir --break-system-packages yt-dlp curl_cffi && \
     apt-get purge -y python3-pip && apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/* && \
     useradd -r -s /bin/false appuser

--- a/cr-infra/src/video/mod.rs
+++ b/cr-infra/src/video/mod.rs
@@ -156,16 +156,19 @@ async fn ytdlp_extract_info(url: &str) -> Result<VideoInfo> {
         let all_fmts: Vec<_> = fmts
             .iter()
             .filter(|f| {
-                f.url.is_some()
-                    && f.height.is_some()
-                    && f.vcodec.as_deref() != Some("none")
-                    && f.ext.as_deref() == Some("mp4")
+                // Must have a URL and contain video (not audio-only)
+                f.url.is_some() && f.vcodec.as_deref() != Some("none")
             })
             .map(|f| {
                 let height = f.height.unwrap_or(0);
+                let resolution = if height > 0 {
+                    format!("{height}p")
+                } else {
+                    f.format_id.clone().unwrap_or_else(|| "unknown".to_string())
+                };
                 VideoFormat {
                     format_id: f.format_id.clone().unwrap_or_default(),
-                    resolution: format!("{height}p"),
+                    resolution,
                     ext: f.ext.clone().unwrap_or_else(|| "mp4".to_string()),
                     url: f.url.clone().unwrap_or_default(),
                     filesize_approx: f.filesize.or(f.filesize_approx),


### PR DESCRIPTION
## Summary
- Relax yt-dlp format filter: accept DASH formats without explicit height (Facebook uses vp09 codec in mp4_dash)
- Add `curl_cffi` to Docker for Dailymotion browser impersonation
- Facebook tested locally: 2 formats (640p, 1024p) extracted successfully

Fixes #235

## Test plan
- [ ] Playwright: Facebook reel (https://www.facebook.com/reel/715756463371195/) → preview + download
- [ ] Playwright: Dailymotion (https://www.dailymotion.com/video/x8dxpgx) → preview + download
- [ ] Existing servers still work (YouTube, Novinky, Stream.cz)
- [ ] ffprobe: video+audio in downloaded files

🤖 Generated with [Claude Code](https://claude.com/claude-code)