### PR TITLE
fix: add cache-busting version to index.css

### DIFF
--- a/cr-web/templates/base.html
+++ b/cr-web/templates/base.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}Česká republika{% endblock %} | ceskarepublika.wiki</title>
     <meta name="description" content="{% block meta_description %}Encyklopedický portál o České republice — kraje, obce, památky, koupání a další.{% endblock %}">
-    <link rel="stylesheet" href="/static/css/index.css">
+    <link rel="stylesheet" href="/static/css/index.css?v=2">
     <link rel="stylesheet" href="/static/css/map.css?v=5">
     <link rel="stylesheet" href="/static/css/lightbox.css?v=2">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">


### PR DESCRIPTION
## Summary

- Add `?v=2` to index.css link — Cloudflare CDN was serving stale CSS after footer responsive update

🤖 Generated with [Claude Code](https://claude.com/claude-code)