### PR TITLE
feat: title parser for SK Torrent video strings (#416)

### DIFF
--- a/scripts/auto_import/test_title_parser.py
+++ b/scripts/auto_import/test_title_parser.py
@@ -1,0 +1,53 @@
+"""Smoke tests for title_parser. Run: python3 -m scripts.auto_import.test_title_parser"""
+
+from scripts.auto_import.title_parser import parse_sktorrent_title
+
+
+CASES = [
+    # (input, expected subset of fields to check)
+    ("Pomocnice / The Housemaid (2025)(CZ)",
+     {"cz_title": "Pomocnice", "en_title": "The Housemaid", "year": 2025,
+      "is_episode": False, "langs": ["CZ"]}),
+    ("Euforie / Euphoria / S03E01 / CZ",
+     {"cz_title": "Euforie", "en_title": "Euphoria", "season": 3, "episode": 1,
+      "is_episode": True, "langs": ["CZ"]}),
+    ("Hitler: Vzestup zla / Hitler: The Rise of Evil (2003)(720p)(CZ)  = CSFD 82%",
+     {"cz_title": "Hitler: Vzestup zla", "en_title": "Hitler: The Rise of Evil",
+      "year": 2003, "quality": "720p", "csfd_rating": 82}),
+    ("Ninjova nadvláda / Ninja III: The Domination (1984)(CZ)",
+     {"cz_title": "Ninjova nadvláda", "en_title": "Ninja III: The Domination",
+      "year": 1984, "is_episode": False}),
+    ("Mayové a jejich poslední velká města (2024)",
+     {"cz_title": "Mayové a jejich poslední velká města", "en_title": None,
+      "year": 2024, "is_episode": False}),
+    ("Skryté skvosty-Hrádek u Nechanic (S01E01)",
+     {"season": 1, "episode": 1, "is_episode": True}),
+    ("Teorie velkého třesku S01E01-17 2007 CZ dab 1080p",
+     {"season": 1, "episode": 1, "year": 2007, "quality": "1080p",
+      "is_episode": True, "langs": ["DUB_CZ"]}),
+    ("",
+     {"cz_title": None, "en_title": None, "is_episode": False}),
+]
+
+
+def main() -> int:
+    fail = 0
+    for raw, expected in CASES:
+        got = parse_sktorrent_title(raw).to_dict()
+        problems = []
+        for k, v in expected.items():
+            actual = got.get(k)
+            if actual != v:
+                problems.append(f"  {k}: expected {v!r}, got {actual!r}")
+        marker = "OK " if not problems else "FAIL"
+        print(f"[{marker}] {raw[:60]!r}")
+        if problems:
+            fail += 1
+            for p in problems:
+                print(p)
+    print(f"\n{len(CASES) - fail}/{len(CASES)} OK")
+    return 0 if fail == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/auto_import/title_parser.py
+++ b/scripts/auto_import/title_parser.py
@@ -1,0 +1,211 @@
+"""Parse SK Torrent video titles into structured data.
+
+SK Torrent titles follow a loose convention:
+    "<CZ_NAME> / <EN_NAME>[ / SxxExx][ (YEAR)][ (QUALITY)][ (LANG)][ = CSFD N%]"
+
+Examples:
+    "Pomocnice / The Housemaid (2025)(CZ)"
+        → {cz: "Pomocnice", en: "The Housemaid", year: 2025, langs: [CZ]}
+    "Euforie / Euphoria / S03E01 / CZ"
+        → {cz: "Euforie", en: "Euphoria", season: 3, episode: 1, langs: [CZ]}
+    "Hitler: Vzestup zla / Hitler: The Rise of Evil (2003)(720p)(CZ) = CSFD 82%"
+        → {cz: "...", en: "...", year: 2003, quality: "720p", langs: [CZ], csfd_rating: 82}
+    "Ninja Resurrection / Ninpuu kamui gaiden / OVA 1/2 / jap. s cz. tit"
+        → {cz: "Ninja Resurrection", en: "Ninpuu kamui gaiden", langs: [SUBS_CZ]}
+
+Parser is intentionally lenient: unknown fields stay None, no exception is
+raised on malformed input. Caller (TMDB resolver) is responsible for treating
+missing fields as a softer match signal.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, asdict
+from typing import Iterable
+
+
+# Episode marker like S03E01, s3e1, 03x01, 3x1
+_EPISODE_RE = re.compile(r"\bS(\d{1,2})E(\d{1,2})\b", re.IGNORECASE)
+_EPISODE_X_RE = re.compile(r"\b(\d{1,2})x(\d{1,2})\b")
+
+# Year in parentheses or anywhere as standalone 4-digit
+_YEAR_PAREN_RE = re.compile(r"\((19|20)\d{2}\)")
+_YEAR_BARE_RE = re.compile(r"\b(19|20)\d{2}\b")
+
+# Quality markers (in parens or bracketed)
+_QUALITY_RE = re.compile(r"\b(2160p|1080p|1080i|720p|480p|HD|UHD|4K)\b", re.IGNORECASE)
+
+# CSFD rating "= CSFD 82%" or "(CSFD 82%)"
+_CSFD_RE = re.compile(r"CSFD\s*(\d{1,3})\s*%", re.IGNORECASE)
+
+# Czech / Slovak language markers
+_DUB_RE = re.compile(
+    r"\b(cz[\s\-]?dab|cz[\s\-]?dabing|cz[\s\-]?dub|"
+    r"sk[\s\-]?dab|cze?s\.?\s*dab|"
+    r"český\s*dabing?|slovenský\s*dabing?)\b",
+    re.IGNORECASE,
+)
+_SUBS_RE = re.compile(
+    r"\b(cz[\s\-]?tit(?:ulky)?|cztit|sk[\s\-]?tit(?:ulky)?|"
+    r"czech\s*subs?|cz\s*subs?|cz\.?\s*tit\.?|s\s*cz\.?\s*tit\.?)\b",
+    re.IGNORECASE,
+)
+# "(CZ)" or " / CZ" suffix (uppercase, surrounded by separators)
+_LANG_TAG_RE = re.compile(r"(?:^|[\(\[/])\s*(CZ|SK|EN|CZE)\s*(?:[\)\]/]|$)", re.IGNORECASE)
+
+# Strip noise like (1080p), [TvRip], (CZ Dabing)
+_STRIP_PARENS_RE = re.compile(r"\s*[\(\[][^\)\]]*[\)\]]")
+
+
+@dataclass
+class ParsedTitle:
+    cz_title: str | None = None
+    en_title: str | None = None
+    year: int | None = None
+    season: int | None = None
+    episode: int | None = None
+    quality: str | None = None       # "1080p", "720p", "480p"
+    langs: list[str] = None          # subset of ["DUB_CZ","DUB_SK","SUBS_CZ","SUBS_SK","CZ"]
+    csfd_rating: int | None = None
+    is_episode: bool = False         # True if SxxExx detected
+    raw: str = ""                    # original input
+
+    def __post_init__(self):
+        if self.langs is None:
+            self.langs = []
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def _detect_episode(title: str) -> tuple[int | None, int | None]:
+    """Return (season, episode) if title contains SxxExx or NxM marker."""
+    m = _EPISODE_RE.search(title)
+    if m:
+        return int(m.group(1)), int(m.group(2))
+    m = _EPISODE_X_RE.search(title)
+    if m:
+        return int(m.group(1)), int(m.group(2))
+    return None, None
+
+
+def _detect_year(title: str) -> int | None:
+    """Year in parentheses wins over a bare 4-digit year (less ambiguous)."""
+    m = _YEAR_PAREN_RE.search(title)
+    if m:
+        return int(m.group(0)[1:5])
+    # Bare year — pick the LAST one (titles like "Top Gun 2 2022" should give 2022)
+    matches = list(_YEAR_BARE_RE.finditer(title))
+    if matches:
+        return int(matches[-1].group(0))
+    return None
+
+
+def _detect_quality(title: str) -> str | None:
+    m = _QUALITY_RE.search(title)
+    if not m:
+        return None
+    raw = m.group(1).lower()
+    # Normalize "HD"/"4K"/"UHD" to a resolution number where possible
+    if raw == "uhd" or raw == "4k":
+        return "2160p"
+    if raw == "hd":
+        return "720p"  # SK Torrent's "HD" badge means ≥ 720p; conservative default
+    return raw
+
+
+def _detect_csfd(title: str) -> int | None:
+    m = _CSFD_RE.search(title)
+    return int(m.group(1)) if m else None
+
+
+def _detect_langs(title: str) -> list[str]:
+    """Best-effort language flags. Order: dubs first, then subs."""
+    flags = []
+    if re.search(r"\b(cz[\s\-]?dab|český\s*dabing?|cze?s\.?\s*dab|cz[\s\-]?dub)\b",
+                 title, re.IGNORECASE):
+        flags.append("DUB_CZ")
+    if re.search(r"\b(sk[\s\-]?dab|slovenský\s*dabing?)\b", title, re.IGNORECASE):
+        flags.append("DUB_SK")
+    if _SUBS_RE.search(title):
+        # Determine CZ vs SK subs
+        if re.search(r"\bsk[\s\-]?tit", title, re.IGNORECASE):
+            flags.append("SUBS_SK")
+        else:
+            flags.append("SUBS_CZ")
+    if not flags:
+        # Fallback to bare CZ/SK tag (e.g. "Euphoria / S03E01 / CZ" → CZ context only)
+        m = _LANG_TAG_RE.search(title)
+        if m:
+            flags.append(m.group(1).upper())
+    return flags
+
+
+def _split_titles(title: str, season: int | None, episode: int | None) -> tuple[str | None, str | None]:
+    """Split the title on `/` separators and return (cz, en).
+
+    Heuristic:
+      1. Drop trailing segments that are obviously NOT titles:
+         year-only, language-only, episode-only (S##E##), quality-only.
+      2. The first remaining segment = cz_title, second = en_title (if any).
+    """
+    parts = [p.strip() for p in title.split("/")]
+    parts = [p for p in parts if p]
+
+    def is_noise(s: str) -> bool:
+        s_clean = s.strip()
+        # Strip parens content first
+        s_naked = _STRIP_PARENS_RE.sub("", s_clean).strip()
+        if not s_naked:
+            return True
+        # Episode-only segment
+        if _EPISODE_RE.fullmatch(s_naked) or _EPISODE_X_RE.fullmatch(s_naked):
+            return True
+        # Year-only
+        if _YEAR_BARE_RE.fullmatch(s_naked):
+            return True
+        # Language tag only
+        if re.fullmatch(r"(CZ|SK|EN|cz\s*dabing?|sk\s*dabing?|cz\s*tit(?:ulky)?|"
+                        r"jap\.?\s*s\s*cz\.?\s*tit\.?)", s_naked, re.IGNORECASE):
+            return True
+        # Quality only
+        if _QUALITY_RE.fullmatch(s_naked):
+            return True
+        return False
+
+    title_parts = [p for p in parts if not is_noise(p)]
+
+    def clean(p: str) -> str:
+        # Strip trailing parens/brackets (year, quality, lang annotations)
+        s = _STRIP_PARENS_RE.sub("", p).strip()
+        # Strip trailing CSFD rating
+        s = _CSFD_RE.sub("", s).strip()
+        # Strip dangling = signs / dashes / dots
+        s = re.sub(r"\s*[=\-•·.]+\s*$", "", s).strip()
+        return s
+
+    cz = clean(title_parts[0]) if len(title_parts) >= 1 else None
+    en = clean(title_parts[1]) if len(title_parts) >= 2 else None
+    return cz or None, en or None
+
+
+def parse_sktorrent_title(title: str) -> ParsedTitle:
+    """Parse a SK Torrent title string. Never raises."""
+    if not title:
+        return ParsedTitle(raw="")
+    raw = title.strip()
+    season, episode = _detect_episode(raw)
+    cz, en = _split_titles(raw, season, episode)
+    return ParsedTitle(
+        cz_title=cz,
+        en_title=en,
+        year=_detect_year(raw),
+        season=season,
+        episode=episode,
+        quality=_detect_quality(raw),
+        langs=_detect_langs(raw),
+        csfd_rating=_detect_csfd(raw),
+        is_episode=season is not None and episode is not None,
+        raw=raw,
+    )

--- a/scripts/auto_import/title_parser.py
+++ b/scripts/auto_import/title_parser.py
@@ -21,8 +21,7 @@ missing fields as a softer match signal.
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass, asdict
-from typing import Iterable
+from dataclasses import dataclass, asdict, field
 
 
 # Episode marker like S03E01, s3e1, 03x01, 3x1
@@ -39,11 +38,14 @@ _QUALITY_RE = re.compile(r"\b(2160p|1080p|1080i|720p|480p|HD|UHD|4K)\b", re.IGNO
 # CSFD rating "= CSFD 82%" or "(CSFD 82%)"
 _CSFD_RE = re.compile(r"CSFD\s*(\d{1,3})\s*%", re.IGNORECASE)
 
-# Czech / Slovak language markers
-_DUB_RE = re.compile(
+# Czech / Slovak dub markers (used by _detect_langs)
+_DUB_CZ_RE = re.compile(
     r"\b(cz[\s\-]?dab|cz[\s\-]?dabing|cz[\s\-]?dub|"
-    r"sk[\s\-]?dab|cze?s\.?\s*dab|"
-    r"český\s*dabing?|slovenský\s*dabing?)\b",
+    r"cze?s\.?\s*dab|český\s*dabing?)\b",
+    re.IGNORECASE,
+)
+_DUB_SK_RE = re.compile(
+    r"\b(sk[\s\-]?dab|slovenský\s*dabing?)\b",
     re.IGNORECASE,
 )
 _SUBS_RE = re.compile(
@@ -51,7 +53,9 @@ _SUBS_RE = re.compile(
     r"czech\s*subs?|cz\s*subs?|cz\.?\s*tit\.?|s\s*cz\.?\s*tit\.?)\b",
     re.IGNORECASE,
 )
-# "(CZ)" or " / CZ" suffix (uppercase, surrounded by separators)
+_SUBS_SK_RE = re.compile(r"\bsk[\s\-]?tit", re.IGNORECASE)
+# "(CZ)" or " / CZ" suffix (uppercase, surrounded by separators).
+# CZE is normalized to CZ; EN is allowed as a documented value.
 _LANG_TAG_RE = re.compile(r"(?:^|[\(\[/])\s*(CZ|SK|EN|CZE)\s*(?:[\)\]/]|$)", re.IGNORECASE)
 
 # Strip noise like (1080p), [TvRip], (CZ Dabing)
@@ -66,14 +70,12 @@ class ParsedTitle:
     season: int | None = None
     episode: int | None = None
     quality: str | None = None       # "1080p", "720p", "480p"
-    langs: list[str] = None          # subset of ["DUB_CZ","DUB_SK","SUBS_CZ","SUBS_SK","CZ"]
+    # Subset of ["DUB_CZ","DUB_SK","SUBS_CZ","SUBS_SK","CZ","SK","EN"].
+    # CZE in source titles is normalized to "CZ".
+    langs: list[str] = field(default_factory=list)
     csfd_rating: int | None = None
     is_episode: bool = False         # True if SxxExx detected
     raw: str = ""                    # original input
-
-    def __post_init__(self):
-        if self.langs is None:
-            self.langs = []
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -123,26 +125,24 @@ def _detect_csfd(title: str) -> int | None:
 def _detect_langs(title: str) -> list[str]:
     """Best-effort language flags. Order: dubs first, then subs."""
     flags = []
-    if re.search(r"\b(cz[\s\-]?dab|český\s*dabing?|cze?s\.?\s*dab|cz[\s\-]?dub)\b",
-                 title, re.IGNORECASE):
+    if _DUB_CZ_RE.search(title):
         flags.append("DUB_CZ")
-    if re.search(r"\b(sk[\s\-]?dab|slovenský\s*dabing?)\b", title, re.IGNORECASE):
+    if _DUB_SK_RE.search(title):
         flags.append("DUB_SK")
     if _SUBS_RE.search(title):
-        # Determine CZ vs SK subs
-        if re.search(r"\bsk[\s\-]?tit", title, re.IGNORECASE):
-            flags.append("SUBS_SK")
-        else:
-            flags.append("SUBS_CZ")
+        flags.append("SUBS_SK" if _SUBS_SK_RE.search(title) else "SUBS_CZ")
     if not flags:
-        # Fallback to bare CZ/SK tag (e.g. "Euphoria / S03E01 / CZ" → CZ context only)
+        # Fallback to bare CZ/SK/EN tag (e.g. "Euphoria / S03E01 / CZ" — bare CZ context only)
         m = _LANG_TAG_RE.search(title)
         if m:
-            flags.append(m.group(1).upper())
+            tag = m.group(1).upper()
+            if tag == "CZE":
+                tag = "CZ"  # normalize ISO-639-2 form
+            flags.append(tag)
     return flags
 
 
-def _split_titles(title: str, season: int | None, episode: int | None) -> tuple[str | None, str | None]:
+def _split_titles(title: str) -> tuple[str | None, str | None]:
     """Split the title on `/` separators and return (cz, en).
 
     Heuristic:
@@ -162,8 +162,9 @@ def _split_titles(title: str, season: int | None, episode: int | None) -> tuple[
         # Episode-only segment
         if _EPISODE_RE.fullmatch(s_naked) or _EPISODE_X_RE.fullmatch(s_naked):
             return True
-        # Year-only
-        if _YEAR_BARE_RE.fullmatch(s_naked):
+        # Year-only — but preserve a sole segment so legitimate 4-digit
+        # titles like "1917 (2019)(CZ)" aren't discarded entirely.
+        if _YEAR_BARE_RE.fullmatch(s_naked) and len(parts) > 1:
             return True
         # Language tag only
         if re.fullmatch(r"(CZ|SK|EN|cz\s*dabing?|sk\s*dabing?|cz\s*tit(?:ulky)?|"
@@ -191,12 +192,16 @@ def _split_titles(title: str, season: int | None, episode: int | None) -> tuple[
 
 
 def parse_sktorrent_title(title: str) -> ParsedTitle:
-    """Parse a SK Torrent title string. Never raises."""
+    """Parse a SK Torrent title string. Never raises.
+
+    Returns the structured ParsedTitle dataclass; callers that prefer a plain
+    dict can use `parse_sktorrent_title(...).to_dict()`.
+    """
     if not title:
         return ParsedTitle(raw="")
     raw = title.strip()
     season, episode = _detect_episode(raw)
-    cz, en = _split_titles(raw, season, episode)
+    cz, en = _split_titles(raw)
     return ParsedTitle(
         cz_title=cz,
         en_title=en,


### PR DESCRIPTION
<!-- claude-session: c0717c9a-16b7-4690-af5a-437a07586132 -->

Closes #416 (part of #413).

## Summary
Pure-Python parser for SK Torrent's loose title convention. Returns ParsedTitle dataclass with cz/en/year/season/episode/quality/langs/csfd_rating.

## Test plan
- [x] 8/8 unit smoke tests pass (films, series episodes, complex titles, empty input)
- [x] Live samples cover: simple film, series with SxxExx, films with quality + CSFD rating, films with no English title, episode-only suffix in parens