### PR TITLE
feat: download page UX overhaul — Připravit button, dynamic library, background playback (#339)

### DIFF
--- a/cr-web/templates/download_video.html
+++ b/cr-web/templates/download_video.html
@@ -896,7 +896,13 @@
             .then(function(items) {
                 var container = document.getElementById('video-library');
                 var grid = document.getElementById('library-grid');
+                // Empty / invalid response: drop everything we had cached
+                // so a later refetch can rebuild from a clean baseline.
+                // Without this reset, deleting the last library row would
+                // leave stale cards rendered in the DOM forever.
                 if (!Array.isArray(items) || items.length === 0) {
+                    grid.innerHTML = '';
+                    renderedLibraryIds.clear();
                     container.style.display = 'none';
                     return [];
                 }
@@ -930,20 +936,36 @@
             .catch(function(e) { console.warn('library load failed', e); return []; });
     }
 
+    // Bumped every time the user touches the URL form (typing, picking a
+    // quality, clicking Načíst info). The deferred refresh check below
+    // uses this revision number to avoid wiping the user's in-progress
+    // preparation when an *earlier* preparation's pipeline finally lands.
+    var preparationFormRevision = 0;
+    function markPreparationFormChanged() {
+        preparationFormRevision++;
+    }
+    document.addEventListener('input', markPreparationFormChanged, true);
+    document.addEventListener('change', markPreparationFormChanged, true);
+
     // Called after a successful preparation. The publish-to-library
     // pipeline runs in the background after Ready, so we retry the
     // refresh a few times until the new entry shows up. Once a new card
     // appears, also clear the URL form so the user can prepare another
-    // video without manual cleanup.
+    // video without manual cleanup — but only if the user has not
+    // already started typing a *new* URL in the meantime, otherwise we
+    // would clobber their in-progress preparation.
     function scheduleLibraryRefresh() {
         var attempts = 0;
         var maxAttempts = 8;
         var delay = 1500;
+        var scheduledRevision = preparationFormRevision;
         function tick() {
             attempts++;
             loadLibrary().then(function(newItems) {
                 if (newItems && newItems.length > 0) {
-                    clearPreparationForm();
+                    if (preparationFormRevision === scheduledRevision) {
+                        clearPreparationForm();
+                    }
                     return;
                 }
                 if (attempts < maxAttempts) {


### PR DESCRIPTION
<!-- claude-session: 31fed042-87fa-4541-9133-47a62274d8d3 -->

## Summary
Restructures `/stahnout-video/` so the action above the form *prepares* a video for download (instead of dumping a file straight to disk), the prepared entry appears in the library grid live without a page reload, and inline playback survives a phone screen-lock so the page works as an ad-free YouTube/podcast proxy.

## What's in this PR

| Sub-issue | Fix |
|---|---|
| **#340** | Action button renamed from "Stáhnout" to "Připravit ke stažení" so the label matches what actually happens |
| **#341** | Removed the auto-trigger Save As dialog from `showSingleDownload`. The visible ready-link stays in the status row and the user clicks it themselves |
| **#342** | New `scheduleLibraryRefresh()` chains delayed `loadLibrary()` calls until the publish-to-library pipeline finishes; `loadLibrary` tracks rendered ids in a `Set` and prepends new entries with a fade-in animation. `clearPreparationForm()` clears the URL form but keeps the ready-link |
| **#343** | `playsinline` + `webkit-playsinline` on the inline `<video>` so audio keeps playing when the phone screen locks. New `registerMediaSession()` populates `navigator.mediaSession.metadata` (title + "ceskarepublika.wiki" artist + thumbnail artwork) and wires up play/pause/seek action handlers |

## Closes
- Closes #339 (parent), #340, #341, #342, #343

## Test plan (verified on production via direct deploy + Chrome MCP)
- [x] Button reads "Připravit ke stažení"
- [x] Click prepare → no Save As dialog opens automatically
- [x] After ~5-10 s the publish pipeline completes and the new card prepends to the library grid (`.library-card-fadein` animation class applied) without a page reload
- [x] URL form clears + preview/quality selector hidden after the prepend
- [x] Ready-link stays visible in the status row so the user can still click it
- [x] Inline `<video>` has `playsinline` + `webkit-playsinline` attributes
- [x] `navigator.mediaSession.metadata` populated with title, artist, artwork on play
- [x] Card count 3 → 4 after one preparation cycle (verified live with TikTok video, id 6, then cleaned up)

## Browser test plan (manual, mobile)
- [ ] Open on Android Chrome → tap card to play → lock screen → audio keeps playing, lock-screen controls show title + thumbnail
- [ ] Tap pause on lock-screen control → inline `<video>` pauses
- [ ] iOS Safari best-effort: audio continues with screen unlocked + control bar visible