### PR TITLE
fix: make footer responsive on mobile devices

### DIFF
--- a/cr-web/static/css/index.css
+++ b/cr-web/static/css/index.css
@@ -484,4 +484,31 @@ body {
         gap: 1rem;
         align-items: flex-start;
     }
+
+    .premium-footer {
+        padding: 2rem 0 1.5rem 0;
+        margin-top: 3rem;
+    }
+
+    .footer-main {
+        flex-direction: column;
+        align-items: center;
+        gap: 1.5rem;
+        padding-bottom: 1.5rem;
+    }
+
+    .footer-brand {
+        font-size: 1rem;
+        text-align: center;
+    }
+
+    .footer-github {
+        padding: 0.5rem 1rem;
+        font-size: 0.85rem;
+    }
+
+    .footer-legal {
+        justify-content: center;
+        text-align: center;
+    }
 }


### PR DESCRIPTION
## Summary

- Add responsive styles for footer in `@media (max-width: 1000px)` block
- Stack footer-main vertically, reduce font size, padding, and margins on mobile
- Center-align footer content on small screens

Closes #255

## Test plan

- [ ] Test on 360px (Samsung Galaxy S8+) — email and GitHub link fully visible
- [ ] Test on 344px (Galaxy Z Fold 5) — no overflow or clipping
- [ ] Desktop layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)