### PR TITLE
ci(deploy): add event-file retention + sync CLAUDE.md filename refs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,12 @@ jobs:
               '{event: $event, status: $status, failedStep: $failedStep, repository: $repository, commit: $commit, commitMessage: $commitMessage, runUrl: $runUrl, environment: $environment, timestamp: $timestamp}' \
               > "$EVENT_FILE"
 
+            # Retain recent deploy event files only so the persistent self-hosted
+            # runner does not accumulate unbounded JSON files over time. Successfully
+            # delivered events are deleted by wake-claude.sh after the consumer ack;
+            # this cleanup catches the few that drop on dead session and any leftover.
+            find "$EVENTS_DIR" -maxdepth 1 -type f -name 'Olbrasoft-cr-deploy-*.json' -mtime +14 -delete 2>/dev/null || true
+
             # Wake ALL Claude Code sessions for this repo via FIFO (only after successful event write)
             WAKE_SCRIPT="$HOME/.claude/hooks/wake-claude.sh"
             if [ -x "$WAKE_SCRIPT" ]; then
@@ -207,6 +213,9 @@ jobs:
               --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
               '{event: $event, status: $status, repository: $repository, commit: $commit, environment: $environment, timestamp: $timestamp}' \
               > "$EVENT_FILE"
+
+            # Retain recent verify event files only (same rationale as deploy).
+            find "$EVENTS_DIR" -maxdepth 1 -type f -name 'Olbrasoft-cr-verify-*.json' -mtime +14 -delete 2>/dev/null || true
 
             # Wake ALL Claude Code sessions for this repo via FIFO (only after successful event write)
             WAKE_SCRIPT="$HOME/.claude/hooks/wake-claude.sh"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,7 +264,7 @@ All work is **issue-driven** and the CI/CD pipeline runs **fully autonomously** 
 Events arrive automatically via two mechanisms. No polling, no inotifywait, no flock.
 
 **Deploy notification:**
-GitHub Actions writes event file to `~/.config/claude-channels/deploy-events/Olbrasoft-cr.json` + calls `wake-claude.sh Olbrasoft/cr` → wakes ALL Claude Code sessions for this repo via FIFO.
+GitHub Actions writes a run-unique event file `~/.config/claude-channels/deploy-events/Olbrasoft-cr-deploy-{COMMIT_SHA}-{RUN_ID}-{RUN_ATTEMPT}.json` and calls `wake-claude.sh Olbrasoft/cr`. The Notifier looks up the PR owner via the PR number derived from the commit SHA and delivers the event to the exact Claude Code session that created the PR. See [Olbrasoft/GitHub.Actions.Notify#22](https://github.com/Olbrasoft/GitHub.Actions.Notify/pull/22) for the session-bound design.
 
 **Code review notification:**
 `gh webhook forward` service receives `pull_request_review` events via WebSocket → `webhook-receiver.py` writes event file + calls `wake-claude.sh Olbrasoft/cr {branch}` → wakes ONLY the session on that PR's branch.
@@ -319,9 +319,9 @@ Pipeline:
 3. Tests (cloud)
 4. Deploy: rsync + docker build + health check (self-hosted runner)
 5. **Notify**: TTS notification via VirtualAssistant (self-hosted runner)
-6. **FIFO wake**: Write `Olbrasoft-cr.json` + call `wake-claude.sh` → FIFO wakes Claude Code
+6. **FIFO wake**: Write `Olbrasoft-cr-deploy-{COMMIT_SHA}-{RUN_ID}-{RUN_ATTEMPT}.json` + call `wake-claude.sh` → FIFO wakes the PR-owner Claude Code session
 7. **Verify**: Playwright health + homepage check (self-hosted runner)
-8. **FIFO wake**: Write `Olbrasoft-cr-verify.json` + call `wake-claude.sh` → FIFO wakes Claude Code
+8. **FIFO wake**: Write `Olbrasoft-cr-verify-{COMMIT_SHA}-{RUN_ID}-{RUN_ATTEMPT}.json` + call `wake-claude.sh` → FIFO wakes the PR-owner Claude Code session
 
 **Quick deploy (during active development, ~20s):**
 


### PR DESCRIPTION
## Summary

Follow-up to PR #312 review comments by Copilot.

1. **Event file retention**: with the run-unique filename pattern from #312, the deploy/verify event directory accumulates one new JSON file per workflow run. `wake-claude.sh` deletes a file as soon as the consumer acks the FIFO write, but events that drop on dead session (or timeout) would otherwise persist indefinitely on the persistent self-hosted runner. Added a `find ... -mtime +14 -delete` cleanup step right after the event write to bound disk usage to roughly the last two weeks.

2. **CLAUDE.md doc sync**: the CI/CD section still referenced the old fixed filenames (`Olbrasoft-cr.json` and `Olbrasoft-cr-verify.json`). Updated to the run-unique pattern and added a link to the session-bound design discussion in [Olbrasoft/GitHub.Actions.Notify#22](https://github.com/Olbrasoft/GitHub.Actions.Notify/pull/22).

Closes the two pending Copilot review comments on #312.

🤖 Generated with [Claude Code](https://claude.com/claude-code)