### PR TITLE
test: intentional health check failure for failedStep test

### DIFF
--- a/cr-web/src/handlers/mod.rs
+++ b/cr-web/src/handlers/mod.rs
@@ -734,8 +734,8 @@ pub(crate) fn type_slug_to_url(type_slug: &str) -> &'static str {
 
 // --- Public handlers that stay in mod.rs ---
 
-pub async fn health() -> &'static str {
-    "OK"
+pub async fn health() -> (axum::http::StatusCode, &'static str) {
+    (axum::http::StatusCode::INTERNAL_SERVER_ERROR, "INTENTIONAL FAILURE — failedStep test")
 }
 
 pub async fn homepage(State(state): State<AppState>) -> WebResult<impl IntoResponse> {


### PR DESCRIPTION
## Summary

- Temporarily return HTTP 500 from /health to test failedStep=health-check detection
- **DO NOT keep merged** — revert immediately after testing

## Test plan

- [ ] CI passes (cloud tests don't use production health endpoint)
- [ ] Deploy succeeds, health check fails → event has `failedStep: "health-check"`
- [ ] Revert immediately after verifying

🤖 Generated with [Claude Code](https://claude.com/claude-code)