### PR TITLE
fix: show video player always for Přehraj.to auto-play

### DIFF
--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -106,6 +106,7 @@ struct FilmDetailTemplate {
     img: String,
     film: FilmRow,
     genres: Vec<FilmGenreNameRow>,
+    #[allow(dead_code)]
     sources: Vec<FilmSourceRow>,
 }
 

--- a/cr-web/templates/film_detail.html
+++ b/cr-web/templates/film_detail.html
@@ -40,8 +40,7 @@
         <span>›</span> <span>{{ film.title }}</span>
     </nav>
 
-    {# Video player section #}
-    {% if film.sktorrent_video_id.is_some() || !sources.is_empty() %}
+    {# Video player section — always shown (Přehraj.to auto-play needs it even without SK Torrent) #}
     <div class="player-section">
         {# SK Torrent — direct CDN MP4 (no server load, scalable).
            Bombuj providers (Filemoon/Streamtape/Mixdrop) removed — CDN URLs
@@ -81,7 +80,6 @@
         {% when None %}
         {% endmatch %}
     </div>
-    {% endif %}
 
     <div class="film-hero">
         <div class="film-cover">


### PR DESCRIPTION
<!-- claude-session: c0717c9a-16b7-4690-af5a-437a07586132 -->

## Summary
Player section was hidden when SK Torrent source was not available, leaving 5,470 films without any video player. Přehraj.to auto-play needs the player element to exist. Now always visible.

## Test plan
- [ ] Visit /filmy-online/ukrajina-rok-valky/ — player visible, Přehraj.to results load and auto-play

🤖 Generated with [Claude Code](https://claude.com/claude-code)