### PR TITLE
fix: complete mobile responsive layout — prevent horizontal overflow

### DIFF
--- a/cr-web/static/css/index.css
+++ b/cr-web/static/css/index.css
@@ -23,7 +23,8 @@
     box-sizing: border-box;
 }
 
-html {
+html,
+body {
     overflow-x: hidden;
 }
 
@@ -485,12 +486,47 @@ body {
         gap: 3rem;
     }
 
+    .header-flex {
+        flex-direction: column;
+        gap: 1rem;
+        align-items: flex-start;
+    }
+
+    .premium-footer {
+        padding: 2rem 0 1.5rem 0;
+        margin-top: 3rem;
+    }
+
+    .footer-main {
+        flex-direction: column;
+        align-items: center;
+        gap: 1.5rem;
+        padding-bottom: 1.5rem;
+    }
+
+    .footer-brand {
+        font-size: 1rem;
+        text-align: center;
+    }
+
+    .footer-github {
+        padding: 0.5rem 1rem;
+        font-size: 0.85rem;
+    }
+
+    .footer-legal {
+        justify-content: center;
+        text-align: center;
+    }
+}
+
+@media (max-width: 600px) {
+
     .container {
         padding: 0 1rem;
     }
 
     .header-flex {
-        flex-direction: column;
         gap: 0.75rem;
         align-items: stretch;
     }
@@ -522,32 +558,5 @@ body {
     .grid-cols-3 {
         grid-template-columns: 1fr 1fr;
         gap: 0.5rem 1.5rem;
-    }
-
-    .premium-footer {
-        padding: 2rem 0 1.5rem 0;
-        margin-top: 3rem;
-    }
-
-    .footer-main {
-        flex-direction: column;
-        align-items: center;
-        gap: 1.5rem;
-        padding-bottom: 1.5rem;
-    }
-
-    .footer-brand {
-        font-size: 1rem;
-        text-align: center;
-    }
-
-    .footer-github {
-        padding: 0.5rem 1rem;
-        font-size: 0.85rem;
-    }
-
-    .footer-legal {
-        justify-content: center;
-        text-align: center;
     }
 }


### PR DESCRIPTION
## Summary

- Add `overflow-x: hidden` on html to prevent horizontal scrolling
- Hide flag (`.context-emblem`) on mobile
- Reduce `.container` padding from 2rem to 1rem on mobile
- Make header items stretch full-width (search bar visible with button)
- Reduce typography sizes for mobile
- Adjust grid columns and gaps for narrow screens

Closes #258

## Test plan

- [ ] 344px — no horizontal scroll, all content visible
- [ ] 360px — search button visible, no overflow
- [ ] 412px — text wraps within viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)