### PR TITLE
fix: remove asyncRewake test comment from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,6 @@
 # CLAUDE.md
 
 Instructions for Claude Code when working in this repository.
-<!-- asyncRewake test 2: deploy event delivery -->
 
 ## CRITICAL — Issue Completion Rules (MANDATORY)
 


### PR DESCRIPTION
## Summary

- Remove leftover test comment from asyncRewake deploy event testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)