### PR TITLE
fix: bump CSS cache version to v3 for mobile breakpoint

### DIFF
--- a/cr-web/templates/base.html
+++ b/cr-web/templates/base.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}Česká republika{% endblock %} | ceskarepublika.wiki</title>
     <meta name="description" content="{% block meta_description %}Encyklopedický portál o České republice — kraje, obce, památky, koupání a další.{% endblock %}">
-    <link rel="stylesheet" href="/static/css/index.css?v=2">
+    <link rel="stylesheet" href="/static/css/index.css?v=3">
     <link rel="stylesheet" href="/static/css/map.css?v=5">
     <link rel="stylesheet" href="/static/css/lightbox.css?v=2">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">


### PR DESCRIPTION
## Summary

- Bump index.css version from v2 to v3 — Cloudflare cached v2 before the @media 600px mobile breakpoint was added, so mobile styles (hidden flag, reduced padding) weren't being served

🤖 Generated with [Claude Code](https://claude.com/claude-code)