### PR TITLE
feat: migrate CI/CD feedback from CronCreate polling to push-based hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,21 +125,27 @@ jobs:
 
       - name: Write deploy event for Claude Code
         if: always()
+        continue-on-error: true
         shell: bash
         run: |
           EVENTS_DIR="$HOME/.config/claude-channels/deploy-events"
           mkdir -p "$EVENTS_DIR"
-          jq -n \
-            --arg event "deploy-complete" \
-            --arg status "${{ job.status }}" \
-            --arg repository "${{ github.repository }}" \
-            --arg commit "${GITHUB_SHA:0:7}" \
-            --arg commitMessage "$(git log -1 --pretty=%s 2>/dev/null || echo unknown)" \
-            --arg runUrl "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
-            --arg environment "production" \
-            --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            '{event: $event, status: $status, repository: $repository, commit: $commit, commitMessage: $commitMessage, runUrl: $runUrl, environment: $environment, timestamp: $timestamp}' \
-            > "$EVENTS_DIR/Olbrasoft-cr.json"
+
+          if command -v jq >/dev/null 2>&1; then
+            jq -n \
+              --arg event "deploy-complete" \
+              --arg status "${{ job.status }}" \
+              --arg repository "${{ github.repository }}" \
+              --arg commit "${GITHUB_SHA:0:7}" \
+              --arg commitMessage "$(git log -1 --pretty=%s 2>/dev/null || echo unknown)" \
+              --arg runUrl "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+              --arg environment "production" \
+              --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+              '{event: $event, status: $status, repository: $repository, commit: $commit, commitMessage: $commitMessage, runUrl: $runUrl, environment: $environment, timestamp: $timestamp}' \
+              > "$EVENTS_DIR/Olbrasoft-cr.json"
+          else
+            echo "jq is not installed on this runner; skipping deploy event write." >&2
+          fi
 
   verify:
     name: Verify production
@@ -159,16 +165,22 @@ jobs:
 
       - name: Write verify event for Claude Code
         if: always()
+        continue-on-error: true
         shell: bash
         run: |
           EVENTS_DIR="$HOME/.config/claude-channels/deploy-events"
           mkdir -p "$EVENTS_DIR"
-          jq -n \
-            --arg event "verify-complete" \
-            --arg status "${{ job.status }}" \
-            --arg repository "${{ github.repository }}" \
-            --arg commit "${GITHUB_SHA:0:7}" \
-            --arg environment "production" \
-            --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            '{event: $event, status: $status, repository: $repository, commit: $commit, environment: $environment, timestamp: $timestamp}' \
-            > "$EVENTS_DIR/Olbrasoft-cr-verify.json"
+
+          if command -v jq >/dev/null 2>&1; then
+            jq -n \
+              --arg event "verify-complete" \
+              --arg status "${{ job.status }}" \
+              --arg repository "${{ github.repository }}" \
+              --arg commit "${GITHUB_SHA:0:7}" \
+              --arg environment "production" \
+              --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+              '{event: $event, status: $status, repository: $repository, commit: $commit, environment: $environment, timestamp: $timestamp}' \
+              > "$EVENTS_DIR/Olbrasoft-cr-verify.json"
+          else
+            echo "jq is not installed on this runner; skipping verify event write." >&2
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,8 +275,10 @@ GitHub Actions writes event file to `~/.config/claude-channels/deploy-events/Olb
 |---|---|---|
 | `deploy-complete` | `success` | Verify: `curl https://ceskarepublika.wiki/health`. Run Playwright verification. Notify user. |
 | `deploy-complete` | `failure` | Notify user: "Deploy selhal!" with run URL. |
+| `deploy-complete` | `cancelled` | Notify user: "Deploy zrušen." Include run URL. Investigate and re-run if needed. |
 | `verify-complete` | `success` | Production verified by CI. Run issue-specific Playwright test. Close issue if OK. |
 | `verify-complete` | `failure` | Notify user. Investigate and fix. |
+| `verify-complete` | `cancelled` | Notify user: "Verifikace zrušena." Investigate and re-run if needed. |
 | `code-review-complete` | `commented` | Read comments: `gh api repos/Olbrasoft/cr/pulls/{PR}/comments`. Fix ALL. Push. |
 
 See `ci-workflow-monitor` skill for full event handling details.


### PR DESCRIPTION
## Summary

- Add event file writing steps to CI workflow: `deploy-complete` after deploy job and `verify-complete` after verify job — writes JSON to `~/.config/claude-channels/deploy-events/` for asyncRewake hook detection
- Update CLAUDE.md: replace CronCreate polling instructions with push-based asyncRewake hook documentation, including event types table and updated deploy pipeline description

Closes #240

## Test plan

- [ ] Merge to main → verify deploy job writes `Olbrasoft-cr.json` event file
- [ ] Verify `watch-deploy-events.sh` detects the event and wakes Claude Code
- [ ] Verify `Olbrasoft-cr-verify.json` is written after verify job
- [ ] Confirm no CronCreate references remain in CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)