### PR TITLE
feat: film enricher orchestrator (#419)

### DIFF
--- a/scripts/auto_import/cover_downloader.py
+++ b/scripts/auto_import/cover_downloader.py
@@ -1,0 +1,86 @@
+"""Download a TMDB poster, convert to WebP at our two display sizes.
+
+Output: `data/movies/covers-webp/{slug}.webp` (200×300) and
+`{slug}-large.webp` (780×1170 portrait, used by film_detail page).
+
+Pure HTTP + Pillow. No DB. Idempotent — skips if both files already exist.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import requests
+
+try:
+    from PIL import Image
+except ImportError:  # pragma: no cover
+    Image = None
+
+TMDB_IMG_BASE = "https://image.tmdb.org/t/p"
+DEFAULT_TIMEOUT = 30
+
+log = logging.getLogger(__name__)
+
+
+def download_cover(
+    poster_path: str,
+    slug: str,
+    out_dir: Path,
+    *,
+    overwrite: bool = False,
+) -> tuple[Path, Path] | None:
+    """Download TMDB poster, save as `{slug}.webp` (200×300) and `{slug}-large.webp` (780×1170).
+
+    Args:
+        poster_path: TMDB path like "/abc.jpg"
+        slug: target filename stem (without extension)
+        out_dir: directory to write into (created if missing)
+        overwrite: re-download even if files already exist
+
+    Returns:
+        (small_path, large_path) on success, None on failure.
+    """
+    if Image is None:
+        log.error("Pillow not installed — cannot convert covers")
+        return None
+    if not poster_path:
+        return None
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    small_path = out_dir / f"{slug}.webp"
+    large_path = out_dir / f"{slug}-large.webp"
+    if not overwrite and small_path.exists() and large_path.exists():
+        log.debug("cover %s already exists — skip", slug)
+        return small_path, large_path
+
+    # Fetch w780 from TMDB (best quality available without going to original)
+    url = f"{TMDB_IMG_BASE}/w780{poster_path}"
+    try:
+        r = requests.get(url, timeout=DEFAULT_TIMEOUT, stream=True)
+    except requests.RequestException as e:
+        log.warning("cover fetch failed for %s: %s", slug, e)
+        return None
+    if r.status_code != 200:
+        log.warning("cover fetch HTTP %d for %s", r.status_code, slug)
+        return None
+
+    try:
+        img = Image.open(r.raw).convert("RGB")
+    except Exception as e:
+        log.warning("cover decode failed for %s: %s", slug, e)
+        return None
+
+    # Large: 780×1170 (preserve aspect — TMDB poster is 2:3)
+    large = img.copy()
+    large.thumbnail((780, 1170), Image.LANCZOS)
+    large.save(large_path, "WEBP", quality=85, method=6)
+
+    # Small: 200×300
+    small = img.copy()
+    small.thumbnail((200, 300), Image.LANCZOS)
+    small.save(small_path, "WEBP", quality=85, method=6)
+
+    log.info("cover saved %s + -large", slug)
+    return small_path, large_path

--- a/scripts/auto_import/enricher.py
+++ b/scripts/auto_import/enricher.py
@@ -1,0 +1,191 @@
+"""Decide and execute the right DB action for each scanned video.
+
+upsert_film orchestrates Path A (existing film, just attach SK Torrent) vs
+Path B (brand-new film, full INSERT with cover + Gemma + genres). Returns the
+action label and target film_id for logging into import_items.
+
+Series + episode handling lives in series_enricher (sub-issue #420) — kept
+separate because the batching logic for new series + multiple episodes is
+non-trivial.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import unicodedata
+from pathlib import Path
+
+import psycopg2
+
+from scripts.auto_import.cover_downloader import download_cover
+from scripts.auto_import.gemma_writer import generate_unique_cs
+from scripts.auto_import.tmdb_resolver import MovieResolution
+
+log = logging.getLogger(__name__)
+
+# TMDB genre id → our genres.slug. Mirror of GENRE_MAP in populate-films.py
+# but using TMDB's numeric IDs (which is what /movie/{id} returns).
+TMDB_MOVIE_GENRE_MAP: dict[int, str | None] = {
+    28:    "akcni",         # Action
+    12:    "dobrodruzny",   # Adventure
+    16:    "animovany",     # Animation
+    35:    "komedie",       # Comedy
+    80:    "krimi",         # Crime
+    99:    "dokumentarni",  # Documentary
+    18:    "drama",         # Drama
+    10751: "rodinny",       # Family
+    14:    "fantasy",       # Fantasy
+    36:    "historicky",    # History
+    27:    "horor",         # Horror
+    10402: "hudebni",       # Music
+    9648:  "mysteriozni",   # Mystery
+    10749: "romanticky",    # Romance
+    878:   "sci-fi",        # Science Fiction
+    10770: None,            # TV Movie — skip
+    53:    "thriller",      # Thriller
+    10752: "valecny",       # War
+    37:    "western",       # Western
+}
+
+
+def _slugify(text: str) -> str:
+    """Czech-aware slug generator (mirror of slug_from_title in populate-films.py)."""
+    if not text:
+        return ""
+    s = unicodedata.normalize("NFKD", text)
+    s = s.encode("ascii", "ignore").decode("ascii")
+    s = s.lower()
+    s = re.sub(r"[^a-z0-9]+", "-", s)
+    return s.strip("-")
+
+
+def _unique_slug(cur, base: str, year: int | None) -> str:
+    """Find a free slug — first try base, then base-{year}, then base-2, base-3..."""
+    if not base:
+        base = "film"
+    cur.execute("SELECT 1 FROM films WHERE slug = %s", (base,))
+    if not cur.fetchone():
+        return base
+    if year:
+        candidate = f"{base}-{year}"
+        cur.execute("SELECT 1 FROM films WHERE slug = %s", (candidate,))
+        if not cur.fetchone():
+            return candidate
+    counter = 2
+    while True:
+        candidate = f"{base}-{counter}"
+        cur.execute("SELECT 1 FROM films WHERE slug = %s", (candidate,))
+        if not cur.fetchone():
+            return candidate
+        counter += 1
+
+
+def _genre_id_lookup(cur) -> dict[str, int]:
+    cur.execute("SELECT slug, id FROM genres")
+    return dict(cur.fetchall())
+
+
+def upsert_film(
+    conn: psycopg2.extensions.connection,
+    *,
+    sktorrent_video_id: int,
+    sktorrent_cdn: int | None,
+    sktorrent_qualities: list[str],
+    movie: MovieResolution,
+    cover_dir: Path,
+) -> tuple[str, int | None]:
+    """Decide between updated_film / added_film / skipped and execute it.
+
+    Args:
+        conn: psycopg2 connection (caller manages commit/rollback)
+        sktorrent_video_id: SK Torrent video id we're attaching
+        sktorrent_cdn: 1-9 (online{N})
+        sktorrent_qualities: ["720p", "480p", ...]
+        movie: TMDB resolution (must have imdb_id)
+        cover_dir: where to save webp covers (e.g. data/movies/covers-webp)
+
+    Returns:
+        (action, film_id) — action is one of "updated_film", "added_film", "skipped"
+    """
+    if not movie.imdb_id:
+        log.warning("upsert_film: TMDB resolution missing imdb_id (tmdb=%d)", movie.tmdb_id)
+        return "skipped", None
+
+    cur = conn.cursor()
+    qualities_str = ",".join(sktorrent_qualities) if sktorrent_qualities else None
+
+    # --- Path A: film already in DB? ---
+    cur.execute(
+        "SELECT id, sktorrent_video_id FROM films WHERE imdb_id = %s",
+        (movie.imdb_id,),
+    )
+    row = cur.fetchone()
+    if row is not None:
+        film_id, existing_skt = row
+        if existing_skt is not None:
+            log.info("film %d (imdb=%s) already has SKT %d — skipping",
+                     film_id, movie.imdb_id, existing_skt)
+            return "skipped", film_id
+        cur.execute(
+            "UPDATE films SET sktorrent_video_id = %s, sktorrent_cdn = %s, "
+            "sktorrent_qualities = %s WHERE id = %s",
+            (sktorrent_video_id, sktorrent_cdn, qualities_str, film_id),
+        )
+        log.info("upserted SKT into existing film %d (imdb=%s)", film_id, movie.imdb_id)
+        return "updated_film", film_id
+
+    # --- Path B: brand new film ---
+    title_cs = movie.title_cs or movie.title_en or movie.original_title or "Film"
+    title_en = movie.title_en
+    base_slug = _slugify(title_cs)
+    slug = _unique_slug(cur, base_slug, movie.year)
+
+    # Cover (best-effort)
+    cover_filename: str | None = None
+    if movie.poster_path:
+        result = download_cover(movie.poster_path, slug, cover_dir)
+        if result is not None:
+            cover_filename = slug
+
+    # Gemma 4 unique CS text
+    sources = []
+    if movie.overview_cs:
+        sources.append(("TMDB CS", movie.overview_cs))
+    if movie.overview_en:
+        sources.append(("TMDB EN", movie.overview_en))
+    generated = generate_unique_cs(title_cs, movie.year, sources, is_series=False)
+    description = generated or movie.overview_cs or movie.overview_en
+
+    cur.execute(
+        """INSERT INTO films
+           (title, original_title, slug, year, description, generated_description,
+            imdb_id, tmdb_id, runtime_min, cover_filename,
+            sktorrent_video_id, sktorrent_cdn, sktorrent_qualities,
+            added_at)
+           VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, now())
+           RETURNING id""",
+        (
+            title_cs, title_en if title_en != title_cs else None, slug, movie.year,
+            description, generated,
+            movie.imdb_id, movie.tmdb_id, movie.runtime_min, cover_filename,
+            sktorrent_video_id, sktorrent_cdn, qualities_str,
+        ),
+    )
+    film_id = cur.fetchone()[0]
+
+    # Genre links
+    if movie.genre_ids:
+        slug_to_id = _genre_id_lookup(cur)
+        for tmdb_gid in movie.genre_ids:
+            slug = TMDB_MOVIE_GENRE_MAP.get(tmdb_gid)
+            if not slug or slug not in slug_to_id:
+                continue
+            cur.execute(
+                "INSERT INTO film_genres (film_id, genre_id) "
+                "VALUES (%s, %s) ON CONFLICT DO NOTHING",
+                (film_id, slug_to_id[slug]),
+            )
+
+    log.info("added film %d (imdb=%s, slug=%s)", film_id, movie.imdb_id, slug)
+    return "added_film", film_id

--- a/scripts/auto_import/gemma_writer.py
+++ b/scripts/auto_import/gemma_writer.py
@@ -1,0 +1,134 @@
+"""Thin wrapper around Gemma 4 (Gemini API) for unique CS description generation.
+
+Reuses the prompt template and call logic from `generate-film-descriptions.py`
+but exposes a single `generate_unique_cs(...)` function suitable for the
+auto-import pipeline. Handles safety-filter refusals gracefully by returning
+None — caller falls back to TMDB CS overview as-is.
+
+Env vars (priority order):
+    GEMINI_API_KEY      — single key (preferred for production cron)
+    GEMINI_API_KEY_1..4 — parallel dev keys (reused if GEMINI_API_KEY missing)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+
+import requests
+
+MODEL = "gemma-3-27b-it"
+URL_TPL = f"https://generativelanguage.googleapis.com/v1beta/models/{MODEL}:generateContent?key={{}}"
+DEFAULT_TIMEOUT = 120
+RATE_LIMIT_PAUSE = 60
+
+log = logging.getLogger(__name__)
+
+
+def _load_keys() -> list[str]:
+    single = os.environ.get("GEMINI_API_KEY", "").strip()
+    if single:
+        return [single]
+    out = []
+    for i in range(1, 5):
+        k = os.environ.get(f"GEMINI_API_KEY_{i}", "").strip()
+        if k:
+            out.append(k)
+    return out
+
+
+def _build_prompt_film(title: str, year: int | None, sources: list[tuple[str, str]]) -> str:
+    parts = [f"Tady jsou popisy filmu {title} ({year or '?'}) z různých zdrojů:\n"]
+    for i, (name, text) in enumerate(sources, 1):
+        parts.append(f"Zdroj {i} ({name}):\n{text}\n")
+    parts.append(
+        "Na základě výše uvedených popisů napiš JEDEN krátký originální český "
+        "popis tohoto filmu.\nPožadavky: 3-6 vět, 150-400 znaků, poutavý styl, "
+        "vlastní formulace (ne kopie ze zdrojů).\nPiš přímo o ději a postavách. "
+        "Nekomentuj zadání, nepiš odrážky, nepiš nadpis.\nPiš POUZE česky — i "
+        "když jsou zdroje anglicky, výstup musí být v plynulé češtině.\n"
+        "Odpověz pouze samotným textem popisu:"
+    )
+    return "\n".join(parts)
+
+
+def _build_prompt_series(title: str, year: int | None, sources: list[tuple[str, str]]) -> str:
+    parts = [f"Tady jsou popisy seriálu {title} ({year or '?'}) z různých zdrojů "
+             "(některé česky, některé anglicky):\n"]
+    for i, (name, text) in enumerate(sources, 1):
+        parts.append(f"Zdroj {i} ({name}):\n{text}\n")
+    parts.append(
+        "Na základě výše uvedených popisů napiš JEDEN originální český popis "
+        "tohoto seriálu.\nPožadavky: 4-7 vět, 300-600 znaků, poutavý styl, "
+        "vlastní formulace.\nPiš o příběhu, hlavních postavách a atmosféře "
+        "seriálu. Výstup musí být POUZE česky.\nNekomentuj zadání, nepiš "
+        "odrážky, nepiš nadpis. Odpověz pouze samotným textem popisu:"
+    )
+    return "\n".join(parts)
+
+
+def _call(prompt: str, key: str, timeout: int = DEFAULT_TIMEOUT) -> str | None:
+    """Single Gemini call. Returns generated text or None on safety-filter / error."""
+    payload = {
+        "contents": [{"role": "user", "parts": [{"text": prompt}]}],
+        "generationConfig": {"temperature": 0.7, "maxOutputTokens": 1000},
+    }
+    try:
+        r = requests.post(URL_TPL.format(key), json=payload, timeout=timeout)
+    except requests.RequestException as e:
+        log.warning("Gemini call failed: %s", e)
+        return None
+    if r.status_code == 429:
+        log.warning("Gemini rate-limited; sleeping %ds", RATE_LIMIT_PAUSE)
+        time.sleep(RATE_LIMIT_PAUSE)
+        return None
+    if r.status_code != 200:
+        log.warning("Gemini HTTP %d: %s", r.status_code, r.text[:200])
+        return None
+    try:
+        data = r.json()
+    except ValueError:
+        return None
+    cands = data.get("candidates") or []
+    if not cands:
+        # Most common reason: safety filter blocked the response
+        log.info("Gemini returned no candidates (safety filter?)")
+        return None
+    parts = cands[0].get("content", {}).get("parts") or []
+    if not parts:
+        return None
+    text = (parts[0].get("text") or "").strip()
+    if text.startswith('"') and text.endswith('"'):
+        text = text[1:-1]
+    return text or None
+
+
+def generate_unique_cs(
+    title: str,
+    year: int | None,
+    sources: list[tuple[str, str]],
+    *,
+    is_series: bool = False,
+) -> str | None:
+    """Generate a unique Czech description from one or more source texts.
+
+    Args:
+        title: film/series name (used in the prompt for context)
+        year: optional year
+        sources: list of (source_name, text) tuples — at least 1 required
+        is_series: True for TV series, picks longer-text prompt template
+
+    Returns:
+        Generated CS text, or None if generation failed (safety filter,
+        rate limit, network error, missing API key, no source texts).
+    """
+    if not sources:
+        return None
+    keys = _load_keys()
+    if not keys:
+        log.warning("No GEMINI_API_KEY env var set — Gemma generation disabled")
+        return None
+    builder = _build_prompt_series if is_series else _build_prompt_film
+    prompt = builder(title, year, sources)
+    return _call(prompt, keys[0])


### PR DESCRIPTION
<!-- claude-session: c0717c9a-16b7-4690-af5a-437a07586132 -->

Closes #419 (part of #413).

## Summary
Three modules for the film side of auto-import:

- **gemma_writer.py** — Gemma 4 wrapper, single `GEMINI_API_KEY` for prod (or `_1..4` fallback for dev). Returns None on safety-filter/rate-limit so caller falls back gracefully.
- **cover_downloader.py** — TMDB poster → WebP small (200×300) + large (780×1170) via Pillow. Idempotent.
- **enricher.py** — `upsert_film(...)` decides between updated_film / added_film / skipped, returning (action, film_id) for logging.

## Path A vs Path B
- **A**: film with same imdb_id exists. If no SKT yet → UPDATE; otherwise skip.
- **B**: new film. Generate slug, download cover, Gemma generate unique CS text, INSERT + film_genres.

## Test plan
- Depends on #414 (tables) + #418 (TMDB resolver) being merged for end-to-end test
- Standalone logic verifiable: TMDB genre map, slug generator, Path A/B branching
- Live integration test once stack lands: feed parsed Pomocnice 2025 → MovieResolution → enricher creates film