### PR TITLE
fix: keep local temp file after R2/Streamtape publish (#363)

### DIFF
--- a/cr-infra/src/video_library/mod.rs
+++ b/cr-infra/src/video_library/mod.rs
@@ -101,7 +101,15 @@ impl VideoLibraryPipeline {
 
     /// Publish a freshly downloaded local file to the library: upload to
     /// Streamtape, upload thumbnail to R2 (with `getsplash` fallback),
-    /// insert into the `videos` table, and remove the local copy.
+    /// and insert into the `videos` table.
+    ///
+    /// The local copy is intentionally **left on disk** so the user can
+    /// still download it via `/api/video/file/{token}` after publish —
+    /// see issue #363, where an earlier version of this method deleted
+    /// the file here and broke the "Stáhnout" ready-link as soon as the
+    /// background upload finished. Temp files are reaped by the manual
+    /// `DELETE /api/video/cleanup` endpoint and the future periodic
+    /// cleanup tracked in #192.
     pub async fn publish_local_video(
         &self,
         local_path: &Path,
@@ -159,11 +167,11 @@ impl VideoLibraryPipeline {
             .await?
             .ok_or(sqlx::Error::RowNotFound)?;
 
-        // 4) Best-effort cleanup of the temp file. Don't fail the publish
-        //    if removal hits a permission error or the file is already gone.
-        if let Err(e) = tokio::fs::remove_file(local_path).await {
-            tracing::warn!("could not remove temp file {local_path:?}: {e}");
-        }
+        // 4) Keep the local temp file on disk on purpose — the handler's
+        //    `/api/video/file/{token}` ready-link still points at it and
+        //    needs to succeed after publish finishes (issue #363). The
+        //    file is cleaned up by `DELETE /api/video/cleanup` and the
+        //    future periodic reaper (#192).
 
         Ok(record)
     }

--- a/cr-web/src/handlers/video_api.rs
+++ b/cr-web/src/handlers/video_api.rs
@@ -447,8 +447,10 @@ pub async fn video_prepare(
                         filename: task.filename.clone(),
                     };
                     // #319 — fire-and-forget publish to the library. Local
-                    // file is kept until the existing temp cleanup runs so
-                    // the user can still download it via /api/video/file/.
+                    // file is intentionally kept on disk by `publish_local_video`
+                    // (see #363) so the user can still download it via
+                    // `/api/video/file/{token}` after the upload finishes.
+                    // Temp files are reaped by `DELETE /api/video/cleanup`.
                     if let Some(pipeline) = dl_state.video_library.clone() {
                         let publish_path = file_path.clone();
                         let publish_meta = publish_meta_template.clone();


### PR DESCRIPTION
<!-- claude-session: 1423c3af-3052-4a9c-84fd-4622a4527689 -->

Closes #363

## Summary

The "Stáhnout" ready-link on `/stahnout-video/` builds an `<a>` pointing at `/api/video/file/{token}`, whose handler reads bytes from the temp file stored in `VideoTask.file_path`. The background `publish_local_video` step was deleting that same file via `tokio::fs::remove_file` immediately after the Streamtape upload + DB insert finished. Whenever the background upload completed before the user clicked the ready-link, the handler hit ENOENT and returned 500, and Chrome showed "file not available" in the downloads panel.

The spawn-site comment in `video_api.rs` already stated the intended behaviour — "Local file is kept until the existing temp cleanup runs so the user can still download it via /api/video/file/" — but `publish_local_video` was violating that contract.

## Changes

- `cr-infra/src/video_library/mod.rs` — drop the `tokio::fs::remove_file(local_path)` call from step 4 of `publish_local_video`; update the method doc comment to document the intentional "leave on disk" behaviour and point at #363 / #192.
- `cr-web/src/handlers/video_api.rs` — update the spawn-site comment to reference `publish_local_video` and `DELETE /api/video/cleanup` instead of "the existing temp cleanup" (which did not exist).

Temp files are reaped by the existing `DELETE /api/video/cleanup` endpoint and by the future periodic reaper tracked in #192.

## Test plan

- [x] `SQLX_OFFLINE=true cargo check` passes
- [x] `cargo fmt --check` passes
- [x] `cargo test -p cr-infra video_library` — 5 existing `sanitize_for_filename` tests still pass
- [ ] CI: Check & Clippy, Format, Test
- [ ] Deploy to production
- [ ] Playwright end-to-end test on https://ceskarepublika.wiki/stahnout-video/: enter URL → Načíst info → Připravit ke stažení → wait for Ready → click the ready-link → verify the file actually downloads with correct Content-Disposition and the bytes match the on-disk video
- [ ] Verify a second "Připravit" for the same URL (dedup path) — still broken in a separate bug; not fixed by this PR