### PR TITLE
fix: real background playback on mobile — 🎧 audio mode (#345)

### DIFF
--- a/cr-web/templates/download_video.html
+++ b/cr-web/templates/download_video.html
@@ -427,26 +427,6 @@
     background: #f8fafc;
     border-bottom: 1px solid var(--color-gray-border);
 }
-.library-actions {
-    display: flex;
-    gap: 0.4rem;
-    margin-top: auto;
-}
-.library-btn {
-    flex: 1;
-    background: var(--color-blue);
-    color: white;
-    border: none;
-    border-radius: 18px;
-    padding: 0.45rem 0.6rem;
-    font-size: 0.78rem;
-    font-weight: 600;
-    cursor: pointer;
-    font-family: 'Inter', sans-serif;
-    transition: background 0.15s;
-    text-align: center;
-}
-.library-btn:hover { background: #0d3962; }
 .library-btn.audio-btn {
     background: var(--color-gold);
 }
@@ -1087,7 +1067,7 @@
         audioBtn.type = 'button';
         audioBtn.className = 'library-btn audio-btn';
         audioBtn.title = 'Pustit jen zvuk — hraje i při zamčené obrazovce na mobilu';
-        audioBtn.innerHTML = '\uD83C\uDFA7 Pustit na pozadí';
+        audioBtn.textContent = '\uD83C\uDFA7 Pustit na pozadí';
         audioBtn.addEventListener('click', function(e) {
             e.stopPropagation();
             playLibraryItemAudio(card, item);


### PR DESCRIPTION
<!-- claude-session: 31fed042-87fa-4541-9133-47a62274d8d3 -->

## Summary
Issue #343 added Media Session API + `playsinline` to the inline `<video>` element, but on real Android Chrome the `<video>` still gets suspended the moment the user locks the screen. The user wanted podcast-style behaviour: open a long video, lock the phone, keep listening.

The reason: mobile browsers treat `<video>` and `<audio>` very differently. `<video>` is suspended on screen lock no matter what Media Session metadata you set; `<audio>` is designed for background playback and reliably keeps going.

## Fix
Add an explicit **🎧 Pustit na pozadí** button to every library card. The existing click-thumbnail-to-play-video flow stays for users who want to *see* the video. The new button creates an `<audio src="…/stream">` element pointing at the same MP4 (browser decodes only the audio track) and keeps playing in background.

- `buildLibraryCard` adds an `library-actions` row with the new golden 🎧 button
- New `playLibraryItemAudio()` pauses any currently playing video in the card, replaces it with `<audio controls>`, keeps the thumbnail above as static "now playing" artwork, and adds a `playing-audio` state class
- `playLibraryItem()` tears down any existing audio before starting a video, so the two modes never run simultaneously
- `registerMediaSession()` works for both element kinds (only touches `.play()` / `.pause()` / `.currentTime` which both share)
- New CSS for `.library-audio` and `.library-btn.audio-btn`

## Closes
- Closes #345
- Refs #339 (parent), #343 (initial Media Session attempt)

## Test plan (verified on production via direct deploy + Chrome MCP)
- [x] 🎧 button visible on every card with text "Pustit na pozadí"
- [x] Click → `playing-audio` class added, `<audio>` element rendered, `src` points at `/api/video/library/{id}/stream`
- [x] After ~4 s: `paused=false`, `readyState=4`, `currentTime=14.74`, `duration=546.30`, `mediaSession.playbackState=playing`, title set
- [x] Thumbnail still visible above the audio control bar
- [x] No double playback when switching between video and audio modes

## Manual test plan (mobile)
- [ ] Android Chrome: tap 🎧 → audio plays → lock screen → audio keeps playing, lock-screen control bar shows title + thumbnail
- [ ] iOS Safari: same flow — audio should keep playing on lock screen (Safari is more restrictive but `<audio>` is the most reliable fallback)