### PR TITLE
ci(deploy): use commit-suffixed event filename + e2e wake test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,18 +142,23 @@ jobs:
           fi
 
           if command -v jq >/dev/null 2>&1; then
+            COMMIT_SHA="${GITHUB_SHA:0:7}"
+            # Use a run-unique filename so concurrent deploys, re-runs, and
+            # multiple deploys of the same commit do not overwrite each other.
+            # See Olbrasoft/GitHub.Actions.Notify PR #22 + #23 for the design.
+            EVENT_FILE="$EVENTS_DIR/Olbrasoft-cr-deploy-${COMMIT_SHA}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.json"
             jq -n \
               --arg event "deploy-complete" \
               --arg status "${{ job.status }}" \
               --arg failedStep "$FAILED_STEP" \
               --arg repository "${{ github.repository }}" \
-              --arg commit "${GITHUB_SHA:0:7}" \
+              --arg commit "$COMMIT_SHA" \
               --arg commitMessage "$(git log -1 --pretty=%s 2>/dev/null || echo unknown)" \
               --arg runUrl "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
               --arg environment "production" \
               --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
               '{event: $event, status: $status, failedStep: $failedStep, repository: $repository, commit: $commit, commitMessage: $commitMessage, runUrl: $runUrl, environment: $environment, timestamp: $timestamp}' \
-              > "$EVENTS_DIR/Olbrasoft-cr.json"
+              > "$EVENT_FILE"
 
             # Wake ALL Claude Code sessions for this repo via FIFO (only after successful event write)
             WAKE_SCRIPT="$HOME/.claude/hooks/wake-claude.sh"
@@ -190,15 +195,18 @@ jobs:
           mkdir -p "$EVENTS_DIR"
 
           if command -v jq >/dev/null 2>&1; then
+            COMMIT_SHA="${GITHUB_SHA:0:7}"
+            # Run-unique filename — same rationale as the deploy event above.
+            EVENT_FILE="$EVENTS_DIR/Olbrasoft-cr-verify-${COMMIT_SHA}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.json"
             jq -n \
               --arg event "verify-complete" \
               --arg status "${{ job.status }}" \
               --arg repository "${{ github.repository }}" \
-              --arg commit "${GITHUB_SHA:0:7}" \
+              --arg commit "$COMMIT_SHA" \
               --arg environment "production" \
               --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
               '{event: $event, status: $status, repository: $repository, commit: $commit, environment: $environment, timestamp: $timestamp}' \
-              > "$EVENTS_DIR/Olbrasoft-cr-verify.json"
+              > "$EVENT_FILE"
 
             # Wake ALL Claude Code sessions for this repo via FIFO (only after successful event write)
             WAKE_SCRIPT="$HOME/.claude/hooks/wake-claude.sh"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ceskarepublika.wiki
 
-**Encyklopedický portál o České republice** — [ceskarepublika.wiki](https://ceskarepublika.wiki)
+**Encyklopedický portál o České republice a její kultuře** — [ceskarepublika.wiki](https://ceskarepublika.wiki)
 
 [![Live](https://img.shields.io/badge/Live-ceskarepublika.wiki-blue?style=flat&logo=globe)](https://ceskarepublika.wiki)
 [![Rust](https://img.shields.io/badge/Rust-2024_edition-DEA584?logo=rust)](https://www.rust-lang.org/)


### PR DESCRIPTION
## Summary

Two changes bundled together:

1. **`ci.yml` fix**: deploy and verify events now use a run-unique filename pattern `${REPO}-deploy-${COMMIT_SHA}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.json`. Without this, two concurrent deploys (or a re-run of the same commit) overwrite each other's event files and the second wake never reaches Claude Code. Matches Olbrasoft/VirtualAssistant#925 and brings cr in line with the session-bound design from Olbrasoft/GitHub.Actions.Notify#22 + #23.

2. **README intro tweak**: end-to-end test of the FIFO push wake mechanism on this project. The README change is the trigger that walks a real PR through the full chain: creation → PostToolUse auto-register → CI → wake → review → wake → fixes → merge → deploy → wake → verify → wake → assistant reaction.

## Why bundled

The README touch is the trigger and the ci.yml fix is the prerequisite — without the fix, this very PR's deploy event would still write to the old fixed-filename `Olbrasoft-cr.json`. Splitting them would mean the test PR cannot use the new filename until a separate merge.

## Test plan after merge

- [ ] PostToolUse hook in Claude session registered owner of this PR (verify in `~/.config/claude-channels/pr-owners/Olbrasoft-cr-<N>.json`)
- [ ] CI completes → wake reaches Claude session → assistant reacts
- [ ] Copilot review arrives → wake → assistant reads + fixes if needed
- [ ] Merge → deploy → wake → assistant verifies production
- [ ] Verify event → wake → assistant runs Playwright on changed page
- [ ] Issue (if any) closed, user notified

🤖 Generated with [Claude Code](https://claude.com/claude-code)