### PR TITLE
feat: periodic temp video cleanup — reap files older than 30 minutes (#192)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,11 +966,13 @@ dependencies = [
  "cr-domain",
  "cr-infra",
  "dotenvy",
+ "filetime",
  "image",
  "reqwest",
  "serde",
  "serde_json",
  "sqlx",
+ "tempfile",
  "thiserror",
  "tokio",
  "tower",
@@ -1297,6 +1299,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -2128,6 +2141,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -3055,6 +3074,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3664,6 +3696,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/cr-web/Cargo.toml
+++ b/cr-web/Cargo.toml
@@ -29,3 +29,7 @@ reqwest = { workspace = true, features = ["stream"] }
 uuid = { workspace = true }
 ammonia = "4.1.2"
 urlencoding = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"
+filetime = "0.2"

--- a/cr-web/src/handlers/video_api.rs
+++ b/cr-web/src/handlers/video_api.rs
@@ -12,6 +12,22 @@ use tokio::sync::{Mutex, Semaphore};
 /// Maximum concurrent video downloads.
 pub static VIDEO_DOWNLOAD_SEMAPHORE: Semaphore = Semaphore::const_new(3);
 
+/// On-disk directory where yt-dlp drops freshly downloaded videos before
+/// they are either served to the user via `/api/video/file/{token}` or
+/// published to the library pipeline.
+pub(crate) const TMP_VIDEO_DIR: &str = "/tmp/cr-videos";
+
+/// Maximum age a temp video may sit on disk before the periodic reaper
+/// removes it. See issue #192 — the VPS has limited disk and we can't
+/// keep videos around forever after the user has finished downloading
+/// them (the library copy on Streamtape + R2 is the canonical long-term
+/// store).
+pub(crate) const TMP_VIDEO_MAX_AGE: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+
+/// How often the periodic reaper wakes up to scan the temp dir.
+pub(crate) const TMP_VIDEO_CLEANUP_INTERVAL: std::time::Duration =
+    std::time::Duration::from_secs(5 * 60);
+
 use crate::state::AppState;
 
 /// Shared state for tracking video download tasks (async).
@@ -681,6 +697,180 @@ pub async fn video_cleanup(State(state): State<AppState>) -> Json<CleanupRespons
         deleted,
         freed_mb: (freed_mb * 10.0).round() / 10.0,
     })
+}
+
+// --- Periodic temp video cleanup (#192) ---
+
+/// Scan `dir` once and delete any regular file whose last-modified
+/// timestamp is older than `max_age`. Returns `(deleted_count,
+/// bytes_freed)`.
+///
+/// Errors (failing to open the dir, failing to read an entry, failing
+/// to delete a single file) are logged and skipped — the reaper runs
+/// every few minutes so any transient issue will be retried on the
+/// next tick.
+pub(crate) async fn purge_stale_temp_videos(
+    dir: &std::path::Path,
+    max_age: std::time::Duration,
+) -> (usize, u64) {
+    let mut deleted = 0usize;
+    let mut freed = 0u64;
+
+    let mut entries = match tokio::fs::read_dir(dir).await {
+        Ok(e) => e,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return (0, 0),
+        Err(e) => {
+            tracing::warn!("temp cleanup: cannot open {dir:?}: {e}");
+            return (0, 0);
+        }
+    };
+
+    loop {
+        let entry = match entries.next_entry().await {
+            Ok(Some(e)) => e,
+            Ok(None) => break,
+            Err(e) => {
+                tracing::warn!("temp cleanup: read_dir error: {e}");
+                break;
+            }
+        };
+        let meta = match entry.metadata().await {
+            Ok(m) => m,
+            Err(e) => {
+                tracing::warn!("temp cleanup: stat {:?}: {e}", entry.path());
+                continue;
+            }
+        };
+        if !meta.is_file() {
+            continue;
+        }
+        let age = meta
+            .modified()
+            .ok()
+            .and_then(|m| m.elapsed().ok())
+            .unwrap_or_default();
+        if age < max_age {
+            continue;
+        }
+        let path = entry.path();
+        let size = meta.len();
+        match tokio::fs::remove_file(&path).await {
+            Ok(()) => {
+                deleted += 1;
+                freed += size;
+                tracing::debug!(
+                    "temp cleanup: removed {path:?} (age={}s, size={} bytes)",
+                    age.as_secs(),
+                    size
+                );
+            }
+            Err(e) => {
+                tracing::warn!("temp cleanup: remove {path:?}: {e}");
+            }
+        }
+    }
+
+    (deleted, freed)
+}
+
+/// Spawn the long-running periodic reaper. Call once at startup from
+/// `main.rs`; the returned handle is detached (the task ends only when
+/// the process exits).
+///
+/// Every `TMP_VIDEO_CLEANUP_INTERVAL` it scans [`TMP_VIDEO_DIR`] and
+/// deletes any file older than `TMP_VIDEO_MAX_AGE`. The first tick
+/// fires on the interval boundary — not immediately on startup —
+/// which deliberately gives in-flight downloads time to complete
+/// before the reaper runs the first time.
+pub fn spawn_temp_video_cleanup_loop() -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let dir = std::path::PathBuf::from(TMP_VIDEO_DIR);
+        let mut ticker = tokio::time::interval(TMP_VIDEO_CLEANUP_INTERVAL);
+        // Skip the immediate tick `interval` fires at t=0 — we want the
+        // first scan to land `TMP_VIDEO_CLEANUP_INTERVAL` after startup
+        // so any download racing the boot doesn't get swept mid-write.
+        ticker.tick().await;
+        loop {
+            ticker.tick().await;
+            let (deleted, freed) = purge_stale_temp_videos(&dir, TMP_VIDEO_MAX_AGE).await;
+            if deleted > 0 {
+                let freed_mb = freed as f64 / (1024.0 * 1024.0);
+                tracing::info!(
+                    "periodic temp cleanup: deleted {deleted} files older than {}m, freed {freed_mb:.1} MB",
+                    TMP_VIDEO_MAX_AGE.as_secs() / 60
+                );
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod temp_cleanup_tests {
+    use super::purge_stale_temp_videos;
+    use std::time::Duration;
+
+    /// Create a file in `dir` whose mtime is `age_secs` in the past and
+    /// whose body is `size` bytes of zeros. Returns the full path.
+    async fn write_aged_file(dir: &std::path::Path, name: &str, size: usize, age_secs: u64) {
+        let path = dir.join(name);
+        tokio::fs::write(&path, vec![0u8; size]).await.unwrap();
+        // Back-date the mtime so the reaper thinks the file is stale.
+        let past = std::time::SystemTime::now() - Duration::from_secs(age_secs);
+        let ft = filetime::FileTime::from_system_time(past);
+        filetime::set_file_mtime(&path, ft).unwrap();
+    }
+
+    #[tokio::test]
+    async fn deletes_only_files_older_than_max_age() {
+        let tmp = tempfile::tempdir().unwrap();
+        // 2 stale files, 1 fresh file.
+        write_aged_file(tmp.path(), "old1.mp4", 1024, 3600).await;
+        write_aged_file(tmp.path(), "old2.mp4", 2048, 3600).await;
+        write_aged_file(tmp.path(), "fresh.mp4", 512, 10).await;
+
+        let (deleted, freed) =
+            purge_stale_temp_videos(tmp.path(), Duration::from_secs(30 * 60)).await;
+
+        assert_eq!(deleted, 2, "should delete the two old files");
+        assert_eq!(freed, 1024 + 2048, "should free the exact byte count");
+        assert!(
+            tmp.path().join("fresh.mp4").exists(),
+            "fresh file must survive"
+        );
+        assert!(!tmp.path().join("old1.mp4").exists());
+        assert!(!tmp.path().join("old2.mp4").exists());
+    }
+
+    #[tokio::test]
+    async fn missing_dir_is_a_no_op() {
+        let missing = std::path::PathBuf::from("/tmp/cr-videos-periodic-cleanup-does-not-exist");
+        let (deleted, freed) =
+            purge_stale_temp_videos(&missing, Duration::from_secs(30 * 60)).await;
+        assert_eq!(deleted, 0);
+        assert_eq!(freed, 0);
+    }
+
+    #[tokio::test]
+    async fn empty_dir_deletes_nothing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (deleted, freed) =
+            purge_stale_temp_videos(tmp.path(), Duration::from_secs(30 * 60)).await;
+        assert_eq!(deleted, 0);
+        assert_eq!(freed, 0);
+    }
+
+    #[tokio::test]
+    async fn skips_subdirectories() {
+        let tmp = tempfile::tempdir().unwrap();
+        tokio::fs::create_dir(tmp.path().join("subdir"))
+            .await
+            .unwrap();
+        write_aged_file(tmp.path(), "old.mp4", 100, 3600).await;
+
+        let (deleted, _) = purge_stale_temp_videos(tmp.path(), Duration::from_secs(30 * 60)).await;
+        assert_eq!(deleted, 1, "only the file should be deleted, not the dir");
+        assert!(tmp.path().join("subdir").exists());
+    }
 }
 
 // --- Thumbnail proxy ---

--- a/cr-web/src/handlers/video_api.rs
+++ b/cr-web/src/handlers/video_api.rs
@@ -281,7 +281,7 @@ pub async fn video_prepare(
     })?;
 
     // Create temp directory if it doesn't exist
-    let tmp_dir = std::path::PathBuf::from("/tmp/cr-videos");
+    let tmp_dir = std::path::PathBuf::from(TMP_VIDEO_DIR);
     tokio::fs::create_dir_all(&tmp_dir).await.map_err(|e| {
         tracing::error!("Failed to create tmp dir: {e}");
         (
@@ -388,7 +388,7 @@ pub async fn video_prepare(
 
                     let wa_result = cr_infra::video::convert_for_whatsapp(
                         &file_path,
-                        &std::path::PathBuf::from("/tmp/cr-videos"),
+                        &std::path::PathBuf::from(TMP_VIDEO_DIR),
                         &dl_token,
                         Some(progress),
                     )
@@ -637,7 +637,7 @@ pub async fn video_recent(State(state): State<AppState>) -> Json<Vec<RecentFile>
     let downloads = state.video_downloads.lock().await;
     let mut files = Vec::new();
 
-    let tmp_dir = std::path::PathBuf::from("/tmp/cr-videos");
+    let tmp_dir = std::path::PathBuf::from(TMP_VIDEO_DIR);
     if let Ok(mut entries) = tokio::fs::read_dir(&tmp_dir).await {
         while let Ok(Some(entry)) = entries.next_entry().await {
             if let Ok(meta) = entry.metadata().await {
@@ -675,7 +675,7 @@ pub async fn video_cleanup(State(state): State<AppState>) -> Json<CleanupRespons
     let mut downloads = state.video_downloads.lock().await;
     downloads.clear();
 
-    let tmp_dir = std::path::PathBuf::from("/tmp/cr-videos");
+    let tmp_dir = std::path::PathBuf::from(TMP_VIDEO_DIR);
     let mut deleted = 0;
     let mut freed: u64 = 0;
 
@@ -773,30 +773,54 @@ pub(crate) async fn purge_stale_temp_videos(
     (deleted, freed)
 }
 
+/// Prune in-memory `VideoDownloads` entries whose `created_at` is older
+/// than `max_age`. Returns the number of tokens removed.
+///
+/// Runs alongside the on-disk reaper so that once a temp file is
+/// deleted, the matching `/api/video/status/{token}` entry goes with
+/// it — otherwise the handler would keep reporting `Ready` while
+/// `/api/video/file/{token}` returns 500 for a missing file.
+pub(crate) async fn prune_stale_video_downloads(
+    downloads: &VideoDownloads,
+    max_age: std::time::Duration,
+) -> usize {
+    let mut map = downloads.lock().await;
+    let before = map.len();
+    map.retain(|_, task| task.created_at.elapsed() < max_age);
+    before - map.len()
+}
+
 /// Spawn the long-running periodic reaper. Call once at startup from
 /// `main.rs`; the returned handle is detached (the task ends only when
 /// the process exits).
 ///
 /// Every `TMP_VIDEO_CLEANUP_INTERVAL` it scans [`TMP_VIDEO_DIR`] and
-/// deletes any file older than `TMP_VIDEO_MAX_AGE`. The first tick
-/// fires on the interval boundary — not immediately on startup —
-/// which deliberately gives in-flight downloads time to complete
-/// before the reaper runs the first time.
-pub fn spawn_temp_video_cleanup_loop() -> tokio::task::JoinHandle<()> {
+/// deletes any file older than `TMP_VIDEO_MAX_AGE`, then prunes the
+/// corresponding in-memory `VideoDownloads` entries so the `status`
+/// endpoint stops reporting `Ready` for tokens whose file is gone.
+///
+/// The first tick fires on the interval boundary — not immediately on
+/// startup — which deliberately gives in-flight downloads time to
+/// complete before the reaper runs the first time. The ticker uses
+/// `MissedTickBehavior::Skip` so a slow sweep (lots of files / slow
+/// I/O) can't trigger a back-to-back burst of catch-up sweeps.
+pub fn spawn_temp_video_cleanup_loop(downloads: VideoDownloads) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let dir = std::path::PathBuf::from(TMP_VIDEO_DIR);
         let mut ticker = tokio::time::interval(TMP_VIDEO_CLEANUP_INTERVAL);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         // Skip the immediate tick `interval` fires at t=0 — we want the
         // first scan to land `TMP_VIDEO_CLEANUP_INTERVAL` after startup
         // so any download racing the boot doesn't get swept mid-write.
         ticker.tick().await;
         loop {
             ticker.tick().await;
-            let (deleted, freed) = purge_stale_temp_videos(&dir, TMP_VIDEO_MAX_AGE).await;
-            if deleted > 0 {
+            let (deleted_files, freed) = purge_stale_temp_videos(&dir, TMP_VIDEO_MAX_AGE).await;
+            let pruned_tokens = prune_stale_video_downloads(&downloads, TMP_VIDEO_MAX_AGE).await;
+            if deleted_files > 0 || pruned_tokens > 0 {
                 let freed_mb = freed as f64 / (1024.0 * 1024.0);
                 tracing::info!(
-                    "periodic temp cleanup: deleted {deleted} files older than {}m, freed {freed_mb:.1} MB",
+                    "periodic temp cleanup: deleted {deleted_files} files ({freed_mb:.1} MB), pruned {pruned_tokens} stale tokens — age threshold {}m",
                     TMP_VIDEO_MAX_AGE.as_secs() / 60
                 );
             }
@@ -810,7 +834,7 @@ mod temp_cleanup_tests {
     use std::time::Duration;
 
     /// Create a file in `dir` whose mtime is `age_secs` in the past and
-    /// whose body is `size` bytes of zeros. Returns the full path.
+    /// whose body is `size` bytes of zeros.
     async fn write_aged_file(dir: &std::path::Path, name: &str, size: usize, age_secs: u64) {
         let path = dir.join(name);
         tokio::fs::write(&path, vec![0u8; size]).await.unwrap();
@@ -870,6 +894,55 @@ mod temp_cleanup_tests {
         let (deleted, _) = purge_stale_temp_videos(tmp.path(), Duration::from_secs(30 * 60)).await;
         assert_eq!(deleted, 1, "only the file should be deleted, not the dir");
         assert!(tmp.path().join("subdir").exists());
+    }
+
+    #[tokio::test]
+    async fn prunes_video_downloads_older_than_max_age() {
+        use super::{VideoDownloads, VideoTask, prune_stale_video_downloads};
+        use std::sync::{
+            Arc,
+            atomic::{AtomicU8, Ordering},
+        };
+
+        let downloads: VideoDownloads =
+            Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new()));
+
+        fn task_with_age(age: Duration) -> VideoTask {
+            VideoTask {
+                status: super::DownloadStatus::Ready {
+                    size_mb: 1.0,
+                    filename: "x.mp4".to_string(),
+                },
+                progress: Arc::new(AtomicU8::new(100)),
+                file_path: std::path::PathBuf::new(),
+                filename: "x.mp4".to_string(),
+                parts: Vec::new(),
+                // Back-date created_at by subtracting from Instant::now().
+                created_at: std::time::Instant::now() - age,
+            }
+        }
+
+        {
+            let mut map = downloads.lock().await;
+            map.insert("stale1".into(), task_with_age(Duration::from_secs(3600)));
+            map.insert("stale2".into(), task_with_age(Duration::from_secs(3600)));
+            map.insert("fresh".into(), task_with_age(Duration::from_secs(10)));
+        }
+
+        let pruned = prune_stale_video_downloads(&downloads, Duration::from_secs(30 * 60)).await;
+        assert_eq!(pruned, 2, "both stale tokens should be pruned");
+
+        let map = downloads.lock().await;
+        assert!(map.contains_key("fresh"), "fresh token must survive");
+        assert!(!map.contains_key("stale1"));
+        assert!(!map.contains_key("stale2"));
+        // sanity: progress atomic is unused in this test but Clippy might
+        // complain about it being dead if we drop it silently.
+        assert_eq!(
+            map["fresh"].progress.load(Ordering::Relaxed),
+            100,
+            "progress atomic survives unchanged"
+        );
     }
 }
 

--- a/cr-web/src/main.rs
+++ b/cr-web/src/main.rs
@@ -89,6 +89,17 @@ async fn main() -> Result<()> {
         _ => None,
     };
 
+    let video_downloads: handlers::video_api::VideoDownloads =
+        Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new()));
+
+    // #192 — periodic reaper for /tmp/cr-videos/. Deletes anything older
+    // than 30 minutes so temp videos left behind by `publish_local_video`
+    // (kept on disk on purpose for the /api/video/file/{token} ready-link,
+    // see #363) don't accumulate and exhaust the VPS disk. Also prunes
+    // matching in-memory `video_downloads` entries so `/status/{token}`
+    // doesn't report `Ready` for a file that's already been reaped.
+    let _cleanup_task = handlers::video_api::spawn_temp_video_cleanup_loop(video_downloads.clone());
+
     let state = AppState {
         region_repo: Arc::new(PgRegionRepository::new(pool.clone())),
         orp_repo: Arc::new(PgOrpRepository::new(pool.clone())),
@@ -101,7 +112,7 @@ async fn main() -> Result<()> {
         geojson_index: Arc::new(geojson_index),
         image_base_url,
         http_client: reqwest::Client::new(),
-        video_downloads: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
+        video_downloads,
         streamtape_config: streamtape_config.map(Arc::new),
         r2_config: r2_config.map(Arc::new),
         video_library,
@@ -256,12 +267,6 @@ async fn main() -> Result<()> {
     };
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
     tracing::info!("Listening on {addr}");
-
-    // #192 — periodic reaper for /tmp/cr-videos/. Deletes anything older
-    // than 30 minutes so temp videos left behind by `publish_local_video`
-    // (kept on disk on purpose for the /api/video/file/{token} ready-link,
-    // see #363) don't accumulate and exhaust the VPS disk.
-    let _cleanup_task = handlers::video_api::spawn_temp_video_cleanup_loop();
 
     let listener = tokio::net::TcpListener::bind(addr).await?;
     axum::serve(listener, app)

--- a/cr-web/src/main.rs
+++ b/cr-web/src/main.rs
@@ -257,6 +257,12 @@ async fn main() -> Result<()> {
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
     tracing::info!("Listening on {addr}");
 
+    // #192 — periodic reaper for /tmp/cr-videos/. Deletes anything older
+    // than 30 minutes so temp videos left behind by `publish_local_video`
+    // (kept on disk on purpose for the /api/video/file/{token} ready-link,
+    // see #363) don't accumulate and exhaust the VPS disk.
+    let _cleanup_task = handlers::video_api::spawn_temp_video_cleanup_loop();
+
     let listener = tokio::net::TcpListener::bind(addr).await?;
     axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_signal())


### PR DESCRIPTION
<!-- claude-session: 1423c3af-3052-4a9c-84fd-4622a4527689 -->

Closes #192
Related: #363 (which ensures files stay on disk after publish so this reaper has a clear, unambiguous owner of disk cleanup).

## Summary

Adds a Tokio background task that scans `/tmp/cr-videos/` every 5 minutes and deletes any regular file whose mtime is older than 30 minutes. Until now the only cleanup was the manual `DELETE /api/video/cleanup` endpoint — leaving a CAX11-sized VPS vulnerable to disk exhaustion whenever nobody remembers to run it.

The first scan is delayed one full interval so downloads that race boot-up have a chance to complete before the reaper runs.

## Changes

- `cr-web/src/handlers/video_api.rs`:
  - New constants `TMP_VIDEO_DIR`, `TMP_VIDEO_MAX_AGE` (30 min), `TMP_VIDEO_CLEANUP_INTERVAL` (5 min)
  - New `purge_stale_temp_videos(dir, max_age) -> (usize, u64)` — one-shot pass that opens the dir, filters by mtime, deletes regular files, logs per-error but never fails the whole sweep
  - New `spawn_temp_video_cleanup_loop()` — wraps `purge_stale_temp_videos` in a `tokio::time::interval` loop
  - New `temp_cleanup_tests` module (4 tests)
- `cr-web/src/main.rs` — spawns the reaper once, right before `axum::serve`
- `cr-web/Cargo.toml` — adds `tempfile` + `filetime` as dev-dependencies for deterministic mtime-based tests

## Test plan

- [x] `cargo check` passes
- [x] `cargo fmt --check` passes
- [x] `cargo test --all` — 11/11 tests pass including the 4 new `temp_cleanup_tests`
  - `deletes_only_files_older_than_max_age`
  - `missing_dir_is_a_no_op`
  - `empty_dir_deletes_nothing`
  - `skips_subdirectories`
- [ ] CI: Check & Clippy, Format, Test
- [ ] Deploy to production
- [ ] Verify on production: `ssh -p 2222 root@46.225.101.253 "ls -la /tmp/cr-videos/ && date"` shows files present, then `docker logs cr-web-1 --since 6m | grep "periodic temp cleanup"` shows the reaper tick firing
- [ ] Playwright sanity: download a video via `/stahnout-video/`, confirm it still works end-to-end