### PR TITLE
fix: streamtape — accept size as JSON string in upload response

### DIFF
--- a/cr-infra/src/streamtape/mod.rs
+++ b/cr-infra/src/streamtape/mod.rs
@@ -130,9 +130,26 @@ struct UploadResult {
     url: String,
     id: String,
     name: String,
+    /// Streamtape's upload endpoint sometimes returns size as a JSON
+    /// string ("13704925") rather than a number — accept either via the
+    /// helper below.
+    #[serde(deserialize_with = "deserialize_u64_or_string")]
     size: u64,
     sha256: String,
     content_type: String,
+}
+
+fn deserialize_u64_or_string<'de, D>(d: D) -> Result<u64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::Error;
+    let v = serde_json::Value::deserialize(d)?;
+    match v {
+        serde_json::Value::Number(n) => n.as_u64().ok_or_else(|| Error::custom("not u64")),
+        serde_json::Value::String(s) => s.parse().map_err(Error::custom),
+        _ => Err(Error::custom("expected u64 or string")),
+    }
 }
 
 // --- dlticket / dl response shapes ---
@@ -148,6 +165,7 @@ struct DlResult {
     #[allow(dead_code)]
     name: String,
     #[allow(dead_code)]
+    #[serde(deserialize_with = "deserialize_u64_or_string")]
     size: u64,
     url: String,
 }
@@ -166,6 +184,7 @@ type InfoResult = std::collections::HashMap<String, Option<InfoEntry>>;
 struct InfoEntry {
     id: String,
     name: String,
+    #[serde(deserialize_with = "deserialize_u64_or_string")]
     size: u64,
     content_type: String,
     status: i64,


### PR DESCRIPTION
<!-- claude-session: 31fed042-87fa-4541-9133-47a62274d8d3 -->

## Summary
Streamtape's `/file/ul` upload completion endpoint returns `size` as a JSON **string** (`"13704925"`), not a number. The strict `u64` deserializer broke every real upload with:

  invalid type: string "13704925", expected u64

The upload itself succeeded — we got back a valid `file_id` — but the parse error short-circuited the pipeline before the DB insert, so the library row never appeared.

## Fix
Add a `deserialize_u64_or_string` helper that accepts either a JSON number or a JSON string and use it for `UploadResult.size`, `DlResult.size` and `InfoEntry.size`. Streamtape's serializer is inconsistent across endpoints, so all three are now tolerant.

## Verified end-to-end on production after deploy
- TikTok video → Streamtape upload OK (file_id `R4B80YBg7xSdejr`, 1.6 MB)
- Thumbnail uploaded to R2 (`videos/thumbs/2f6a890ad64db8c0.jpg`)
- `INSERT INTO videos id=1` with all metadata populated
- `GET /api/video/library` returns the entry with thumbnail_url + streamtape_url
- `GET /api/video/library/1/play` resolves a fresh `*.tapecontent.net` URL
- Second `POST /api/video/prepare` with the same (url, quality) → dedup hit log, no yt-dlp, no Streamtape, instant response
- `DELETE /api/video/library/1` → 204, library back to `[]`, Streamtape file deleted, R2 thumbnail deleted

Refs #314, #317