### PR TITLE
test: intentionally broken Rust for CI failure wake [DO NOT MERGE]

### DIFF
--- a/cr-domain/src/intentional_negative_test_for_ci_wake.rs
+++ b/cr-domain/src/intentional_negative_test_for_ci_wake.rs
@@ -1,0 +1,10 @@
+// THIS FILE IS INTENTIONALLY BROKEN.
+// It exists ONLY to verify that the FIFO push-wake mechanism delivers a
+// CI failure event back to the originating Claude Code session.
+// The PR containing this file MUST NOT be merged — close it after the
+// failure wake event has been received.
+
+pub fn intentional_negative_test_for_ci_wake() -> i32 {
+    let value: i32 = "this is not a number";
+    value
+}

--- a/cr-domain/src/lib.rs
+++ b/cr-domain/src/lib.rs
@@ -18,6 +18,7 @@ pub mod coordinates;
 pub mod entities;
 pub mod error;
 pub mod id;
+pub mod intentional_negative_test_for_ci_wake;
 pub mod repository;
 pub mod slug;
 


### PR DESCRIPTION
<!-- claude-session: b68de255-e271-4c80-b1d6-0d4a9d121a82 -->

## Summary
**DO NOT MERGE.** This PR contains a Rust file with an intentional type error (`let value: i32 = "this is not a number"`).

End-to-end negative test of the FIFO push-wake mechanism — verifies that a CI failure event is delivered to the originating Claude Code session.

## Test plan
- [ ] CI Check & Clippy fails (expected)
- [ ] Failure wake event arrives at THIS session
- [ ] PR is closed without merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)