### PR TITLE
fix: add id and name attributes to search input

### DIFF
--- a/cr-web/templates/base.html
+++ b/cr-web/templates/base.html
@@ -31,7 +31,7 @@
             </div>
             {% endblock %}
             <div class="search-container">
-                <input type="text" class="search-input" placeholder="{% block search_placeholder %}Hledat obec, kraj, památku...{% endblock %}">
+                <input type="text" id="search" name="q" class="search-input" placeholder="{% block search_placeholder %}Hledat obec, kraj, památku...{% endblock %}">
                 <button class="search-btn">Hledat</button>
             </div>
             {% block header_right %}


### PR DESCRIPTION
## Summary

- Add `id="search"` and `name="q"` to search input — fixes DevTools warning "A form field element should have an id or name attribute"
- CSP eval() error in console is from browser extensions (lockdown-install.js), not our code

🤖 Generated with [Claude Code](https://claude.com/claude-code)