### PR TITLE
fix: WhatsApp button label ≤720p

### DIFF
--- a/cr-web/templates/download_video.html
+++ b/cr-web/templates/download_video.html
@@ -621,7 +621,7 @@
         waImg.src = '/static/img/services/whatsapp.svg';
         waImg.alt = 'WhatsApp';
         waBtn.appendChild(waImg);
-        var waLabel = '720p';
+        var waLabel = '\u2264720p';
         if (whatsappParts > 1) {
             waLabel += ' (' + whatsappParts + '\u00d7)';
         }


### PR DESCRIPTION
## Summary
- WhatsApp button label now shows "≤720p" instead of "720p" to indicate maximum resolution, not fixed

Address Copilot review comment on PR #291.

🤖 Generated with [Claude Code](https://claude.com/claude-code)