### PR TITLE
Fix YouTube download: validate cookies path

### DIFF
--- a/cr-infra/src/video/mod.rs
+++ b/cr-infra/src/video/mod.rs
@@ -193,13 +193,20 @@ fn ytdlp_command() -> tokio::process::Command {
         let cookies = cookies.trim();
         if !cookies.is_empty() {
             let path = std::path::Path::new(cookies);
-            let is_valid = path.is_file() && path.metadata().is_ok_and(|m| m.len() > 0);
-            if is_valid {
-                cmd.arg("--cookies").arg(cookies);
-            } else {
-                tracing::warn!(
-                    "YTDLP_COOKIES path is not a valid cookies file, skipping: {cookies}"
-                );
+            match path.metadata() {
+                Ok(meta) if meta.is_file() && meta.len() > 0 => {
+                    cmd.arg("--cookies").arg(cookies);
+                }
+                Ok(_) => {
+                    tracing::warn!(
+                        "YTDLP_COOKIES path is not a valid cookies file, skipping: {cookies}"
+                    );
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        "YTDLP_COOKIES path metadata could not be read, skipping: {cookies}: {err}"
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- Fix YouTube video download failure caused by Docker volume mount creating an empty directory instead of a file for `youtube-cookies.txt`
- Validate that `YTDLP_COOKIES` path is a regular file with non-zero size before passing `--cookies` to yt-dlp
- Log warning when cookies path is invalid instead of silently failing

## Test plan
- [x] Tested on production: YouTube video info loads successfully
- [x] Tested on production: Video download completes (145.5 MB mp4)
- [x] Server logs show no errors

Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)