### PR TITLE
fix: complete mobile responsive layout — prevent horizontal overflow

### DIFF
--- a/cr-web/static/css/index.css
+++ b/cr-web/static/css/index.css
@@ -15,10 +15,16 @@
     --shadow-premium: 0 10px 15px -3px rgba(0, 0, 0, 0.05), 0 4px 6px -2px rgba(0, 0, 0, 0.02);
 }
 
-* {
+*,
+*::before,
+*::after {
     margin: 0;
     padding: 0;
     box-sizing: border-box;
+}
+
+html {
+    overflow-x: hidden;
 }
 
 body {
@@ -479,10 +485,43 @@ body {
         gap: 3rem;
     }
 
+    .container {
+        padding: 0 1rem;
+    }
+
     .header-flex {
         flex-direction: column;
-        gap: 1rem;
-        align-items: flex-start;
+        gap: 0.75rem;
+        align-items: stretch;
+    }
+
+    .context-emblem {
+        display: none;
+    }
+
+    .search-container {
+        max-width: 100%;
+    }
+
+    .section-title {
+        font-size: 1.5rem;
+    }
+
+    .block-title {
+        font-size: 1.2rem;
+    }
+
+    .lead-text {
+        font-size: 1rem;
+    }
+
+    .grid-cols-2 {
+        gap: 0.5rem 1.5rem;
+    }
+
+    .grid-cols-3 {
+        grid-template-columns: 1fr 1fr;
+        gap: 0.5rem 1.5rem;
     }
 
     .premium-footer {


### PR DESCRIPTION
## Summary

- Add `overflow-x: hidden` on html to prevent horizontal scrolling
- Hide flag (`.context-emblem`) on mobile — saves vertical space
- Reduce `.container` padding from 2rem to 1rem on mobile
- Make header items stretch full-width (search bar visible with button)
- Reduce typography sizes for mobile (section-title, block-title, lead-text)
- Adjust grid columns and gaps for narrow screens

Closes #258

## Test plan

- [ ] 344px (Galaxy Z Fold 5) — no horizontal scroll, all content visible
- [ ] 360px (Galaxy S8+) — search button visible, no overflow
- [ ] 412px (Pixel 7) — text wraps within viewport
- [ ] Desktop — layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)