### PR TITLE
fix: restore Filmy/Seriály online links on homepage

### DIFF
--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -22,6 +22,13 @@ struct FilmRow {
     sktorrent_cdn: Option<i16>,
     #[allow(dead_code)]
     sktorrent_qualities: Option<String>,
+    #[allow(dead_code)]
+    added_at: Option<chrono::DateTime<chrono::Utc>>,
+    prehrajto_url: Option<String>,
+    #[allow(dead_code)]
+    prehrajto_has_dub: bool,
+    #[allow(dead_code)]
+    prehrajto_has_subs: bool,
 }
 
 #[derive(sqlx::FromRow)]
@@ -58,11 +65,43 @@ struct CountRow {
 pub struct FilmsQuery {
     strana: Option<i64>,
     razeni: Option<String>, // "rok", "imdb", "csfd", "nazev"
-    #[allow(dead_code)]
-    zanry: Option<String>, // comma-separated genre slugs to include (future)
-    #[allow(dead_code)]
-    bez: Option<String>, // comma-separated genre slugs to exclude (future)
+    zanry: Option<String>,  // comma-separated genre slugs to include
+    bez: Option<String>,    // comma-separated genre slugs to exclude
     q: Option<String>,      // search query
+    rok: Option<String>,    // year filter
+    rezim: Option<String>,  // "and" (all genres) or "or" (any genre)
+    smer: Option<String>,   // "asc" or "desc" (default)
+    jazyk: Option<String>,  // comma-separated: dub, sub
+}
+
+impl FilmsQuery {
+    fn genre_mode_and(&self) -> bool {
+        self.rezim.as_deref() == Some("and")
+    }
+
+    fn sort_desc(&self) -> bool {
+        self.smer.as_deref() != Some("asc")
+    }
+
+    fn audio_filter(&self) -> Option<&'static str> {
+        // Default: no jazyk param → filter to dubbed only
+        let val = self.jazyk.as_deref().map(|s| s.trim()).unwrap_or("dub");
+        if val == "vse" {
+            return None;
+        }
+        if val.is_empty() {
+            return Some("f.has_dub = true");
+        }
+        let parts: Vec<&str> = val.split(',').map(|s| s.trim()).collect();
+        let has_dub = parts.contains(&"dub") || parts.contains(&"cz") || parts.contains(&"sk");
+        let has_sub = parts.contains(&"sub") || parts.contains(&"titulky");
+        match (has_dub, has_sub) {
+            (true, false) => Some("f.has_dub = true"),
+            (false, true) => Some("f.has_subtitles = true"),
+            (true, true) => Some("(f.has_dub = true OR f.has_subtitles = true)"),
+            _ => None,
+        }
+    }
 }
 
 impl FilmsQuery {
@@ -70,17 +109,53 @@ impl FilmsQuery {
         self.strana.unwrap_or(1).max(1)
     }
 
-    fn order_clause(&self) -> &str {
-        match self.razeni.as_deref() {
-            Some("imdb") => "f.imdb_rating DESC NULLS LAST, f.title",
-            Some("csfd") => "f.csfd_rating DESC NULLS LAST, f.title",
-            Some("nazev") => "f.title, f.year DESC NULLS LAST",
-            _ => "f.year DESC NULLS LAST, f.title",
+    fn order_clause(&self) -> &'static str {
+        let desc = self.sort_desc();
+        match (self.razeni.as_deref(), desc) {
+            (Some("rok"), true) => "f.year DESC NULLS LAST, f.title",
+            (Some("rok"), false) => "f.year ASC NULLS LAST, f.title",
+            (Some("imdb"), true) => "f.imdb_rating DESC NULLS LAST, f.title",
+            (Some("imdb"), false) => "f.imdb_rating ASC NULLS LAST, f.title",
+            (Some("csfd"), true) => "f.csfd_rating DESC NULLS LAST, f.title",
+            (Some("csfd"), false) => "f.csfd_rating ASC NULLS LAST, f.title",
+            (Some("nazev"), true) => "f.title DESC, f.year DESC NULLS LAST",
+            (Some("nazev"), false) => "f.title ASC, f.year DESC NULLS LAST",
+            // Default: "pridano" (added_at) — most recently added first
+            (_, true) => "f.added_at DESC NULLS LAST, f.title",
+            (_, false) => "f.added_at ASC NULLS LAST, f.title",
         }
     }
 
     fn sort_key(&self) -> &str {
-        self.razeni.as_deref().unwrap_or("rok")
+        self.razeni.as_deref().unwrap_or("pridano")
+    }
+
+    fn include_genres(&self) -> Vec<String> {
+        self.zanry
+            .as_ref()
+            .map(|s| {
+                s.split(',')
+                    .map(|g| g.trim().to_string())
+                    .filter(|g| !g.is_empty())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    fn exclude_genres(&self) -> Vec<String> {
+        self.bez
+            .as_ref()
+            .map(|s| {
+                s.split(',')
+                    .map(|g| g.trim().to_string())
+                    .filter(|g| !g.is_empty())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    fn year_filter(&self) -> Option<i16> {
+        self.rok.as_ref().and_then(|s| s.trim().parse().ok())
     }
 }
 
@@ -98,6 +173,7 @@ struct FilmsListTemplate {
     current_genre: Option<GenreRow>,
     sort_key: String,
     query_string: String,
+    search_query: Option<String>,
 }
 
 #[derive(Template)]
@@ -151,57 +227,117 @@ pub async fn films_list(
         }
     });
 
-    let (total_count, films) = if let Some(ref pattern) = search_q {
-        let count_row = sqlx::query_as::<_, CountRow>(
-            "SELECT count(*) as count FROM films WHERE title ILIKE $1 OR original_title ILIKE $1",
-        )
-        .bind(pattern)
-        .fetch_one(&state.db)
+    let include = params.include_genres();
+    let exclude = params.exclude_genres();
+    let year_f = params.year_filter();
+
+    // Build dynamic WHERE parts
+    let mut where_parts: Vec<String> = vec![];
+    let mut bind_idx = 1;
+
+    let has_search = search_q.is_some();
+    if has_search {
+        where_parts.push(format!(
+            "(f.title ILIKE ${bind_idx} OR f.original_title ILIKE ${bind_idx})"
+        ));
+        bind_idx += 1;
+    }
+    if !include.is_empty() {
+        if params.genre_mode_and() {
+            // AND: film must have ALL selected genres
+            where_parts.push(format!(
+                "f.id IN (SELECT fg.film_id FROM film_genres fg \
+                 JOIN genres g ON g.id = fg.genre_id \
+                 WHERE g.slug = ANY(${bind_idx}) \
+                 GROUP BY fg.film_id HAVING COUNT(DISTINCT g.slug) = {})",
+                include.len()
+            ));
+        } else {
+            // OR (default): film must have ANY selected genre
+            where_parts.push(format!(
+                "f.id IN (SELECT fg.film_id FROM film_genres fg \
+                 JOIN genres g ON g.id = fg.genre_id \
+                 WHERE g.slug = ANY(${bind_idx}))"
+            ));
+        }
+        bind_idx += 1;
+    }
+    if !exclude.is_empty() {
+        where_parts.push(format!(
+            "f.id NOT IN (SELECT fg.film_id FROM film_genres fg \
+             JOIN genres g ON g.id = fg.genre_id \
+             WHERE g.slug = ANY(${bind_idx}))"
+        ));
+        bind_idx += 1;
+    }
+    if year_f.is_some() {
+        where_parts.push(format!("f.year = ${bind_idx}"));
+        bind_idx += 1;
+    }
+    if let Some(af) = params.audio_filter() {
+        where_parts.push(af.to_string());
+    }
+
+    let where_clause = if where_parts.is_empty() {
+        String::new()
+    } else {
+        format!("WHERE {}", where_parts.join(" AND "))
+    };
+
+    // Count query
+    let count_query = format!("SELECT count(*) as count FROM films f {where_clause}");
+    let mut cq = sqlx::query_as::<_, CountRow>(&count_query);
+    if let Some(ref p) = search_q {
+        cq = cq.bind(p.clone());
+    }
+    if !include.is_empty() {
+        cq = cq.bind(include.clone());
+    }
+    if !exclude.is_empty() {
+        cq = cq.bind(exclude.clone());
+    }
+    if let Some(yr) = year_f {
+        cq = cq.bind(yr);
+    }
+    let count_row = cq.fetch_one(&state.db).await?;
+
+    // Films query
+    let films_query = format!(
+        "SELECT f.id, f.title, f.slug, f.year, f.description, f.original_title, \
+         f.imdb_rating, f.csfd_rating, f.runtime_min, f.cover_filename, \
+         f.sktorrent_video_id, f.sktorrent_cdn, f.sktorrent_qualities, f.added_at, \
+         f.prehrajto_url, f.prehrajto_has_dub, f.prehrajto_has_subs \
+         FROM films f {where_clause} \
+         ORDER BY {order} \
+         LIMIT ${limit_idx} OFFSET ${offset_idx}",
+        limit_idx = bind_idx,
+        offset_idx = bind_idx + 1
+    );
+    let mut fq = sqlx::query_as::<_, FilmRow>(&films_query);
+    if let Some(ref p) = search_q {
+        fq = fq.bind(p.clone());
+    }
+    if !include.is_empty() {
+        fq = fq.bind(include.clone());
+    }
+    if !exclude.is_empty() {
+        fq = fq.bind(exclude.clone());
+    }
+    if let Some(yr) = year_f {
+        fq = fq.bind(yr);
+    }
+    let films = fq
+        .bind(FILMS_PER_PAGE)
+        .bind(offset)
+        .fetch_all(&state.db)
         .await?;
 
-        let query = format!(
-            "SELECT f.id, f.title, f.slug, f.year, f.description, f.original_title, \
-             f.imdb_rating, f.csfd_rating, f.runtime_min, f.cover_filename, \
-             f.sktorrent_video_id, f.sktorrent_cdn, f.sktorrent_qualities \
-             FROM films f \
-             WHERE f.title ILIKE $1 OR f.original_title ILIKE $1 \
-             ORDER BY {order} \
-             LIMIT $2 OFFSET $3"
-        );
-        let films = sqlx::query_as::<_, FilmRow>(&query)
-            .bind(pattern)
-            .bind(FILMS_PER_PAGE)
-            .bind(offset)
-            .fetch_all(&state.db)
-            .await?;
-
-        (count_row.count.unwrap_or(0), films)
-    } else {
-        let count_row = sqlx::query_as::<_, CountRow>("SELECT count(*) as count FROM films")
-            .fetch_one(&state.db)
-            .await?;
-
-        let query = format!(
-            "SELECT f.id, f.title, f.slug, f.year, f.description, f.original_title, \
-             f.imdb_rating, f.csfd_rating, f.runtime_min, f.cover_filename, \
-             f.sktorrent_video_id, f.sktorrent_cdn, f.sktorrent_qualities \
-             FROM films f \
-             ORDER BY {order} \
-             LIMIT $1 OFFSET $2"
-        );
-        let films = sqlx::query_as::<_, FilmRow>(&query)
-            .bind(FILMS_PER_PAGE)
-            .bind(offset)
-            .fetch_all(&state.db)
-            .await?;
-
-        (count_row.count.unwrap_or(0), films)
-    };
+    let (total_count, films) = (count_row.count.unwrap_or(0), films);
     let total_pages = (total_count as f64 / FILMS_PER_PAGE as f64).ceil() as i64;
 
     let genres = load_genres(&state.db).await?;
 
-    // Build query string for pagination links (preserve sort + search)
+    // Build query string for pagination links (preserve sort + filters)
     let mut qs_parts = Vec::new();
     if params.razeni.is_some() {
         qs_parts.push(format!("razeni={}", params.sort_key()));
@@ -212,11 +348,54 @@ pub async fn films_list(
             qs_parts.push(format!("q={}", urlencoding::encode(t)));
         }
     }
+    if let Some(ref z) = params.zanry
+        && !z.is_empty()
+    {
+        qs_parts.push(format!("zanry={}", urlencoding::encode(z)));
+    }
+    if let Some(ref m) = params.rezim
+        && m == "and"
+    {
+        qs_parts.push("rezim=and".to_string());
+    }
+    if let Some(ref s) = params.smer
+        && s == "asc"
+    {
+        qs_parts.push("smer=asc".to_string());
+    }
+    if let Some(ref j) = params.jazyk
+        && !j.is_empty()
+    {
+        // Preserve all explicit values including "vse" (default without param = "dub")
+        qs_parts.push(format!("jazyk={}", urlencoding::encode(j)));
+    }
+    if let Some(ref b) = params.bez
+        && !b.is_empty()
+    {
+        qs_parts.push(format!("bez={}", urlencoding::encode(b)));
+    }
+    if let Some(ref r) = params.rok
+        && !r.is_empty()
+    {
+        qs_parts.push(format!("rok={}", urlencoding::encode(r)));
+    }
     let query_string = if qs_parts.is_empty() {
         String::new()
     } else {
         format!("&{}", qs_parts.join("&"))
     };
+
+    let search_query = params
+        .q
+        .as_ref()
+        .and_then(|q| {
+            let t = q.trim();
+            if t.is_empty() {
+                None
+            } else {
+                Some(t.to_string())
+            }
+        });
 
     let tmpl = FilmsListTemplate {
         img: state.image_base_url.clone(),
@@ -228,6 +407,7 @@ pub async fn films_list(
         current_genre: None,
         sort_key: params.sort_key().to_string(),
         query_string,
+        search_query,
     };
     Ok(Html(tmpl.render()?).into_response())
 }
@@ -238,7 +418,10 @@ pub async fn films_detail(
     Path(slug): Path<String>,
     axum::extract::Query(params): axum::extract::Query<FilmsQuery>,
 ) -> WebResult<Response> {
-    // WebP cover request: /filmy-online/some-film.webp
+    // WebP cover request: /filmy-online/some-film.webp (small) or -large.webp
+    if slug.ends_with("-large.webp") {
+        return films_cover_large(State(state), Path(slug)).await;
+    }
     if slug.ends_with(".webp") {
         return films_cover(State(state), Path(slug)).await;
     }
@@ -258,7 +441,8 @@ pub async fn films_detail(
     let film = sqlx::query_as::<_, FilmRow>(
         "SELECT id, title, slug, year, description, original_title, \
          imdb_rating, csfd_rating, runtime_min, cover_filename, \
-         sktorrent_video_id, sktorrent_cdn, sktorrent_qualities \
+         sktorrent_video_id, sktorrent_cdn, sktorrent_qualities, added_at, \
+         prehrajto_url, prehrajto_has_dub, prehrajto_has_subs \
          FROM films WHERE slug = $1",
     )
     .bind(&slug)
@@ -306,30 +490,68 @@ async fn films_by_genre(
     let page = params.page();
     let offset = (page - 1) * FILMS_PER_PAGE;
     let order = params.order_clause();
+    let exclude = params.exclude_genres();
+    let year_f = params.year_filter();
 
-    let count_row = sqlx::query_as::<_, CountRow>(
-        "SELECT count(*) as count FROM films f \
+    // Build WHERE clauses for exclude genres and year
+    let mut where_parts: Vec<String> = vec!["fg.genre_id = $1".to_string()];
+    let mut bind_idx = 2;
+    if !exclude.is_empty() {
+        where_parts.push(format!(
+            "f.id NOT IN (SELECT fg2.film_id FROM film_genres fg2 \
+             JOIN genres g2 ON g2.id = fg2.genre_id \
+             WHERE g2.slug = ANY(${bind_idx}))"
+        ));
+        bind_idx += 1;
+    }
+    if year_f.is_some() {
+        where_parts.push(format!("f.year = ${bind_idx}"));
+        bind_idx += 1;
+    }
+    if let Some(af) = params.audio_filter() {
+        where_parts.push(af.to_string());
+    }
+    let where_clause = where_parts.join(" AND ");
+
+    // Count
+    let count_query = format!(
+        "SELECT count(DISTINCT f.id) as count FROM films f \
          JOIN film_genres fg ON f.id = fg.film_id \
-         WHERE fg.genre_id = $1",
-    )
-    .bind(genre.id)
-    .fetch_one(&state.db)
-    .await?;
+         WHERE {where_clause}"
+    );
+    let mut count_q = sqlx::query_as::<_, CountRow>(&count_query).bind(genre.id);
+    if !exclude.is_empty() {
+        count_q = count_q.bind(exclude.clone());
+    }
+    if let Some(yr) = year_f {
+        count_q = count_q.bind(yr);
+    }
+    let count_row = count_q.fetch_one(&state.db).await?;
     let total_count = count_row.count.unwrap_or(0);
     let total_pages = (total_count as f64 / FILMS_PER_PAGE as f64).ceil() as i64;
 
-    let query = format!(
-        "SELECT f.id, f.title, f.slug, f.year, f.description, f.original_title, \
+    // Films
+    let films_query = format!(
+        "SELECT DISTINCT f.id, f.title, f.slug, f.year, f.description, f.original_title, \
          f.imdb_rating, f.csfd_rating, f.runtime_min, f.cover_filename, \
-         f.sktorrent_video_id, f.sktorrent_cdn, f.sktorrent_qualities \
+         f.sktorrent_video_id, f.sktorrent_cdn, f.sktorrent_qualities, f.added_at, \
+         f.prehrajto_url, f.prehrajto_has_dub, f.prehrajto_has_subs \
          FROM films f \
          JOIN film_genres fg ON f.id = fg.film_id \
-         WHERE fg.genre_id = $1 \
+         WHERE {where_clause} \
          ORDER BY {order} \
-         LIMIT $2 OFFSET $3"
+         LIMIT ${limit_idx} OFFSET ${offset_idx}",
+        limit_idx = bind_idx,
+        offset_idx = bind_idx + 1
     );
-    let films = sqlx::query_as::<_, FilmRow>(&query)
-        .bind(genre.id)
+    let mut q = sqlx::query_as::<_, FilmRow>(&films_query).bind(genre.id);
+    if !exclude.is_empty() {
+        q = q.bind(exclude.clone());
+    }
+    if let Some(yr) = year_f {
+        q = q.bind(yr);
+    }
+    let films = q
         .bind(FILMS_PER_PAGE)
         .bind(offset)
         .fetch_all(&state.db)
@@ -340,6 +562,37 @@ async fn films_by_genre(
     let mut qs_parts = Vec::new();
     if params.razeni.is_some() {
         qs_parts.push(format!("razeni={}", params.sort_key()));
+    }
+    if let Some(ref s) = params.smer
+        && s == "asc"
+    {
+        qs_parts.push("smer=asc".to_string());
+    }
+    if let Some(ref j) = params.jazyk
+        && !j.is_empty()
+    {
+        // Preserve all explicit values including "vse" (default without param = "dub")
+        qs_parts.push(format!("jazyk={}", urlencoding::encode(j)));
+    }
+    if let Some(ref z) = params.zanry
+        && !z.is_empty()
+    {
+        qs_parts.push(format!("zanry={}", urlencoding::encode(z)));
+    }
+    if let Some(ref m) = params.rezim
+        && m == "and"
+    {
+        qs_parts.push("rezim=and".to_string());
+    }
+    if let Some(ref b) = params.bez
+        && !b.is_empty()
+    {
+        qs_parts.push(format!("bez={}", urlencoding::encode(b)));
+    }
+    if let Some(ref r) = params.rok
+        && !r.is_empty()
+    {
+        qs_parts.push(format!("rok={}", urlencoding::encode(r)));
     }
     let query_string = if qs_parts.is_empty() {
         String::new()
@@ -357,6 +610,7 @@ async fn films_by_genre(
         current_genre: Some(genre),
         sort_key: params.sort_key().to_string(),
         query_string,
+        search_query: None,
     };
     Ok(Html(tmpl.render()?).into_response())
 }
@@ -462,6 +716,113 @@ pub async fn films_cover(
         .into_response())
 }
 
+/// GET /filmy-online/{slug}-large.webp — serve large WebP cover (w780 from TMDB, cached)
+pub async fn films_cover_large(
+    State(state): State<AppState>,
+    Path(slug_webp): Path<String>,
+) -> WebResult<Response> {
+    let slug = slug_webp
+        .strip_suffix("-large.webp")
+        .unwrap_or(&slug_webp);
+
+    #[derive(sqlx::FromRow)]
+    struct CoverRow {
+        tmdb_id: Option<i32>,
+    }
+
+    let row = sqlx::query_as::<_, CoverRow>("SELECT tmdb_id FROM films WHERE slug = $1")
+        .bind(slug)
+        .fetch_optional(&state.db)
+        .await?;
+
+    let tmdb_id = row.and_then(|r| r.tmdb_id);
+    let covers_dir =
+        std::env::var("COVERS_DIR").unwrap_or_else(|_| "data/movies/covers-webp".to_string());
+
+    // Cache path: {covers_dir}/large/{slug}.webp
+    let cache_dir = std::path::Path::new(&covers_dir).join("large");
+    let cache_path = cache_dir.join(format!("{slug}.webp"));
+
+    // Serve from cache if exists
+    if cache_path.exists()
+        && let Ok(bytes) = tokio::fs::read(&cache_path).await
+    {
+        return Ok((
+            StatusCode::OK,
+            [
+                (header::CONTENT_TYPE, "image/webp"),
+                (header::CACHE_CONTROL, "public, max-age=31536000, immutable"),
+            ],
+            bytes,
+        )
+            .into_response());
+    }
+
+    // Fetch from TMDB
+    if let Some(tid) = tmdb_id {
+        // First get poster_path
+        let tmdb_key = "0405855b8275307d3cf3284470fd9d28";
+        let detail_url = format!(
+            "https://api.themoviedb.org/3/movie/{tid}?api_key={tmdb_key}&language=cs-CZ"
+        );
+
+        if let Ok(resp) = state
+            .http_client
+            .get(&detail_url)
+            .timeout(std::time::Duration::from_secs(10))
+            .send()
+            .await
+            && let Ok(data) = resp.json::<serde_json::Value>().await
+            && let Some(poster_path) = data.get("poster_path").and_then(|v| v.as_str())
+        {
+            // Download w780 poster
+            let poster_url = format!("https://image.tmdb.org/t/p/w780{poster_path}");
+            if let Ok(img_resp) = state
+                .http_client
+                .get(&poster_url)
+                .timeout(std::time::Duration::from_secs(15))
+                .send()
+                .await
+                && img_resp.status().is_success()
+                && let Ok(bytes) = img_resp.bytes().await
+            {
+                // Try to convert to WebP for smaller size
+                let output_bytes = if let Ok(img) = image::load_from_memory(&bytes) {
+                    let mut buf = Vec::new();
+                    let mut cursor = std::io::Cursor::new(&mut buf);
+                    if img
+                        .write_to(&mut cursor, image::ImageFormat::WebP)
+                        .is_ok()
+                    {
+                        buf
+                    } else {
+                        bytes.to_vec()
+                    }
+                } else {
+                    bytes.to_vec()
+                };
+
+                // Save to cache
+                let _ = tokio::fs::create_dir_all(&cache_dir).await;
+                let _ = tokio::fs::write(&cache_path, &output_bytes).await;
+
+                return Ok((
+                    StatusCode::OK,
+                    [
+                        (header::CONTENT_TYPE, "image/webp"),
+                        (header::CACHE_CONTROL, "public, max-age=31536000, immutable"),
+                    ],
+                    output_bytes,
+                )
+                    .into_response());
+            }
+        }
+    }
+
+    // Fallback to small cover
+    films_cover(State(state), Path(format!("{slug}.webp"))).await
+}
+
 // --- Sktorrent resolve API ---
 
 #[derive(Deserialize)]
@@ -564,7 +925,7 @@ pub async fn sktorrent_resolve(
     )
     .unwrap();
 
-    let sources: Vec<SktorrentSource> = re
+    let mut sources: Vec<SktorrentSource> = re
         .captures_iter(&html)
         .filter_map(|cap| {
             Some(SktorrentSource {
@@ -575,11 +936,16 @@ pub async fn sktorrent_resolve(
         })
         .collect();
 
+    // If page didn't return sources (geo-blocked), scan CDN servers with HEAD requests
+    if sources.is_empty() {
+        sources = scan_sktorrent_cdns(&state.http_client, video_id).await;
+    }
+
     if sources.is_empty() {
         return axum::Json(SktorrentResolveResponse {
             video_id,
             sources: vec![],
-            error: Some("No video sources found on sktorrent page".to_string()),
+            error: Some("No video sources found on sktorrent".to_string()),
             cached: false,
         });
     }
@@ -609,6 +975,71 @@ pub async fn sktorrent_resolve(
         error: None,
         cached: false,
     })
+}
+
+/// Scan sktorrent CDN servers (1..=30) with HEAD request to find working URL.
+/// Used as fallback when page is geo-blocked but CDN URLs work globally.
+async fn scan_sktorrent_cdns(
+    client: &reqwest::Client,
+    video_id: i32,
+) -> Vec<SktorrentSource> {
+    let qualities = [("720p", 720), ("480p", 480), ("HD", 700), ("SD", 360)];
+    let mut found: Vec<SktorrentSource> = vec![];
+
+    // Scan CDNs in parallel batches of 10
+    let cdns: Vec<i32> = (1..=30).collect();
+    for batch in cdns.chunks(10) {
+        let mut tasks = Vec::new();
+        for &cdn in batch {
+            for (q_label, q_res) in qualities.iter() {
+                let url = format!(
+                    "https://online{cdn}.sktorrent.eu/media/videos//h264/{video_id}_{q_label}.mp4"
+                );
+                let client = client.clone();
+                let q_label = q_label.to_string();
+                let q_res = *q_res;
+                let url_clone = url.clone();
+                tasks.push(tokio::spawn(async move {
+                    let ok = client
+                        .head(&url_clone)
+                        .timeout(std::time::Duration::from_secs(3))
+                        .send()
+                        .await
+                        .map(|r| r.status().is_success() || r.status().as_u16() == 206)
+                        .unwrap_or(false);
+                    (ok, url, q_label, q_res)
+                }));
+            }
+        }
+
+        let mut batch_results = Vec::new();
+        for t in tasks {
+            if let Ok((ok, url, q, res)) = t.await
+                && ok
+            {
+                batch_results.push(SktorrentSource {
+                    url,
+                    quality: q,
+                    res,
+                });
+            }
+        }
+
+        if !batch_results.is_empty() {
+            // Dedupe by quality
+            for src in batch_results {
+                if !found.iter().any(|s| s.quality == src.quality) {
+                    found.push(src);
+                }
+            }
+            // If we found both qualities, we're done
+            if found.len() >= 2 {
+                break;
+            }
+        }
+    }
+
+    found
 }
 
 // --- Helpers ---

--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -171,6 +171,7 @@ struct FilmsListTemplate {
     total_pages: i64,
     total_count: i64,
     current_genre: Option<GenreRow>,
+    #[allow(dead_code)]
     sort_key: String,
     query_string: String,
     search_query: Option<String>,
@@ -385,17 +386,14 @@ pub async fn films_list(
         format!("&{}", qs_parts.join("&"))
     };
 
-    let search_query = params
-        .q
-        .as_ref()
-        .and_then(|q| {
-            let t = q.trim();
-            if t.is_empty() {
-                None
-            } else {
-                Some(t.to_string())
-            }
-        });
+    let search_query = params.q.as_ref().and_then(|q| {
+        let t = q.trim();
+        if t.is_empty() {
+            None
+        } else {
+            Some(t.to_string())
+        }
+    });
 
     let tmpl = FilmsListTemplate {
         img: state.image_base_url.clone(),
@@ -721,9 +719,7 @@ pub async fn films_cover_large(
     State(state): State<AppState>,
     Path(slug_webp): Path<String>,
 ) -> WebResult<Response> {
-    let slug = slug_webp
-        .strip_suffix("-large.webp")
-        .unwrap_or(&slug_webp);
+    let slug = slug_webp.strip_suffix("-large.webp").unwrap_or(&slug_webp);
 
     #[derive(sqlx::FromRow)]
     struct CoverRow {
@@ -762,9 +758,8 @@ pub async fn films_cover_large(
     if let Some(tid) = tmdb_id {
         // First get poster_path
         let tmdb_key = "0405855b8275307d3cf3284470fd9d28";
-        let detail_url = format!(
-            "https://api.themoviedb.org/3/movie/{tid}?api_key={tmdb_key}&language=cs-CZ"
-        );
+        let detail_url =
+            format!("https://api.themoviedb.org/3/movie/{tid}?api_key={tmdb_key}&language=cs-CZ");
 
         if let Ok(resp) = state
             .http_client
@@ -790,10 +785,7 @@ pub async fn films_cover_large(
                 let output_bytes = if let Ok(img) = image::load_from_memory(&bytes) {
                     let mut buf = Vec::new();
                     let mut cursor = std::io::Cursor::new(&mut buf);
-                    if img
-                        .write_to(&mut cursor, image::ImageFormat::WebP)
-                        .is_ok()
-                    {
+                    if img.write_to(&mut cursor, image::ImageFormat::WebP).is_ok() {
                         buf
                     } else {
                         bytes.to_vec()
@@ -979,10 +971,7 @@ pub async fn sktorrent_resolve(
 
 /// Scan sktorrent CDN servers (1..=30) with HEAD request to find working URL.
 /// Used as fallback when page is geo-blocked but CDN URLs work globally.
-async fn scan_sktorrent_cdns(
-    client: &reqwest::Client,
-    video_id: i32,
-) -> Vec<SktorrentSource> {
+async fn scan_sktorrent_cdns(client: &reqwest::Client, video_id: i32) -> Vec<SktorrentSource> {
     let qualities = [("720p", 720), ("480p", 480), ("HD", 700), ("SD", 360)];
     let mut found: Vec<SktorrentSource> = vec![];
 

--- a/cr-web/src/handlers/mod.rs
+++ b/cr-web/src/handlers/mod.rs
@@ -28,13 +28,13 @@ pub use audiobooks::audiobooks;
 pub use download_video::download_video;
 pub use films::{films_detail, films_list, films_search, sktorrent_resolve};
 pub use filmy_serialy::filmy_serialy;
+pub use geojson::{geojson_municipality, geojson_orp};
+pub use landmarks::{api_landmarks, landmarks_by_url, landmarks_index};
+pub use pools::{pools_by_category, pools_hub};
 pub use series::{
     episode_detail, series_episode_still, series_list, series_person_image, series_resolve,
     series_search,
 };
-pub use geojson::{geojson_municipality, geojson_orp};
-pub use landmarks::{api_landmarks, landmarks_by_url, landmarks_index};
-pub use pools::{pools_by_category, pools_hub};
 pub use video_api::{
     library_delete, library_file, library_list, library_play, library_stream, video_cleanup,
     video_file, video_file_part, video_info, video_prepare, video_recent, video_status,

--- a/cr-web/src/handlers/mod.rs
+++ b/cr-web/src/handlers/mod.rs
@@ -20,6 +20,7 @@ mod municipalities;
 mod orp;
 mod pools;
 mod regions;
+mod series;
 pub mod video_api;
 
 // Re-export all public handlers so main.rs doesn't need changes
@@ -27,6 +28,10 @@ pub use audiobooks::audiobooks;
 pub use download_video::download_video;
 pub use films::{films_detail, films_list, films_search, sktorrent_resolve};
 pub use filmy_serialy::filmy_serialy;
+pub use series::{
+    episode_detail, series_episode_still, series_list, series_person_image, series_resolve,
+    series_search,
+};
 pub use geojson::{geojson_municipality, geojson_orp};
 pub use landmarks::{api_landmarks, landmarks_by_url, landmarks_index};
 pub use pools::{pools_by_category, pools_hub};

--- a/cr-web/src/handlers/movies_api.rs
+++ b/cr-web/src/handlers/movies_api.rs
@@ -51,11 +51,20 @@ pub struct SearchResponse {
     movies: Vec<MovieResult>,
 }
 
+#[derive(Serialize, Clone)]
+pub struct SubtitleTrack {
+    url: String,
+    lang: String,
+    label: String,
+}
+
 #[derive(Serialize)]
 pub struct VideoUrlResponse {
     success: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     video_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    subtitles: Option<Vec<SubtitleTrack>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<String>,
 }
@@ -65,6 +74,12 @@ pub struct ValidateResponse {
     valid: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     status: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    duration_sec: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    width: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    height: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<String>,
 }
@@ -85,10 +100,18 @@ struct ProxyMovie {
 }
 
 #[derive(Deserialize)]
+struct ProxySubtitleTrack {
+    url: Option<String>,
+    lang: Option<String>,
+    label: Option<String>,
+}
+
+#[derive(Deserialize)]
 struct ProxyVideoResponse {
     success: Option<bool>,
     #[serde(rename = "videoUrl")]
     video_url: Option<String>,
+    subtitles: Option<Vec<ProxySubtitleTrack>>,
     error: Option<String>,
 }
 
@@ -225,23 +248,37 @@ pub async fn movies_video_url(
         "Proxy not configured".to_string(),
     ))?;
 
-    let url = format!(
+    // Fetch video URL and page HTML concurrently via CZ proxy
+    let video_api_url = format!(
         "{}?action=video&url={}&key={}",
         proxy_url,
         urlencoding::encode(&video_url),
         proxy_key
     );
+    let page_api_url = format!(
+        "{}?action=proxy&url={}&key={}",
+        proxy_url,
+        urlencoding::encode(&video_url),
+        proxy_key
+    );
 
-    let resp = state
-        .http_client
-        .get(&url)
-        .timeout(std::time::Duration::from_secs(30))
-        .send()
-        .await
-        .map_err(|e| {
-            tracing::error!("CzProxy video failed: {e}");
-            (StatusCode::BAD_GATEWAY, format!("Proxy error: {e}"))
-        })?;
+    let (video_resp, page_resp) = tokio::join!(
+        state
+            .http_client
+            .get(&video_api_url)
+            .timeout(std::time::Duration::from_secs(30))
+            .send(),
+        state
+            .http_client
+            .get(&page_api_url)
+            .timeout(std::time::Duration::from_secs(30))
+            .send()
+    );
+
+    let resp = video_resp.map_err(|e| {
+        tracing::error!("CzProxy video failed: {e}");
+        (StatusCode::BAD_GATEWAY, format!("Proxy error: {e}"))
+    })?;
 
     let data: ProxyVideoResponse = resp.json().await.map_err(|e| {
         tracing::error!("CzProxy video parse failed: {e}");
@@ -251,9 +288,36 @@ pub async fn movies_video_url(
         )
     })?;
 
+    // Extract subtitles: prefer CZ proxy response, fallback to parsing page HTML
+    let mut subtitles = data.subtitles.map(|tracks| {
+        tracks
+            .into_iter()
+            .filter_map(|t| {
+                Some(SubtitleTrack {
+                    url: t.url?,
+                    lang: t.lang.unwrap_or_default(),
+                    label: t.label.unwrap_or_default(),
+                })
+            })
+            .collect::<Vec<_>>()
+    });
+
+    // If CZ proxy didn't return subtitles, extract from page HTML
+    if subtitles.as_ref().is_none_or(|s| s.is_empty()) {
+        if let Ok(page_r) = page_resp {
+            if let Ok(html) = page_r.text().await {
+                let extracted = extract_subtitles_from_html(&html);
+                if !extracted.is_empty() {
+                    subtitles = Some(extracted);
+                }
+            }
+        }
+    }
+
     Ok(Json(VideoUrlResponse {
         success: data.success.unwrap_or(false),
         video_url: data.video_url,
+        subtitles,
         error: data.error,
     }))
 }
@@ -261,7 +325,54 @@ pub async fn movies_video_url(
 /// PHP proxy URL for prehraj.to validation (ASP.NET proxy returns 401, PHP works).
 const PREHRAJTO_PHP_PROXY: &str = "http://tumarsrobot.unas.cz/index.php";
 
-/// Validate video availability via PHP proxy (tumarsrobot.unas.cz)
+/// Extract `'videoLength': 772` from prehraj.to page HTML (seconds).
+fn extract_video_length(html: &str) -> Option<u32> {
+    static RE: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+        regex::Regex::new(r"'videoLength'\s*:\s*(\d+)").unwrap()
+    });
+    RE.captures(html)
+        .and_then(|c| c.get(1))
+        .and_then(|m| m.as_str().parse::<u32>().ok())
+}
+
+/// Extract real video width/height from prehraj.to microdata.
+/// Names in the candidate title are unreliable ("1080p" uploads can be 480p);
+/// the page's `<meta itemprop="height">` reports the actual stream dimensions.
+fn extract_dimensions(html: &str) -> (Option<u32>, Option<u32>) {
+    static RE_W: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+        regex::Regex::new(r#"itemprop="width"\s+content="(\d+)""#).unwrap()
+    });
+    static RE_H: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+        regex::Regex::new(r#"itemprop="height"\s+content="(\d+)""#).unwrap()
+    });
+    let w = RE_W.captures(html)
+        .and_then(|c| c.get(1))
+        .and_then(|m| m.as_str().parse::<u32>().ok());
+    let h = RE_H.captures(html)
+        .and_then(|c| c.get(1))
+        .and_then(|m| m.as_str().parse::<u32>().ok());
+    (w, h)
+}
+
+/// Extract `contentUrl` from prehraj.to page (mp4 on CDN). Return true if the
+/// CDN is one of the direct-playable hosts (premiumcdn.net). A non-direct URL
+/// would require proxying — not what we want for scale.
+fn extract_is_direct(html: &str) -> bool {
+    static RE: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+        regex::Regex::new(r#"itemprop="contentUrl"\s+content="([^"]+)""#).unwrap()
+    });
+    RE.captures(html)
+        .and_then(|c| c.get(1))
+        .map(|m| {
+            let url = m.as_str();
+            url.contains(".premiumcdn.net/") || url.contains("premiumcdn.net:")
+        })
+        .unwrap_or(false)
+}
+
+/// Validate video availability and fetch duration in one request by parsing
+/// the prehraj.to page HTML (via CZ proxy). Returns both `valid` (DIRECT on
+/// premiumcdn) and `duration_sec`.
 pub async fn movies_validate(
     State(state): State<AppState>,
     Query(params): Query<ValidateQuery>,
@@ -271,16 +382,73 @@ pub async fn movies_validate(
         return Json(ValidateResponse {
             valid: false,
             status: None,
+            duration_sec: None,
+            width: None,
+            height: None,
             error: Some("Invalid or missing prehraj.to URL".to_string()),
         });
     }
-    // Use PHP proxy for validation — ASP.NET proxy returns 401 for valid CDN URLs
+
+    // Prefer CZ proxy (action=proxy) for HTML fetch — same infra used by
+    // movies_video_url. Fall back to PHP proxy HEAD-check if CZ proxy is
+    // unavailable (loses duration info but preserves legacy valid flag).
+    if let Some((proxy_url, proxy_key)) = cz_proxy_config() {
+        let req_url = format!(
+            "{}?action=proxy&url={}&key={}",
+            proxy_url,
+            urlencoding::encode(&url),
+            proxy_key
+        );
+        match state
+            .http_client
+            .get(&req_url)
+            .timeout(std::time::Duration::from_secs(25))
+            .send()
+            .await
+        {
+            Ok(resp) => {
+                let status = resp.status().as_u16();
+                if !resp.status().is_success() {
+                    return Json(ValidateResponse {
+                        valid: false,
+                        status: Some(status),
+                        duration_sec: None,
+            width: None,
+            height: None,
+                        error: None,
+                    });
+                }
+                match resp.text().await {
+                    Ok(html) => {
+                        let valid = extract_is_direct(&html);
+                        let duration_sec = extract_video_length(&html);
+                        let (width, height) = extract_dimensions(&html);
+                        return Json(ValidateResponse {
+                            valid,
+                            status: Some(status),
+                            duration_sec,
+                            width,
+                            height,
+                            error: None,
+                        });
+                    }
+                    Err(e) => {
+                        tracing::warn!("validate: read body failed: {e}");
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!("validate: CZ proxy request failed: {e}");
+            }
+        }
+    }
+
+    // Fallback: legacy PHP proxy HEAD check (no duration_sec)
     let req_url = format!(
         "{}?action=validate&url={}",
         PREHRAJTO_PHP_PROXY,
         urlencoding::encode(&url),
     );
-
     match state
         .http_client
         .get(&req_url)
@@ -292,17 +460,26 @@ pub async fn movies_validate(
             Ok(data) => Json(ValidateResponse {
                 valid: data.valid.unwrap_or(false),
                 status: data.status,
+                duration_sec: None,
+            width: None,
+            height: None,
                 error: None,
             }),
             Err(_) => Json(ValidateResponse {
                 valid: false,
                 status: None,
+                duration_sec: None,
+            width: None,
+            height: None,
                 error: Some("Invalid response".to_string()),
             }),
         },
         Err(e) => Json(ValidateResponse {
             valid: false,
             status: None,
+            duration_sec: None,
+            width: None,
+            height: None,
             error: Some(format!("Request failed: {e}")),
         }),
     }
@@ -397,6 +574,64 @@ pub async fn movies_stream(
             tracing::error!("Stream proxy failed: {e}");
             (StatusCode::BAD_GATEWAY, "Stream failed").into_response()
         }
+    }
+}
+
+// --- Subtitle (VTT) proxy ---
+
+#[derive(Deserialize)]
+pub struct SubtitleQuery {
+    pub url: String,
+}
+
+/// Proxy VTT subtitle files from premiumcdn.net through our domain.
+/// HTML5 <track> elements require CORS headers that CDN doesn't provide.
+pub async fn movies_subtitle(
+    State(state): State<AppState>,
+    Query(query): Query<SubtitleQuery>,
+) -> impl IntoResponse {
+    let parsed = match reqwest::Url::parse(&query.url) {
+        Ok(u) => u,
+        Err(_) => return (StatusCode::BAD_REQUEST, "Invalid URL").into_response(),
+    };
+    // Only allow premiumcdn.net VTT files
+    let host = parsed.host_str().unwrap_or("");
+    if !host.ends_with("premiumcdn.net") || !parsed.path().ends_with(".vtt") {
+        return (StatusCode::FORBIDDEN, "URL not allowed").into_response();
+    }
+
+    let resp = state
+        .http_client
+        .get(parsed.as_str())
+        .header("User-Agent", "Mozilla/5.0")
+        .header("Referer", "https://prehraj.to/")
+        .timeout(std::time::Duration::from_secs(15))
+        .send()
+        .await;
+
+    match resp {
+        Ok(r) if r.status().is_success() => match r.bytes().await {
+            Ok(bytes) => (
+                StatusCode::OK,
+                [
+                    (header::CONTENT_TYPE, "text/vtt; charset=utf-8".to_string()),
+                    (
+                        header::ACCESS_CONTROL_ALLOW_ORIGIN,
+                        "*".to_string(),
+                    ),
+                    (
+                        header::CACHE_CONTROL,
+                        "public, max-age=3600".to_string(),
+                    ),
+                ],
+                bytes,
+            )
+                .into_response(),
+            Err(_) => {
+                (StatusCode::BAD_GATEWAY, "Failed to read subtitle").into_response()
+            }
+        },
+        _ => (StatusCode::NOT_FOUND, "Subtitle not available").into_response(),
     }
 }
 
@@ -884,6 +1119,43 @@ fn decode_base_n(s: &str, base: u32) -> Option<u32> {
         result = result.checked_mul(base)?.checked_add(digit)?;
     }
     Some(result)
+}
+
+/// Extract VTT subtitle tracks from Přehraj.to page HTML.
+/// Matches JWPlayer track config: { file: "...vtt", label: "CZE - 123 - cze", kind: "captions" }
+fn extract_subtitles_from_html(html: &str) -> Vec<SubtitleTrack> {
+    let re = regex::Regex::new(
+        r#"\{\s*file\s*:\s*"([^"]+\.vtt[^"]*)"\s*,\s*(?:"default"\s*:\s*true\s*,\s*)?label\s*:\s*"([^"]+)"\s*,\s*kind\s*:\s*"captions"\s*\}"#,
+    )
+    .unwrap();
+
+    let lang_re = regex::Regex::new(r"(\w{2,3})\s*$").unwrap();
+
+    re.captures_iter(html)
+        .map(|cap| {
+            let vtt_url = cap[1].replace("\\u0026", "&").replace("&amp;", "&");
+            let label_raw = &cap[2];
+
+            // Extract language code from label like "CZE - 8929014 - cze"
+            let lang = lang_re
+                .captures(label_raw)
+                .map(|m| m[1].to_lowercase())
+                .unwrap_or_default();
+
+            // Clean label: "CZE - 8929014 - cze" → "CZE"
+            let label = regex::Regex::new(r"\s*-\s*\d+\s*-\s*\w+$")
+                .unwrap()
+                .replace(label_raw, "")
+                .trim()
+                .to_string();
+
+            SubtitleTrack {
+                url: vtt_url,
+                lang,
+                label,
+            }
+        })
+        .collect()
 }
 
 /// Result from Playwright resolve — URL + optional cookies for CDN access.

--- a/cr-web/src/handlers/movies_api.rs
+++ b/cr-web/src/handlers/movies_api.rs
@@ -303,14 +303,13 @@ pub async fn movies_video_url(
     });
 
     // If CZ proxy didn't return subtitles, extract from page HTML
-    if subtitles.as_ref().is_none_or(|s| s.is_empty()) {
-        if let Ok(page_r) = page_resp {
-            if let Ok(html) = page_r.text().await {
-                let extracted = extract_subtitles_from_html(&html);
-                if !extracted.is_empty() {
-                    subtitles = Some(extracted);
-                }
-            }
+    if subtitles.as_ref().is_none_or(|s| s.is_empty())
+        && let Ok(page_r) = page_resp
+        && let Ok(html) = page_r.text().await
+    {
+        let extracted = extract_subtitles_from_html(&html);
+        if !extracted.is_empty() {
+            subtitles = Some(extracted);
         }
     }
 
@@ -327,9 +326,8 @@ const PREHRAJTO_PHP_PROXY: &str = "http://tumarsrobot.unas.cz/index.php";
 
 /// Extract `'videoLength': 772` from prehraj.to page HTML (seconds).
 fn extract_video_length(html: &str) -> Option<u32> {
-    static RE: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
-        regex::Regex::new(r"'videoLength'\s*:\s*(\d+)").unwrap()
-    });
+    static RE: std::sync::LazyLock<regex::Regex> =
+        std::sync::LazyLock::new(|| regex::Regex::new(r"'videoLength'\s*:\s*(\d+)").unwrap());
     RE.captures(html)
         .and_then(|c| c.get(1))
         .and_then(|m| m.as_str().parse::<u32>().ok())
@@ -345,10 +343,12 @@ fn extract_dimensions(html: &str) -> (Option<u32>, Option<u32>) {
     static RE_H: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
         regex::Regex::new(r#"itemprop="height"\s+content="(\d+)""#).unwrap()
     });
-    let w = RE_W.captures(html)
+    let w = RE_W
+        .captures(html)
         .and_then(|c| c.get(1))
         .and_then(|m| m.as_str().parse::<u32>().ok());
-    let h = RE_H.captures(html)
+    let h = RE_H
+        .captures(html)
         .and_then(|c| c.get(1))
         .and_then(|m| m.as_str().parse::<u32>().ok());
     (w, h)
@@ -413,8 +413,8 @@ pub async fn movies_validate(
                         valid: false,
                         status: Some(status),
                         duration_sec: None,
-            width: None,
-            height: None,
+                        width: None,
+                        height: None,
                         error: None,
                     });
                 }
@@ -461,16 +461,16 @@ pub async fn movies_validate(
                 valid: data.valid.unwrap_or(false),
                 status: data.status,
                 duration_sec: None,
-            width: None,
-            height: None,
+                width: None,
+                height: None,
                 error: None,
             }),
             Err(_) => Json(ValidateResponse {
                 valid: false,
                 status: None,
                 duration_sec: None,
-            width: None,
-            height: None,
+                width: None,
+                height: None,
                 error: Some("Invalid response".to_string()),
             }),
         },
@@ -615,21 +615,13 @@ pub async fn movies_subtitle(
                 StatusCode::OK,
                 [
                     (header::CONTENT_TYPE, "text/vtt; charset=utf-8".to_string()),
-                    (
-                        header::ACCESS_CONTROL_ALLOW_ORIGIN,
-                        "*".to_string(),
-                    ),
-                    (
-                        header::CACHE_CONTROL,
-                        "public, max-age=3600".to_string(),
-                    ),
+                    (header::ACCESS_CONTROL_ALLOW_ORIGIN, "*".to_string()),
+                    (header::CACHE_CONTROL, "public, max-age=3600".to_string()),
                 ],
                 bytes,
             )
                 .into_response(),
-            Err(_) => {
-                (StatusCode::BAD_GATEWAY, "Failed to read subtitle").into_response()
-            }
+            Err(_) => (StatusCode::BAD_GATEWAY, "Failed to read subtitle").into_response(),
         },
         _ => (StatusCode::NOT_FOUND, "Subtitle not available").into_response(),
     }

--- a/cr-web/src/handlers/series.rs
+++ b/cr-web/src/handlers/series.rs
@@ -1,0 +1,927 @@
+//! TV series listing and detail pages at `/serialy-online/`.
+//! Similar structure to films but with seasons + episodes.
+
+use askama::Template;
+use axum::extract::{Path, State};
+use axum::http::{StatusCode, header};
+use axum::response::{Html, IntoResponse, Response};
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+
+use crate::error::WebResult;
+use crate::state::AppState;
+
+const SERIES_PER_PAGE: i64 = 24;
+
+#[derive(FromRow, Serialize)]
+pub struct SeriesRow {
+    id: i32,
+    title: String,
+    slug: String,
+    first_air_year: Option<i16>,
+    #[allow(dead_code)]
+    last_air_year: Option<i16>,
+    description: Option<String>,
+    original_title: Option<String>,
+    imdb_rating: Option<f32>,
+    csfd_rating: Option<i16>,
+    #[allow(dead_code)]
+    season_count: Option<i16>,
+    #[allow(dead_code)]
+    episode_count: Option<i16>,
+    cover_filename: Option<String>,
+    #[allow(dead_code)]
+    added_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// Episode card shown on list pages — one latest episode per series,
+/// sorted by added_at DESC. Layout mirrors bombuj.si: series cover + title
+/// + "Epizoda S×E" badge + CC (subtitles) badge.
+#[derive(FromRow, Serialize)]
+pub struct EpisodeCardRow {
+    #[allow(dead_code)]
+    pub id: i32,
+    pub series_slug: String,
+    pub series_title: String,
+    pub series_original_title: Option<String>,
+    pub series_cover_filename: Option<String>,
+    pub series_first_air_year: Option<i16>,
+    pub series_imdb_rating: Option<f32>,
+    pub series_csfd_rating: Option<i16>,
+    pub series_description: Option<String>,
+    pub season: i16,
+    pub episode: i16,
+    pub has_subtitles: Option<bool>,
+    pub has_dub: Option<bool>,
+    #[allow(dead_code)]
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(FromRow, Serialize)]
+pub struct EpisodeRow {
+    pub id: i32,
+    pub season: i16,
+    pub episode: i16,
+    pub title: Option<String>,
+    pub sktorrent_video_id: Option<i32>,
+    pub sktorrent_cdn: Option<i16>,
+    pub sktorrent_qualities: Option<String>,
+    pub episode_name: Option<String>,
+    pub overview: Option<String>,
+    pub air_date: Option<chrono::NaiveDate>,
+    pub runtime: Option<i16>,
+    pub still_filename: Option<String>,
+    pub prehrajto_url: Option<String>,
+    pub prehrajto_has_dub: bool,
+    pub prehrajto_has_subs: bool,
+}
+
+#[derive(FromRow)]
+struct GenreRow {
+    id: i32,
+    slug: String,
+    name_cs: String,
+}
+
+#[derive(FromRow)]
+struct CountRow {
+    count: Option<i64>,
+}
+
+#[derive(Deserialize)]
+pub struct SeriesQuery {
+    strana: Option<i64>,
+    razeni: Option<String>,
+    q: Option<String>,
+}
+
+impl SeriesQuery {
+    fn page(&self) -> i64 {
+        self.strana.unwrap_or(1).max(1)
+    }
+
+    fn order_clause(&self) -> &'static str {
+        match self.razeni.as_deref() {
+            Some("rok") => "s.first_air_year DESC NULLS LAST, s.title",
+            Some("imdb") => "s.imdb_rating DESC NULLS LAST, s.title",
+            Some("nazev") => "s.title ASC",
+            _ => "s.added_at DESC NULLS LAST, s.title",
+        }
+    }
+
+    fn sort_key(&self) -> &str {
+        self.razeni.as_deref().unwrap_or("pridano")
+    }
+}
+
+#[derive(Template)]
+#[template(path = "series_list.html")]
+struct SeriesListTemplate {
+    img: String,
+    /// Episode cards — one latest per series.
+    episodes: Vec<EpisodeCardRow>,
+    /// Full series results — shown only when user searches by title.
+    series: Vec<SeriesRow>,
+    genres: Vec<GenreRow>,
+    page: i64,
+    total_pages: i64,
+    total_count: i64,
+    current_genre: Option<GenreRow>,
+    sort_key: String,
+    query_string: String,
+    search_query: Option<String>,
+}
+
+#[derive(Template)]
+#[template(path = "series_detail.html")]
+struct SeriesDetailTemplate {
+    img: String,
+    series: SeriesRow,
+    genres: Vec<GenreRow>,
+    seasons: Vec<Season>,
+    actors: Vec<PersonRow>,
+    creators: Vec<PersonRow>,
+}
+
+#[derive(Template)]
+#[template(path = "episode_detail.html")]
+struct EpisodeDetailTemplate {
+    img: String,
+    series: SeriesRow,
+    episode: EpisodeRow,
+    prev_episode: Option<EpisodeNav>,
+    next_episode: Option<EpisodeNav>,
+    directors: Vec<PersonRow>,
+    writers: Vec<PersonRow>,
+}
+
+pub struct EpisodeNav {
+    pub season: i16,
+    pub episode: i16,
+    pub episode_name: Option<String>,
+}
+
+#[derive(FromRow, Clone)]
+pub struct PersonRow {
+    #[allow(dead_code)]
+    pub id: i32,
+    pub name: String,
+    pub profile_filename: Option<String>,
+    pub character_name: Option<String>,
+}
+
+pub struct Season {
+    pub number: i16,
+    pub episodes: Vec<EpisodeRow>,
+}
+
+pub async fn series_list(
+    State(state): State<AppState>,
+    axum::extract::Query(params): axum::extract::Query<SeriesQuery>,
+) -> WebResult<Response> {
+    let page = params.page();
+    let offset = (page - 1) * SERIES_PER_PAGE;
+    let order = params.order_clause();
+
+    let search_q = params.q.as_ref().and_then(|q| {
+        let t = q.trim();
+        if t.len() >= 2 {
+            Some(format!("%{t}%"))
+        } else {
+            None
+        }
+    });
+
+    // Search mode: show series results (by title). No search: show latest-
+    // episode-per-series grid (bombuj.si style).
+    let (total_count, series, episodes) = if let Some(ref pattern) = search_q {
+        let count_row = sqlx::query_as::<_, CountRow>(
+            "SELECT count(*) as count FROM series WHERE title ILIKE $1 OR original_title ILIKE $1",
+        )
+        .bind(pattern)
+        .fetch_one(&state.db)
+        .await?;
+
+        let query = format!(
+            "SELECT s.id, s.title, s.slug, s.first_air_year, s.last_air_year, \
+             s.description, s.original_title, s.imdb_rating, s.csfd_rating, \
+             s.season_count, s.episode_count, s.cover_filename, s.added_at \
+             FROM series s \
+             WHERE s.title ILIKE $1 OR s.original_title ILIKE $1 \
+             ORDER BY {order} LIMIT $2 OFFSET $3"
+        );
+        let rows = sqlx::query_as::<_, SeriesRow>(&query)
+            .bind(pattern)
+            .bind(SERIES_PER_PAGE)
+            .bind(offset)
+            .fetch_all(&state.db)
+            .await?;
+        (count_row.count.unwrap_or(0), rows, Vec::new())
+    } else {
+        let count_row = sqlx::query_as::<_, CountRow>(
+            "SELECT count(DISTINCT e.series_id) as count FROM episodes e",
+        )
+        .fetch_one(&state.db)
+        .await?;
+
+        let episodes = fetch_latest_episode_cards(&state, None, SERIES_PER_PAGE, offset).await?;
+        (count_row.count.unwrap_or(0), Vec::new(), episodes)
+    };
+
+    let total_pages = (total_count as f64 / SERIES_PER_PAGE as f64).ceil() as i64;
+
+    let genres = sqlx::query_as::<_, GenreRow>(
+        "SELECT g.id, g.slug, g.name_cs FROM genres g \
+         JOIN series_genres sg ON g.id = sg.genre_id \
+         GROUP BY g.id, g.slug, g.name_cs ORDER BY g.name_cs",
+    )
+    .fetch_all(&state.db)
+    .await?;
+
+    let mut qs_parts = Vec::new();
+    if params.razeni.is_some() {
+        qs_parts.push(format!("razeni={}", params.sort_key()));
+    }
+    if let Some(ref q) = params.q {
+        let t = q.trim();
+        if !t.is_empty() {
+            qs_parts.push(format!("q={}", urlencoding::encode(t)));
+        }
+    }
+    let query_string = if qs_parts.is_empty() {
+        String::new()
+    } else {
+        format!("&{}", qs_parts.join("&"))
+    };
+
+    let search_query = params.q.clone().and_then(|q| {
+        let t = q.trim();
+        if t.is_empty() { None } else { Some(t.to_string()) }
+    });
+
+    let tmpl = SeriesListTemplate {
+        img: state.image_base_url.clone(),
+        episodes,
+        series,
+        genres,
+        page,
+        total_pages,
+        total_count,
+        current_genre: None,
+        sort_key: params.sort_key().to_string(),
+        query_string,
+        search_query,
+    };
+    Ok(Html(tmpl.render()?).into_response())
+}
+
+/// Latest-episode-per-series query. If `genre_id` is provided, only series
+/// belonging to that genre are included. Result is already sorted so the
+/// caller needn't reorder.
+async fn fetch_latest_episode_cards(
+    state: &AppState,
+    genre_id: Option<i32>,
+    limit: i64,
+    offset: i64,
+) -> WebResult<Vec<EpisodeCardRow>> {
+    let base = "WITH per_series AS ( \
+        SELECT DISTINCT ON (e.series_id) \
+            e.id, e.series_id, e.season, e.episode, e.has_subtitles, e.has_dub, e.created_at \
+        FROM episodes e \
+        {GENRE_JOIN} \
+        {GENRE_WHERE} \
+        ORDER BY e.series_id, e.created_at DESC \
+     ) \
+     SELECT ps.id, \
+        s.slug AS series_slug, \
+        s.title AS series_title, \
+        s.original_title AS series_original_title, \
+        s.cover_filename AS series_cover_filename, \
+        s.first_air_year AS series_first_air_year, \
+        s.imdb_rating AS series_imdb_rating, \
+        s.csfd_rating AS series_csfd_rating, \
+        s.description AS series_description, \
+        ps.season, ps.episode, ps.has_subtitles, ps.has_dub, ps.created_at \
+     FROM per_series ps \
+     JOIN series s ON s.id = ps.series_id \
+     ORDER BY ps.created_at DESC NULLS LAST \
+     LIMIT $1 OFFSET $2";
+
+    let (genre_join, genre_where) = if genre_id.is_some() {
+        (
+            "JOIN series_genres sg ON sg.series_id = e.series_id",
+            "WHERE sg.genre_id = $3",
+        )
+    } else {
+        ("", "")
+    };
+    let sql = base
+        .replace("{GENRE_JOIN}", genre_join)
+        .replace("{GENRE_WHERE}", genre_where);
+
+    let rows = if let Some(gid) = genre_id {
+        sqlx::query_as::<_, EpisodeCardRow>(&sql)
+            .bind(limit)
+            .bind(offset)
+            .bind(gid)
+            .fetch_all(&state.db)
+            .await?
+    } else {
+        sqlx::query_as::<_, EpisodeCardRow>(&sql)
+            .bind(limit)
+            .bind(offset)
+            .fetch_all(&state.db)
+            .await?
+    };
+    Ok(rows)
+}
+
+/// Resolve /serialy-online/{slug}/ — genre or series detail
+pub async fn series_resolve(
+    State(state): State<AppState>,
+    Path(slug_raw): Path<String>,
+    axum::extract::Query(params): axum::extract::Query<SeriesQuery>,
+) -> WebResult<Response> {
+    let state_clone = state.clone();
+    // WebP cover
+    if slug_raw.ends_with(".webp") {
+        return series_cover(State(state), Path(slug_raw)).await;
+    }
+
+    // Genre page?
+    let genre = sqlx::query_as::<_, GenreRow>(
+        "SELECT id, slug, name_cs FROM genres WHERE slug = $1"
+    )
+    .bind(&slug_raw)
+    .fetch_optional(&state.db)
+    .await?;
+
+    if let Some(genre) = genre {
+        return series_by_genre(state, genre, params).await;
+    }
+
+    // Series detail
+    let series = sqlx::query_as::<_, SeriesRow>(
+        "SELECT id, title, slug, first_air_year, last_air_year, description, \
+         original_title, imdb_rating, csfd_rating, season_count, episode_count, \
+         cover_filename, added_at \
+         FROM series WHERE slug = $1",
+    )
+    .bind(&slug_raw)
+    .fetch_optional(&state.db)
+    .await?;
+
+    let Some(series) = series else {
+        return Ok((StatusCode::NOT_FOUND, "Seriál nenalezen").into_response());
+    };
+
+    let genres = sqlx::query_as::<_, GenreRow>(
+        "SELECT g.id, g.slug, g.name_cs FROM genres g \
+         JOIN series_genres sg ON g.id = sg.genre_id \
+         WHERE sg.series_id = $1 ORDER BY g.name_cs",
+    )
+    .bind(series.id)
+    .fetch_all(&state.db)
+    .await?;
+
+    // Only list episodes that have a playable source — either SK Torrent or a
+    // cached Přehraj.to URL. TMDB stubs without any source stay in the DB
+    // (useful when enrichment picks them up later) but we don't show them.
+    let episodes = sqlx::query_as::<_, EpisodeRow>(
+        "SELECT id, season, episode, title, sktorrent_video_id, sktorrent_cdn, sktorrent_qualities, \
+         episode_name, overview, air_date, runtime, still_filename, \
+         prehrajto_url, prehrajto_has_dub, prehrajto_has_subs \
+         FROM episodes \
+         WHERE series_id = $1 \
+           AND (sktorrent_video_id IS NOT NULL OR prehrajto_url IS NOT NULL) \
+         ORDER BY season, episode, sktorrent_video_id",
+    )
+    .bind(series.id)
+    .fetch_all(&state.db)
+    .await?;
+
+    // Group by season, dedupe episode numbers (prefer first quality version per season/episode)
+    let mut seasons: Vec<Season> = Vec::new();
+    let mut current_season: Option<Season> = None;
+    let mut seen_in_season: std::collections::HashSet<i16> = std::collections::HashSet::new();
+
+    for ep in episodes {
+        if let Some(ref s) = current_season {
+            if s.number != ep.season {
+                seasons.push(current_season.take().unwrap());
+                seen_in_season.clear();
+            }
+        }
+        if current_season.is_none() {
+            current_season = Some(Season {
+                number: ep.season,
+                episodes: Vec::new(),
+            });
+        }
+        if seen_in_season.insert(ep.episode)
+            && let Some(ref mut s) = current_season
+        {
+            s.episodes.push(ep);
+        }
+    }
+    if let Some(s) = current_season {
+        seasons.push(s);
+    }
+
+    // Top cast + creators
+    let actors = sqlx::query_as::<_, PersonRow>(
+        "SELECT p.id, p.name, p.profile_filename, sa.character_name \
+         FROM people p JOIN series_actors sa ON sa.person_id = p.id \
+         WHERE sa.series_id = $1 ORDER BY sa.order_index LIMIT 10",
+    )
+    .bind(series.id)
+    .fetch_all(&state_clone.db)
+    .await
+    .unwrap_or_default();
+
+    let creators = sqlx::query_as::<_, PersonRow>(
+        "SELECT p.id, p.name, p.profile_filename, NULL::varchar as character_name \
+         FROM people p JOIN series_directors sd ON sd.person_id = p.id \
+         WHERE sd.series_id = $1 ORDER BY p.name",
+    )
+    .bind(series.id)
+    .fetch_all(&state_clone.db)
+    .await
+    .unwrap_or_default();
+
+    let tmpl = SeriesDetailTemplate {
+        img: state_clone.image_base_url.clone(),
+        series,
+        genres,
+        seasons,
+        actors,
+        creators,
+    };
+    Ok(Html(tmpl.render()?).into_response())
+}
+
+/// GET /serialy-online/{slug}/{NxM}/ — episode detail page with player
+pub async fn episode_detail(
+    State(state): State<AppState>,
+    Path((slug, ep_path)): Path<(String, String)>,
+) -> WebResult<Response> {
+    // Parse "1x3" → (1, 3)
+    let Some((s_str, e_str)) = ep_path.split_once('x') else {
+        return Ok((StatusCode::NOT_FOUND, "Neplatná URL").into_response());
+    };
+    let Ok(season_num) = s_str.parse::<i16>() else {
+        return Ok((StatusCode::NOT_FOUND, "Neplatná sezóna").into_response());
+    };
+    let Ok(episode_num) = e_str.parse::<i16>() else {
+        return Ok((StatusCode::NOT_FOUND, "Neplatná epizoda").into_response());
+    };
+
+    let series = sqlx::query_as::<_, SeriesRow>(
+        "SELECT id, title, slug, first_air_year, last_air_year, description, \
+         original_title, imdb_rating, csfd_rating, season_count, episode_count, \
+         cover_filename, added_at FROM series WHERE slug = $1",
+    )
+    .bind(&slug)
+    .fetch_optional(&state.db)
+    .await?;
+    let Some(series) = series else {
+        return Ok((StatusCode::NOT_FOUND, "Seriál nenalezen").into_response());
+    };
+
+    // Episode must have a playable source (SK Torrent or cached Přehraj.to URL).
+    // TMDB-stub episodes without any source 404 — they exist only for future
+    // enrichment and should never be reachable from the listing or via URL.
+    let episode = sqlx::query_as::<_, EpisodeRow>(
+        "SELECT id, season, episode, title, sktorrent_video_id, sktorrent_cdn, sktorrent_qualities, \
+         episode_name, overview, air_date, runtime, still_filename, \
+         prehrajto_url, prehrajto_has_dub, prehrajto_has_subs \
+         FROM episodes \
+         WHERE series_id = $1 AND season = $2 AND episode = $3 \
+           AND (sktorrent_video_id IS NOT NULL OR prehrajto_url IS NOT NULL) \
+         ORDER BY sktorrent_video_id LIMIT 1",
+    )
+    .bind(series.id)
+    .bind(season_num)
+    .bind(episode_num)
+    .fetch_optional(&state.db)
+    .await?;
+    let Some(episode) = episode else {
+        return Ok((StatusCode::NOT_FOUND, "Epizoda nenalezena").into_response());
+    };
+
+    // Navigation: previous and next episode — same source-available filter
+    let all_episodes = sqlx::query_as::<_, (i16, i16, Option<String>)>(
+        "SELECT DISTINCT ON (season, episode) season, episode, episode_name \
+         FROM episodes \
+         WHERE series_id = $1 \
+           AND (sktorrent_video_id IS NOT NULL OR prehrajto_url IS NOT NULL) \
+         ORDER BY season, episode",
+    )
+    .bind(series.id)
+    .fetch_all(&state.db)
+    .await
+    .unwrap_or_default();
+    let current_idx = all_episodes
+        .iter()
+        .position(|(s, e, _)| *s == season_num && *e == episode_num);
+    let prev_episode = current_idx
+        .and_then(|i| i.checked_sub(1).and_then(|j| all_episodes.get(j)))
+        .map(|(s, e, n)| EpisodeNav {
+            season: *s,
+            episode: *e,
+            episode_name: n.clone(),
+        });
+    let next_episode = current_idx
+        .and_then(|i| all_episodes.get(i + 1))
+        .map(|(s, e, n)| EpisodeNav {
+            season: *s,
+            episode: *e,
+            episode_name: n.clone(),
+        });
+
+    let directors = sqlx::query_as::<_, PersonRow>(
+        "SELECT p.id, p.name, p.profile_filename, NULL::varchar as character_name \
+         FROM people p JOIN episode_directors ed ON ed.person_id = p.id \
+         WHERE ed.episode_id = $1 ORDER BY p.name",
+    )
+    .bind(episode.id)
+    .fetch_all(&state.db)
+    .await
+    .unwrap_or_default();
+
+    let writers = sqlx::query_as::<_, PersonRow>(
+        "SELECT p.id, p.name, p.profile_filename, NULL::varchar as character_name \
+         FROM people p JOIN episode_writers ew ON ew.person_id = p.id \
+         WHERE ew.episode_id = $1 ORDER BY p.name",
+    )
+    .bind(episode.id)
+    .fetch_all(&state.db)
+    .await
+    .unwrap_or_default();
+
+    let tmpl = EpisodeDetailTemplate {
+        img: state.image_base_url.clone(),
+        series,
+        episode,
+        prev_episode,
+        next_episode,
+        directors,
+        writers,
+    };
+    Ok(Html(tmpl.render()?).into_response())
+}
+
+async fn series_by_genre(
+    state: AppState,
+    genre: GenreRow,
+    params: SeriesQuery,
+) -> WebResult<Response> {
+    let page = params.page();
+    let offset = (page - 1) * SERIES_PER_PAGE;
+
+    let count_row = sqlx::query_as::<_, CountRow>(
+        "SELECT count(DISTINCT e.series_id) as count FROM episodes e \
+         JOIN series_genres sg ON sg.series_id = e.series_id WHERE sg.genre_id = $1",
+    )
+    .bind(genre.id)
+    .fetch_one(&state.db)
+    .await?;
+    let total_count = count_row.count.unwrap_or(0);
+    let total_pages = (total_count as f64 / SERIES_PER_PAGE as f64).ceil() as i64;
+
+    let episodes =
+        fetch_latest_episode_cards(&state, Some(genre.id), SERIES_PER_PAGE, offset).await?;
+
+    let all_genres = sqlx::query_as::<_, GenreRow>(
+        "SELECT g.id, g.slug, g.name_cs FROM genres g \
+         JOIN series_genres sg ON g.id = sg.genre_id \
+         GROUP BY g.id, g.slug, g.name_cs ORDER BY g.name_cs",
+    )
+    .fetch_all(&state.db)
+    .await?;
+
+    let tmpl = SeriesListTemplate {
+        img: state.image_base_url.clone(),
+        episodes,
+        series: Vec::new(),
+        genres: all_genres,
+        page,
+        total_pages,
+        total_count,
+        current_genre: Some(genre),
+        sort_key: params.sort_key().to_string(),
+        query_string: String::new(),
+        search_query: None,
+    };
+    Ok(Html(tmpl.render()?).into_response())
+}
+
+#[derive(Serialize)]
+struct SeriesSearchResult {
+    slug: String,
+    title: String,
+    year: Option<i16>,
+    imdb_rating: Option<f32>,
+    cover: bool,
+}
+
+#[derive(FromRow)]
+struct SeriesSearchRow {
+    slug: String,
+    title: String,
+    first_air_year: Option<i16>,
+    imdb_rating: Option<f32>,
+    cover_filename: Option<String>,
+}
+
+/// GET /api/series/search?q=...
+pub async fn series_search(
+    State(state): State<AppState>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
+) -> WebResult<Response> {
+    let q = params.get("q").map(|s| s.trim()).unwrap_or("");
+    if q.len() < 2 {
+        return Ok(axum::Json(Vec::<SeriesSearchResult>::new()).into_response());
+    }
+    let pattern = format!("%{q}%");
+    let starts_pattern = format!("{q}%");
+    let rows = sqlx::query_as::<_, SeriesSearchRow>(
+        "SELECT slug, title, first_air_year, imdb_rating, cover_filename \
+         FROM series \
+         WHERE title ILIKE $1 OR original_title ILIKE $1 \
+         ORDER BY \
+           CASE WHEN title ILIKE $2 THEN 0 \
+                WHEN title ILIKE $1 THEN 1 \
+                WHEN original_title ILIKE $2 THEN 2 \
+                ELSE 3 END, \
+           imdb_rating DESC NULLS LAST \
+         LIMIT 10",
+    )
+    .bind(&pattern)
+    .bind(&starts_pattern)
+    .fetch_all(&state.db)
+    .await?;
+
+    let results: Vec<SeriesSearchResult> = rows
+        .into_iter()
+        .map(|r| SeriesSearchResult {
+            slug: r.slug,
+            title: r.title,
+            year: r.first_air_year,
+            imdb_rating: r.imdb_rating,
+            cover: r.cover_filename.is_some(),
+        })
+        .collect();
+
+    Ok(axum::Json(results).into_response())
+}
+
+pub async fn series_cover(
+    State(state): State<AppState>,
+    Path(slug_webp): Path<String>,
+) -> WebResult<Response> {
+    // Detect -large variant — fetches w780 poster from TMDB (cached to disk)
+    if slug_webp.ends_with("-large.webp") {
+        return series_cover_large(State(state), Path(slug_webp)).await;
+    }
+    let slug = slug_webp.strip_suffix(".webp").unwrap_or(&slug_webp);
+
+    #[derive(sqlx::FromRow)]
+    struct CoverRow {
+        cover_filename: Option<String>,
+    }
+
+    let row = sqlx::query_as::<_, CoverRow>("SELECT cover_filename FROM series WHERE slug = $1")
+        .bind(slug)
+        .fetch_optional(&state.db)
+        .await?;
+
+    let cover_filename = row.and_then(|r| r.cover_filename);
+    let covers_dir =
+        std::env::var("SERIES_COVERS_DIR").unwrap_or_else(|_| "data/series/covers-webp".to_string());
+
+    if let Some(filename) = cover_filename {
+        let path = std::path::Path::new(&covers_dir).join(format!("{filename}.webp"));
+        if path.exists()
+            && let Ok(bytes) = tokio::fs::read(&path).await
+        {
+            return Ok((
+                StatusCode::OK,
+                [
+                    (header::CONTENT_TYPE, "image/webp"),
+                    (header::CACHE_CONTROL, "public, max-age=31536000"),
+                ],
+                bytes,
+            )
+                .into_response());
+        }
+    }
+
+    // Placeholder
+    static PLACEHOLDER: &[u8] = &[
+        0x52, 0x49, 0x46, 0x46, 0x1a, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50, 0x56, 0x50, 0x38,
+        0x4c, 0x0d, 0x00, 0x00, 0x00, 0x2f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00,
+    ];
+    Ok((
+        StatusCode::OK,
+        [
+            (header::CONTENT_TYPE, "image/webp"),
+            (header::CACHE_CONTROL, "public, max-age=3600"),
+        ],
+        PLACEHOLDER.to_vec(),
+    )
+        .into_response())
+}
+
+/// GET /serialy-online/{slug}-large.webp — serve w780 poster from TMDB (cached).
+/// Mirrors films_cover_large for feature parity on series detail pages.
+pub async fn series_cover_large(
+    State(state): State<AppState>,
+    Path(slug_webp): Path<String>,
+) -> WebResult<Response> {
+    let slug = slug_webp
+        .strip_suffix("-large.webp")
+        .unwrap_or(&slug_webp);
+
+    #[derive(sqlx::FromRow)]
+    struct CoverRow {
+        tmdb_id: Option<i32>,
+    }
+
+    let row = sqlx::query_as::<_, CoverRow>("SELECT tmdb_id FROM series WHERE slug = $1")
+        .bind(slug)
+        .fetch_optional(&state.db)
+        .await?;
+
+    let tmdb_id = row.and_then(|r| r.tmdb_id);
+    let covers_dir = std::env::var("SERIES_COVERS_DIR")
+        .unwrap_or_else(|_| "data/series/covers-webp".to_string());
+
+    // Cache path: {covers_dir}/large/{slug}.webp
+    let cache_dir = std::path::Path::new(&covers_dir).join("large");
+    let cache_path = cache_dir.join(format!("{slug}.webp"));
+
+    if cache_path.exists()
+        && let Ok(bytes) = tokio::fs::read(&cache_path).await
+    {
+        return Ok((
+            StatusCode::OK,
+            [
+                (header::CONTENT_TYPE, "image/webp"),
+                (header::CACHE_CONTROL, "public, max-age=31536000, immutable"),
+            ],
+            bytes,
+        )
+            .into_response());
+    }
+
+    // Fetch from TMDB (TV endpoint)
+    if let Some(tid) = tmdb_id {
+        let tmdb_key = "0405855b8275307d3cf3284470fd9d28";
+        let detail_url =
+            format!("https://api.themoviedb.org/3/tv/{tid}?api_key={tmdb_key}&language=cs-CZ");
+
+        if let Ok(resp) = state
+            .http_client
+            .get(&detail_url)
+            .timeout(std::time::Duration::from_secs(10))
+            .send()
+            .await
+            && let Ok(data) = resp.json::<serde_json::Value>().await
+            && let Some(poster_path) = data.get("poster_path").and_then(|v| v.as_str())
+        {
+            let poster_url = format!("https://image.tmdb.org/t/p/w780{poster_path}");
+            if let Ok(img_resp) = state
+                .http_client
+                .get(&poster_url)
+                .timeout(std::time::Duration::from_secs(15))
+                .send()
+                .await
+                && img_resp.status().is_success()
+                && let Ok(bytes) = img_resp.bytes().await
+            {
+                let output_bytes = if let Ok(img) = image::load_from_memory(&bytes) {
+                    let mut buf = Vec::new();
+                    let mut cursor = std::io::Cursor::new(&mut buf);
+                    if img
+                        .write_to(&mut cursor, image::ImageFormat::WebP)
+                        .is_ok()
+                    {
+                        buf
+                    } else {
+                        bytes.to_vec()
+                    }
+                } else {
+                    bytes.to_vec()
+                };
+
+                let _ = tokio::fs::create_dir_all(&cache_dir).await;
+                let _ = tokio::fs::write(&cache_path, &output_bytes).await;
+
+                return Ok((
+                    StatusCode::OK,
+                    [
+                        (header::CONTENT_TYPE, "image/webp"),
+                        (header::CACHE_CONTROL, "public, max-age=31536000, immutable"),
+                    ],
+                    output_bytes,
+                )
+                    .into_response());
+            }
+        }
+    }
+
+    // Fallback to small cover (inline to avoid async recursion)
+    let row = sqlx::query_as::<_, CoverRow2>("SELECT cover_filename FROM series WHERE slug = $1")
+        .bind(slug)
+        .fetch_optional(&state.db)
+        .await?;
+    let covers_dir_small = std::env::var("SERIES_COVERS_DIR")
+        .unwrap_or_else(|_| "data/series/covers-webp".to_string());
+    if let Some(filename) = row.and_then(|r| r.cover_filename) {
+        let path = std::path::Path::new(&covers_dir_small).join(format!("{filename}.webp"));
+        if path.exists()
+            && let Ok(bytes) = tokio::fs::read(&path).await
+        {
+            return Ok((
+                StatusCode::OK,
+                [
+                    (header::CONTENT_TYPE, "image/webp"),
+                    (header::CACHE_CONTROL, "public, max-age=31536000"),
+                ],
+                bytes,
+            )
+                .into_response());
+        }
+    }
+    // Tiny empty WebP placeholder
+    static PLACEHOLDER: &[u8] = &[
+        0x52, 0x49, 0x46, 0x46, 0x1a, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50, 0x56, 0x50, 0x38,
+        0x4c, 0x0d, 0x00, 0x00, 0x00, 0x2f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00,
+    ];
+    Ok((
+        StatusCode::OK,
+        [
+            (header::CONTENT_TYPE, "image/webp"),
+            (header::CACHE_CONTROL, "public, max-age=3600"),
+        ],
+        PLACEHOLDER.to_vec(),
+    )
+        .into_response())
+}
+
+#[derive(sqlx::FromRow)]
+struct CoverRow2 {
+    cover_filename: Option<String>,
+}
+
+/// GET /serialy-online/person/{filename} — serve person profile image from disk.
+pub async fn series_person_image(Path(filename): Path<String>) -> WebResult<Response> {
+    if !filename.ends_with(".webp") || filename.contains('/') || filename.contains("..") {
+        return Ok((StatusCode::NOT_FOUND, "Not found").into_response());
+    }
+    let dir = std::env::var("SERIES_PEOPLE_DIR")
+        .unwrap_or_else(|_| "data/series/people".to_string());
+    let path = std::path::Path::new(&dir).join(&filename);
+    if path.exists()
+        && let Ok(bytes) = tokio::fs::read(&path).await
+    {
+        return Ok((
+            StatusCode::OK,
+            [
+                (header::CONTENT_TYPE, "image/webp"),
+                (header::CACHE_CONTROL, "public, max-age=31536000, immutable"),
+            ],
+            bytes,
+        )
+            .into_response());
+    }
+    Ok((StatusCode::NOT_FOUND, "Not found").into_response())
+}
+
+/// GET /serialy-online/still/{filename} — serve episode still from disk.
+pub async fn series_episode_still(Path(filename): Path<String>) -> WebResult<Response> {
+    // Sanity-check filename: WebP only, no path traversal
+    if !filename.ends_with(".webp") || filename.contains('/') || filename.contains("..") {
+        return Ok((StatusCode::NOT_FOUND, "Not found").into_response());
+    }
+    let stills_dir = std::env::var("SERIES_STILLS_DIR")
+        .unwrap_or_else(|_| "data/series/episode-stills".to_string());
+    let path = std::path::Path::new(&stills_dir).join(&filename);
+    if path.exists()
+        && let Ok(bytes) = tokio::fs::read(&path).await
+    {
+        return Ok((
+            StatusCode::OK,
+            [
+                (header::CONTENT_TYPE, "image/webp"),
+                (header::CACHE_CONTROL, "public, max-age=31536000, immutable"),
+            ],
+            bytes,
+        )
+            .into_response());
+    }
+    Ok((StatusCode::NOT_FOUND, "Not found").into_response())
+}

--- a/cr-web/src/handlers/series.rs
+++ b/cr-web/src/handlers/series.rs
@@ -127,6 +127,7 @@ struct SeriesListTemplate {
     total_pages: i64,
     total_count: i64,
     current_genre: Option<GenreRow>,
+    #[allow(dead_code)]
     sort_key: String,
     query_string: String,
     search_query: Option<String>,
@@ -256,7 +257,11 @@ pub async fn series_list(
 
     let search_query = params.q.clone().and_then(|q| {
         let t = q.trim();
-        if t.is_empty() { None } else { Some(t.to_string()) }
+        if t.is_empty() {
+            None
+        } else {
+            Some(t.to_string())
+        }
     });
 
     let tmpl = SeriesListTemplate {
@@ -349,12 +354,11 @@ pub async fn series_resolve(
     }
 
     // Genre page?
-    let genre = sqlx::query_as::<_, GenreRow>(
-        "SELECT id, slug, name_cs FROM genres WHERE slug = $1"
-    )
-    .bind(&slug_raw)
-    .fetch_optional(&state.db)
-    .await?;
+    let genre =
+        sqlx::query_as::<_, GenreRow>("SELECT id, slug, name_cs FROM genres WHERE slug = $1")
+            .bind(&slug_raw)
+            .fetch_optional(&state.db)
+            .await?;
 
     if let Some(genre) = genre {
         return series_by_genre(state, genre, params).await;
@@ -406,11 +410,11 @@ pub async fn series_resolve(
     let mut seen_in_season: std::collections::HashSet<i16> = std::collections::HashSet::new();
 
     for ep in episodes {
-        if let Some(ref s) = current_season {
-            if s.number != ep.season {
-                seasons.push(current_season.take().unwrap());
-                seen_in_season.clear();
-            }
+        if let Some(ref s) = current_season
+            && s.number != ep.season
+        {
+            seasons.push(current_season.take().unwrap());
+            seen_in_season.clear();
         }
         if current_season.is_none() {
             current_season = Some(Season {
@@ -697,8 +701,8 @@ pub async fn series_cover(
         .await?;
 
     let cover_filename = row.and_then(|r| r.cover_filename);
-    let covers_dir =
-        std::env::var("SERIES_COVERS_DIR").unwrap_or_else(|_| "data/series/covers-webp".to_string());
+    let covers_dir = std::env::var("SERIES_COVERS_DIR")
+        .unwrap_or_else(|_| "data/series/covers-webp".to_string());
 
     if let Some(filename) = cover_filename {
         let path = std::path::Path::new(&covers_dir).join(format!("{filename}.webp"));
@@ -740,9 +744,7 @@ pub async fn series_cover_large(
     State(state): State<AppState>,
     Path(slug_webp): Path<String>,
 ) -> WebResult<Response> {
-    let slug = slug_webp
-        .strip_suffix("-large.webp")
-        .unwrap_or(&slug_webp);
+    let slug = slug_webp.strip_suffix("-large.webp").unwrap_or(&slug_webp);
 
     #[derive(sqlx::FromRow)]
     struct CoverRow {
@@ -804,10 +806,7 @@ pub async fn series_cover_large(
                 let output_bytes = if let Ok(img) = image::load_from_memory(&bytes) {
                     let mut buf = Vec::new();
                     let mut cursor = std::io::Cursor::new(&mut buf);
-                    if img
-                        .write_to(&mut cursor, image::ImageFormat::WebP)
-                        .is_ok()
-                    {
+                    if img.write_to(&mut cursor, image::ImageFormat::WebP).is_ok() {
                         buf
                     } else {
                         bytes.to_vec()
@@ -882,8 +881,8 @@ pub async fn series_person_image(Path(filename): Path<String>) -> WebResult<Resp
     if !filename.ends_with(".webp") || filename.contains('/') || filename.contains("..") {
         return Ok((StatusCode::NOT_FOUND, "Not found").into_response());
     }
-    let dir = std::env::var("SERIES_PEOPLE_DIR")
-        .unwrap_or_else(|_| "data/series/people".to_string());
+    let dir =
+        std::env::var("SERIES_PEOPLE_DIR").unwrap_or_else(|_| "data/series/people".to_string());
     let path = std::path::Path::new(&dir).join(&filename);
     if path.exists()
         && let Ok(bytes) = tokio::fs::read(&path).await

--- a/cr-web/src/main.rs
+++ b/cr-web/src/main.rs
@@ -212,7 +212,10 @@ async fn main() -> Result<()> {
             axum::routing::get(handlers::movies_api::movies_proxy_stream),
         )
         .route("/films/search", axum::routing::get(handlers::films_search))
-        .route("/series/search", axum::routing::get(handlers::series_search))
+        .route(
+            "/series/search",
+            axum::routing::get(handlers::series_search),
+        )
         .route(
             "/films/sktorrent-resolve",
             axum::routing::get(handlers::sktorrent_resolve),
@@ -246,7 +249,10 @@ async fn main() -> Result<()> {
             axum::routing::get(handlers::films_detail),
         )
         .route("/serialy-online", axum::routing::get(handlers::series_list))
-        .route("/serialy-online/", axum::routing::get(handlers::series_list))
+        .route(
+            "/serialy-online/",
+            axum::routing::get(handlers::series_list),
+        )
         .route(
             "/serialy-online/still/{filename}",
             axum::routing::get(handlers::series_episode_still),

--- a/cr-web/src/main.rs
+++ b/cr-web/src/main.rs
@@ -196,6 +196,10 @@ async fn main() -> Result<()> {
             axum::routing::get(handlers::movies_api::movies_thumb),
         )
         .route(
+            "/movies/subtitle",
+            axum::routing::get(handlers::movies_api::movies_subtitle),
+        )
+        .route(
             "/movies/filemoon-resolve",
             axum::routing::get(handlers::movies_api::filemoon_resolve),
         )
@@ -208,6 +212,7 @@ async fn main() -> Result<()> {
             axum::routing::get(handlers::movies_api::movies_proxy_stream),
         )
         .route("/films/search", axum::routing::get(handlers::films_search))
+        .route("/series/search", axum::routing::get(handlers::series_search))
         .route(
             "/films/sktorrent-resolve",
             axum::routing::get(handlers::sktorrent_resolve),
@@ -239,6 +244,32 @@ async fn main() -> Result<()> {
         .route(
             "/filmy-online/{slug}/",
             axum::routing::get(handlers::films_detail),
+        )
+        .route("/serialy-online", axum::routing::get(handlers::series_list))
+        .route("/serialy-online/", axum::routing::get(handlers::series_list))
+        .route(
+            "/serialy-online/still/{filename}",
+            axum::routing::get(handlers::series_episode_still),
+        )
+        .route(
+            "/serialy-online/person/{filename}",
+            axum::routing::get(handlers::series_person_image),
+        )
+        .route(
+            "/serialy-online/{slug}/{ep}",
+            axum::routing::get(handlers::episode_detail),
+        )
+        .route(
+            "/serialy-online/{slug}/{ep}/",
+            axum::routing::get(handlers::episode_detail),
+        )
+        .route(
+            "/serialy-online/{slug}",
+            axum::routing::get(handlers::series_resolve),
+        )
+        .route(
+            "/serialy-online/{slug}/",
+            axum::routing::get(handlers::series_resolve),
         )
         .route(
             "/filmy-a-serialy",

--- a/cr-web/templates/episode_detail.html
+++ b/cr-web/templates/episode_detail.html
@@ -1,0 +1,681 @@
+{% extends "base.html" %}
+
+{% block title %}{{ series.title }} — S{{ episode.season }}E{{ episode.episode }}{% match episode.episode_name %}{% when Some with (n) %} {{ n }}{% when None %}{% endmatch %} — seriál online{% endblock %}
+
+{% block meta_description %}{% match episode.overview %}{% when Some with (d) %}{{ d }}{% when None %}{{ series.title }} S{{ episode.season }}E{{ episode.episode }} — sledujte online{% endmatch %}{% endblock %}
+
+{% block og_title %}{{ series.title }} — S{{ episode.season }}E{{ episode.episode }}{% match episode.episode_name %}{% when Some with (n) %} {{ n }}{% when None %}{% endmatch %}{% endblock %}
+{% block og_description %}{% match episode.overview %}{% when Some with (d) %}{{ d }}{% when None %}{{ series.title }} — epizoda {{ episode.season }}x{{ episode.episode }}{% endmatch %}{% endblock %}
+{% block og_image %}{% match episode.still_filename %}{% when Some with (f) %}https://ceskarepublika.wiki/serialy-online/still/{{ f }}{% when None %}{% match series.cover_filename %}{% when Some with (c) %}https://ceskarepublika.wiki/serialy-online/{{ series.slug }}.webp{% when None %}https://ceskarepublika.wiki/static/img/og-filmy-a-serialy-v6.png{% endmatch %}{% endmatch %}{% endblock %}
+{% block og_type %}video.episode{% endblock %}
+
+{% block leaflet %}{% endblock %}
+
+{% block head %}
+<link rel="icon" type="image/svg+xml" href="/static/img/logo-filmy-a-serialy.svg?v=6">
+<script src="https://cdn.jsdelivr.net/npm/hls.js@1.5.8/dist/hls.min.js"></script>
+<meta property="og:url" content="https://ceskarepublika.wiki/serialy-online/{{ series.slug }}/{{ episode.season }}x{{ episode.episode }}/">
+{% endblock %}
+
+{% block header_left %}
+<div class="logo-group" style="display:flex;align-items:center;gap:0.5rem;">
+    <a href="/serialy-online/" style="display:flex;align-items:center;text-decoration:none;" alt="Seriály online" title="Seriály online">
+        <img src="/static/img/logo-filmy-a-serialy.svg?v=6" alt="Logo Seriály online" title="Seriály online" class="header-emblem">
+    </a>
+    <h1>{{ series.title }}</h1>
+</div>
+{% endblock %}
+
+{% block header_search %}
+<div class="search-container" id="header-search-box">
+    <input type="text" id="series-search" class="search-input" placeholder="Hledat seriál..." autocomplete="off">
+    <button class="search-btn" onclick="doSearch()" alt="Hledat" title="Hledat">Hledat</button>
+    <div id="search-results" class="search-dropdown"></div>
+</div>
+{% endblock %}
+
+{% block header_right %}<div class="context-emblem"></div>{% endblock %}
+
+{% block content %}
+<main class="episode-detail-page">
+    <nav class="breadcrumb">
+        <a href="/" alt="Česká republika" title="Česká republika">Česká republika</a>
+        <span>›</span> <a href="/serialy-online/" alt="Seriály online" title="Seriály online">Seriály online</a>
+        <span>›</span> <a href="/serialy-online/{{ series.slug }}/" alt="{{ series.title }}" title="{{ series.title }}">{{ series.title }}</a>
+        <span>›</span> <span>S{{ episode.season }}E{{ episode.episode }}</span>
+    </nav>
+
+    <div class="player-section">
+        <div class="source-tabs" id="source-tabs">
+            <button class="source-tab active" id="tab-source-1" onclick="switchToSource1()">Zdroj 1</button>
+        </div>
+        <div class="player-panel">
+            <video id="series-player" controls preload="metadata" width="100%"
+                   {% match episode.still_filename %}{% when Some with (f) %}poster="/serialy-online/still/{{ f }}"{% when None %}{% match series.cover_filename %}{% when Some with (c) %}poster="/serialy-online/{{ series.slug }}-large.webp"{% when None %}{% endmatch %}{% endmatch %}></video>
+            <div class="player-controls">
+                <div class="player-quality" id="source-quality"></div>
+                <div id="subtitle-controls" class="subtitle-controls" style="display:none;">
+                    <span class="sub-label">Velikost titulků</span>
+                    <select id="sub-size-select" class="sub-select" onchange="setSubSize(this.value)" title="Velikost titulků">
+                        <option value="14">14 px</option>
+                        <option value="16">16 px</option>
+                        <option value="18">18 px</option>
+                        <option value="20" selected>20 px</option>
+                        <option value="24">24 px</option>
+                        <option value="28">28 px</option>
+                        <option value="32">32 px</option>
+                        <option value="36">36 px</option>
+                        <option value="40">40 px</option>
+                    </select>
+                </div>
+                <div id="source-status" class="source-status"></div>
+            </div>
+        </div>
+        <div class="prehrajto-section" id="prehrajto-section" style="display:none;">
+            <h3>Další zdroje</h3>
+            <div id="prehrajto-results" class="prehrajto-results"></div>
+            <button type="button" id="prehrajto-more" class="prehrajto-more" style="display:none;" alt="Zobrazit další zdroje" title="Zobrazit další zdroje">Zobrazit další zdroje</button>
+        </div>
+    </div>
+
+    <div class="episode-info">
+        <h2>S{{ episode.season }}E{{ episode.episode }}{% match episode.episode_name %}{% when Some with (n) %} — {{ n }}{% when None %}{% endmatch %}</h2>
+        <div class="episode-meta">
+            {% match episode.air_date %}{% when Some with (d) %}<span class="meta-pill">📅 {{ d }}</span>{% when None %}{% endmatch %}
+            {% match episode.runtime %}{% when Some with (r) %}<span class="meta-pill">⏱ {{ r }} min</span>{% when None %}{% endmatch %}
+        </div>
+        {% match episode.overview %}{% when Some with (o) %}<p class="episode-overview">{{ o }}</p>{% when None %}{% endmatch %}
+
+        {% if !directors.is_empty() %}
+        <div class="crew-row">
+            <span class="crew-label">Režie:</span>
+            {% for p in directors %}<span class="crew-name">{{ p.name }}</span>{% endfor %}
+        </div>
+        {% endif %}
+        {% if !writers.is_empty() %}
+        <div class="crew-row">
+            <span class="crew-label">Scénář:</span>
+            {% for p in writers %}<span class="crew-name">{{ p.name }}</span>{% endfor %}
+        </div>
+        {% endif %}
+    </div>
+
+    <div class="episode-nav">
+        {% match prev_episode %}
+        {% when Some with (p) %}
+        <a class="nav-prev" href="/serialy-online/{{ series.slug }}/{{ p.season }}x{{ p.episode }}/"
+           alt="Předchozí: S{{ p.season }}E{{ p.episode }}" title="Předchozí: S{{ p.season }}E{{ p.episode }}{% match p.episode_name %}{% when Some with (n) %} — {{ n }}{% when None %}{% endmatch %}">
+           ← S{{ p.season }}E{{ p.episode }}
+        </a>
+        {% when None %}<span></span>{% endmatch %}
+        <a class="nav-back" href="/serialy-online/{{ series.slug }}/" alt="Zpět na seznam epizod" title="Zpět na seznam epizod">Všechny epizody</a>
+        {% match next_episode %}
+        {% when Some with (n) %}
+        <a class="nav-next" href="/serialy-online/{{ series.slug }}/{{ n.season }}x{{ n.episode }}/"
+           alt="Další: S{{ n.season }}E{{ n.episode }}" title="Další: S{{ n.season }}E{{ n.episode }}{% match n.episode_name %}{% when Some with (nm) %} — {{ nm }}{% when None %}{% endmatch %}">
+           S{{ n.season }}E{{ n.episode }} →
+        </a>
+        {% when None %}<span></span>{% endmatch %}
+    </div>
+</main>
+
+<style>
+.episode-detail-page { max-width: 960px; margin: 0 auto; padding: 1rem; }
+.breadcrumb { font-size: 0.85rem; color: #888; margin-bottom: 1.2rem; }
+.breadcrumb a { color: #11457E; text-decoration: none; }
+
+/* Search dropdown */
+#header-search-box { position: relative; overflow: visible !important; }
+.search-dropdown { display: none; position: absolute; top: calc(100% + 4px); left: 0; right: 0; background: white; border: 1px solid #ddd; border-radius: 12px; box-shadow: 0 8px 24px rgba(0,0,0,0.18); z-index: 200; max-height: 420px; overflow-y: auto; }
+.search-dropdown.open { display: block; }
+.search-item { display: flex; align-items: center; gap: 0.7rem; padding: 0.5rem 0.8rem; text-decoration: none; color: inherit; border-bottom: 1px solid #f0f0f0; }
+.search-item:hover { background: #f5f5f5; }
+.search-item img { width: 40px; height: 60px; object-fit: cover; border-radius: 4px; }
+.search-item .si-placeholder { width: 40px; height: 60px; background: #eee; border-radius: 4px; }
+.search-item .si-info { flex: 1; min-width: 0; }
+.search-item .si-title { font-weight: 500; display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.search-item .si-meta { font-size: 0.8rem; color: #888; }
+
+/* Player */
+.player-section { margin-bottom: 1.5rem; }
+.source-tabs { display: flex; gap: 0.3rem; background: #1a1a1a; padding: 0.4rem 0.6rem; border-radius: 10px 10px 0 0; }
+.source-tab { background: #333; color: #ccc; border: none; padding: 0.35rem 0.8rem; border-radius: 4px; font-size: 0.8rem; cursor: pointer; transition: background 0.15s; }
+.source-tab:hover { background: #444; }
+.source-tab.active { background: #D7141A; color: white; }
+.player-panel { background: #000; border-radius: 0 0 10px 10px; overflow: hidden; }
+.player-panel video { display: block; width: 100%; max-height: 540px; background: #000; }
+.player-controls { display: flex; align-items: center; flex-wrap: wrap; gap: 0.5rem; padding: 0.4rem 0.6rem; background: #111; }
+.player-quality { display: flex; gap: 0.3rem; }
+.quality-btn { background: #333; color: #ccc; border: none; padding: 0.25rem 0.8rem; border-radius: 4px; cursor: pointer; font-size: 0.8rem; }
+.quality-btn.active { background: #D7141A; color: white; }
+.subtitle-controls { display: flex; align-items: center; gap: 0.4rem; margin-left: 0.3rem; }
+.sub-label { color: #bbb; font-size: 0.78rem; }
+.sub-select { background: #333; color: #eee; border: 1px solid #444; border-radius: 4px; padding: 0.2rem 0.3rem; font-size: 0.78rem; cursor: pointer; }
+.source-status { font-size: 0.78rem; color: #888; margin-left: auto; }
+video::cue { background: rgba(0,0,0,0.7); color: white; font-family: sans-serif; }
+
+/* Additional sources list */
+.prehrajto-section { margin-top: 1rem; padding: 0.8rem; background: #f8f8f8; border-radius: 8px; }
+.prehrajto-section h3 { font-size: 1rem; margin: 0 0 0.6rem; color: #555; }
+.prehrajto-results { display: flex; flex-direction: column; gap: 0.4rem; }
+.prehrajto-item { display: flex; align-items: center; gap: 0.6rem; padding: 0.5rem; background: white; border: 1px solid #eee; border-radius: 6px; cursor: pointer; transition: background 0.15s, border-color 0.15s; position: relative; width: 100%; text-align: left; font: inherit; color: inherit; }
+.prehrajto-item:hover { background: #f0f0f0; }
+.prehrajto-item.loading { opacity: 0.5; cursor: wait; }
+.prehrajto-item.active { background: #C5A059; border-color: #C5A059; color: white; }
+.prehrajto-item.active .pt-title { color: white; }
+.prehrajto-item .play-indicator { display: none; flex-shrink: 0; width: 22px; height: 22px; align-items: center; justify-content: center; background: rgba(255,255,255,0.2); border-radius: 50%; color: white; font-size: 0.7rem; }
+.prehrajto-item.active .play-indicator { display: inline-flex; }
+.prehrajto-item img { width: 60px; height: 40px; object-fit: cover; border-radius: 3px; }
+.prehrajto-more { margin-top: 0.5rem; width: 100%; padding: 0.5rem 0.8rem; background: #f1f5f9; border: 1px solid #ddd; border-radius: 6px; color: #11457E; font-size: 0.85rem; font-weight: 600; cursor: pointer; transition: background 0.15s; }
+.prehrajto-more:hover { background: #e2e8f0; }
+.pt-info { flex: 1; min-width: 0; }
+.pt-title { font-size: 0.85rem; font-weight: 500; display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: inherit; }
+.pt-loading { color: #888; font-size: 0.85rem; padding: 0.5rem; text-align: center; }
+.cc-badge-sm { display: inline-block; padding: 0.1rem 0.4rem; margin-left: 0.3rem; background: #4ade80; color: #003c1c; border-radius: 3px; font-size: 0.7rem; font-weight: 700; letter-spacing: 0.03em; }
+.prehrajto-item.active .cc-badge-sm { background: rgba(255,255,255,0.25); color: white; }
+.pt-badge { display: inline-block; padding: 0.1rem 0.4rem; border-radius: 3px; font-size: 0.7rem; font-weight: 700; margin-left: 0.3rem; }
+.pt-badge.direct { background: #27ae60; color: white; }
+.pt-badge.proxy { background: #f39c12; color: white; }
+.pt-badge.quality-hd { background: #1e40af; color: white; }
+.pt-badge.quality-sd { background: #92400e; color: white; }
+.pt-badge.quality-low { background: #6b7280; color: white; }
+.pt-badge-dur { display: inline-block; padding: 0.1rem 0.4rem; margin-left: 0.3rem; font-size: 0.7rem; color: #888; }
+.prehrajto-item.active .pt-badge { background: rgba(255,255,255,0.25); color: white; }
+.prehrajto-item.active .pt-badge-dur { color: rgba(255,255,255,0.85); }
+
+/* Episode info */
+.episode-info { margin: 1.5rem 0; }
+.episode-info h2 { margin: 0 0 0.5rem; font-size: 1.3rem; }
+.episode-meta { display: flex; gap: 0.5rem; margin-bottom: 0.8rem; flex-wrap: wrap; }
+.meta-pill { padding: 0.2rem 0.6rem; background: #f1f5f9; border-radius: 999px; font-size: 0.82rem; color: #555; }
+.episode-overview { line-height: 1.6; color: #333; margin-bottom: 1rem; }
+.crew-row { margin-bottom: 0.4rem; font-size: 0.9rem; }
+.crew-label { font-weight: 600; color: #555; margin-right: 0.3rem; }
+.crew-name { display: inline-block; padding: 0.15rem 0.6rem; background: #f1f5f9; color: #11457E; border-radius: 999px; font-size: 0.82rem; margin: 0 0.2rem 0.2rem 0; }
+
+/* Navigation */
+.episode-nav { display: grid; grid-template-columns: 1fr auto 1fr; gap: 0.5rem; align-items: center; margin: 1.5rem 0; }
+.episode-nav a { padding: 0.5rem 0.9rem; border-radius: 6px; background: #f1f5f9; color: #11457E; text-decoration: none; font-size: 0.85rem; font-weight: 600; transition: background 0.15s, color 0.15s; }
+.episode-nav a:hover { background: #11457E; color: white; }
+.episode-nav .nav-prev { text-align: left; justify-self: start; }
+.episode-nav .nav-next { text-align: right; justify-self: end; }
+</style>
+
+<script>
+var seriesTitle = "{{ series.title }}";
+var initialSeason = {{ episode.season }};
+var initialEpisode = {{ episode.episode }};
+var initialVideoId = {{ episode.sktorrent_video_id.unwrap_or(0) }};
+var initialCdn = {{ episode.sktorrent_cdn.unwrap_or(0) }};
+var initialQualities = "{% match episode.sktorrent_qualities %}{% when Some with (q) %}{{ q }}{% when None %}480p{% endmatch %}".split(",").filter(function(q) { return q.match(/^\d+p$/); });
+// Cached Přehraj.to URL for this episode (stable across searches).
+// Used as primary Zdroj 1 when SK Torrent is not available.
+var prehrajtoUrl = {% match episode.prehrajto_url %}{% when Some with (u) %}"{{ u }}"{% when None %}null{% endmatch %};
+var prehrajtoHasDub  = {{ episode.prehrajto_has_dub }};
+var prehrajtoHasSubs = {{ episode.prehrajto_has_subs }};
+
+// State — same shape as series_detail.html player
+var state = { source1: null, source2: null, activeSource: 1, activeEpisodeBtn: null };
+var resolvedSources = {};
+var currentPrehrajto = { all: [], visibleCount: 3 };
+var _subPoll = null;
+
+function initPlayer() {
+    if (initialVideoId) {
+        // Primary: SK Torrent (has quality options)
+        var qualities = initialQualities.length ? initialQualities : ['480p'];
+        var sources = qualities.map(function(q) {
+            return {
+                url: 'https://online' + initialCdn + '.sktorrent.eu/media/videos//h264/' + initialVideoId + '_' + q + '.mp4',
+                quality: q,
+                res: parseInt(q, 10),
+            };
+        });
+        sources.sort(function(a, b) { return b.res - a.res; });
+        state.source1 = {
+            episode: { season: initialSeason, episode: initialEpisode },
+            sources: sources,
+            currentIndex: 0,
+            videoId: initialVideoId,
+        };
+        switchToSource1();
+    } else if (prehrajtoUrl) {
+        // Fallback: cached Přehraj.to URL. Resolve on the fly, then play.
+        document.getElementById('source-status').textContent = 'Načítání Přehraj.to...';
+        fetch('/api/movies/video-url?url=' + encodeURIComponent(prehrajtoUrl))
+            .then(function(r) { return r.json(); })
+            .then(function(data) {
+                if (!data.success || !data.video_url) {
+                    document.getElementById('source-status').textContent = 'Zdroj nedostupný';
+                    return;
+                }
+                var url = data.video_url.replace(/&amp;/g, '&');
+                var isHls = url.indexOf('.m3u8') !== -1;
+                state.source1 = {
+                    episode: { season: initialSeason, episode: initialEpisode },
+                    prehrajto: true,
+                    url: url,
+                    isHls: isHls,
+                    subtitles: data.subtitles || [],
+                };
+                switchToSource1Prehrajto();
+            })
+            .catch(function() {
+                document.getElementById('source-status').textContent = 'Zdroj nedostupný';
+            });
+    } else {
+        document.getElementById('source-status').textContent = 'Zdroj nedostupný';
+    }
+    loadPrehrajtoForEpisode(initialSeason, initialEpisode);
+}
+
+/* Variant of switchToSource1 for cached Přehraj.to primary source */
+function switchToSource1Prehrajto() {
+    if (!state.source1 || !state.source1.prehrajto) return;
+    state.activeSource = 1;
+    setActiveTab(1);
+    var qualDiv = document.getElementById('source-quality');
+    qualDiv.innerHTML = '';
+    qualDiv.style.display = 'none';
+    playUrl(state.source1.url, state.source1.isHls ? 'hls' : 'mp4');
+    document.getElementById('source-status').textContent = 'S' + state.source1.episode.season + 'E' + state.source1.episode.episode;
+    applySubtitles(state.source1.subtitles || []);
+    document.querySelectorAll('.prehrajto-item.active').forEach(function(el) { el.classList.remove('active'); });
+}
+
+function switchToSource1() {
+    if (!state.source1) return;
+    if (state.source1.prehrajto) {
+        switchToSource1Prehrajto();
+        return;
+    }
+    state.activeSource = 1;
+    setActiveTab(1);
+    var subCtrl = document.getElementById('subtitle-controls');
+    if (subCtrl) subCtrl.style.display = 'none';
+    var player = document.getElementById('series-player');
+    player.querySelectorAll('track').forEach(function(t) { t.remove(); });
+    document.querySelectorAll('.prehrajto-item.active').forEach(function(el) { el.classList.remove('active'); });
+    renderQualityButtons1();
+    playQuality1(state.source1.currentIndex, true);
+}
+
+function renderQualityButtons1() {
+    var qualDiv = document.getElementById('source-quality');
+    qualDiv.innerHTML = '';
+    state.source1.sources.forEach(function(s, i) {
+        var qBtn = document.createElement('button');
+        qBtn.className = 'quality-btn' + (i === state.source1.currentIndex ? ' active' : '');
+        qBtn.textContent = s.quality;
+        qBtn.onclick = function() { playQuality1(i, true); };
+        qualDiv.appendChild(qBtn);
+    });
+    qualDiv.style.display = '';
+}
+
+function playQuality1(index, doPlay) {
+    if (!state.source1) return;
+    var src = state.source1.sources[index];
+    state.source1.currentIndex = index;
+    var player = document.getElementById('series-player');
+    if (window._hls) { window._hls.destroy(); window._hls = null; }
+    player.src = src.url;
+    player.dataset.fallbackVideoId = state.source1.videoId;
+    document.querySelectorAll('#source-quality .quality-btn').forEach(function(b, i) {
+        b.classList.toggle('active', i === index);
+    });
+    document.getElementById('source-status').textContent = 'S' + state.source1.episode.season + 'E' + state.source1.episode.episode;
+    if (doPlay) {
+        player.play().catch(function() {
+            // Browser blocked autoplay with sound on fresh page load — fall back
+            // to muted autoplay, then unmute on the very next user interaction
+            // (click anywhere, keypress, etc.) so the viewer gets sound as soon
+            // as they touch the page instead of hunting for the volume icon.
+            player.muted = true;
+            player.play().catch(function() {});
+            unmuteOnFirstInteraction(player);
+        });
+    }
+}
+
+function unmuteOnFirstInteraction(player) {
+    if (player._unmuteArmed) return;
+    player._unmuteArmed = true;
+    var handler = function() {
+        if (player.muted) {
+            player.muted = false;
+            if (player.volume === 0) player.volume = 1;
+        }
+        document.removeEventListener('click', handler, true);
+        document.removeEventListener('keydown', handler, true);
+        document.removeEventListener('touchstart', handler, true);
+        player._unmuteArmed = false;
+    };
+    document.addEventListener('click', handler, true);
+    document.addEventListener('keydown', handler, true);
+    document.addEventListener('touchstart', handler, true);
+}
+
+function switchToSource2() {
+    if (!state.source2) return;
+    state.activeSource = 2;
+    setActiveTab(2);
+    var qualDiv = document.getElementById('source-quality');
+    qualDiv.innerHTML = '';
+    qualDiv.style.display = 'none';
+    playUrl(state.source2.url, state.source2.isHls ? 'hls' : 'mp4');
+    document.getElementById('source-status').textContent = state.source2.label || 'Externí zdroj';
+    applySubtitles(state.source2.subtitles || []);
+    document.querySelectorAll('.prehrajto-item.active').forEach(function(el) { el.classList.remove('active'); });
+    if (state.source2.activeItem) state.source2.activeItem.classList.add('active');
+}
+
+function setActiveTab(n) {
+    var t1 = document.getElementById('tab-source-1');
+    var t2 = document.getElementById('tab-source-2');
+    if (t1) t1.classList.toggle('active', n === 1);
+    if (t2) t2.classList.toggle('active', n === 2);
+}
+
+function ensureSource2Tab() {
+    if (document.getElementById('tab-source-2')) return;
+    var tabs = document.getElementById('source-tabs');
+    var btn = document.createElement('button');
+    btn.className = 'source-tab';
+    btn.id = 'tab-source-2';
+    btn.textContent = 'Zdroj 2';
+    btn.onclick = switchToSource2;
+    tabs.appendChild(btn);
+}
+
+function loadPrehrajtoForEpisode(season, episode) {
+    var section = document.getElementById('prehrajto-section');
+    var container = document.getElementById('prehrajto-results');
+    if (!section || !container) return;
+    section.style.display = '';
+    container.innerHTML = '<div class="pt-loading">Hledám další zdroje...</div>';
+    var sStr = season < 10 ? '0' + season : '' + season;
+    var eStr = episode < 10 ? '0' + episode : '' + episode;
+    var query = seriesTitle + ' S' + sStr + 'E' + eStr;
+
+    fetch('/api/movies/search?q=' + encodeURIComponent(query))
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+            container.innerHTML = '';
+            var moreBtn = document.getElementById('prehrajto-more');
+            if (moreBtn) moreBtn.style.display = 'none';
+            if (!data.success || !data.movies || !data.movies.length) {
+                container.innerHTML = '<div class="pt-loading">Nic nenalezeno</div>';
+                return;
+            }
+            currentPrehrajto.all = data.movies.slice(0, 15);
+            currentPrehrajto.visibleCount = 3;
+            renderPrehrajto();
+            if (currentPrehrajto.all.length > currentPrehrajto.visibleCount && moreBtn) {
+                moreBtn.style.display = '';
+                moreBtn.textContent = 'Zobrazit další zdroje (' + (currentPrehrajto.all.length - currentPrehrajto.visibleCount) + ')';
+                moreBtn.onclick = function() {
+                    currentPrehrajto.visibleCount = currentPrehrajto.all.length;
+                    renderPrehrajto();
+                    moreBtn.style.display = 'none';
+                    validatePrehrajto(currentPrehrajto.all);
+                };
+            }
+            validatePrehrajto(currentPrehrajto.all.slice(0, currentPrehrajto.visibleCount));
+        })
+        .catch(function() { container.innerHTML = '<div class="pt-loading">Chyba při hledání</div>'; });
+}
+
+function buildPrehrajtoItem(movie) {
+    var item = document.createElement('button');
+    item.type = 'button';
+    item.className = 'prehrajto-item';
+    item.dataset.movieUrl = movie.url;
+    var cached = resolvedSources[movie.url];
+    item.dataset.height = cached && cached.height ? cached.height : 0;
+    var year = movie.year ? ' (' + movie.year + ')' : '';
+    var tooltip = (movie.title || 'Další zdroj') + year;
+    item.title = tooltip;
+    item.setAttribute('alt', tooltip);
+    item.onclick = function() { playPrehrajtoEpisode(movie, item); };
+    var thumb = movie.thumbnail
+        ? '<img src="/api/movies/thumb?url=' + encodeURIComponent(movie.thumbnail) + '" alt="' + (movie.title || 'Náhled') + '" title="' + (movie.title || '') + '">'
+        : '';
+    var badges = '';
+    if (cached) {
+        badges += cached.isDirect
+            ? '<span class="pt-badge direct" title="Přímý zdroj">Přímý</span>'
+            : '<span class="pt-badge proxy" title="Přes proxy">Proxy</span>';
+        // Real video resolution from prehraj.to microdata (not the filename —
+        // "1080p" in a candidate title is often a lie). Same logic as film_detail.
+        if (cached.height) {
+            var qCls = cached.height >= 1080 ? 'quality-hd' : (cached.height >= 720 ? 'quality-sd' : 'quality-low');
+            badges += '<span class="pt-badge ' + qCls + '" title="Skutečné rozlišení streamu">' + cached.height + 'p</span>';
+        }
+        if (cached.subtitles && cached.subtitles.length) badges += '<span class="cc-badge-sm" title="České titulky dostupné">CC</span>';
+        if (cached.duration_sec) {
+            var mm = Math.round(cached.duration_sec / 60);
+            badges += '<span class="pt-badge-dur" title="Délka videa">' + mm + ' min</span>';
+        }
+    }
+    item.innerHTML = thumb
+        + '<div class="pt-info"><span class="pt-title">' + (movie.title || '') + year + badges + '</span></div>'
+        + '<span class="play-indicator">▶</span>';
+    return item;
+}
+
+function renderPrehrajto() {
+    var container = document.getElementById('prehrajto-results');
+    if (!container) return;
+    var all = currentPrehrajto.all.slice();
+    // Primary key: direct > proxy > not-yet-validated.
+    // Secondary key (within each group): height DESC so 1080p > 720p > 480p > 304p.
+    all.sort(function(a, b) {
+        var ra = resolvedSources[a.url]; var rb = resolvedSources[b.url];
+        var ga = ra ? (ra.isDirect ? 0 : 1) : 2;
+        var gb = rb ? (rb.isDirect ? 0 : 1) : 2;
+        if (ga !== gb) return ga - gb;
+        var ha = ra && ra.height ? ra.height : 0;
+        var hb = rb && rb.height ? rb.height : 0;
+        return hb - ha;
+    });
+    container.innerHTML = '';
+    all.slice(0, currentPrehrajto.visibleCount).forEach(function(movie) {
+        container.appendChild(buildPrehrajtoItem(movie));
+    });
+    if (state.source2 && state.source2.movie) {
+        var it = container.querySelector('.prehrajto-item[data-movie-url="' + state.source2.movie.url.replace(/"/g, '\\"') + '"]');
+        if (it) { it.classList.add('active'); state.source2.activeItem = it; }
+    }
+}
+
+function validatePrehrajto(movies) {
+    movies.forEach(function(movie) {
+        if (resolvedSources[movie.url]) return;
+        fetch('/api/movies/validate?url=' + encodeURIComponent(movie.url))
+            .then(function(r) { return r.json(); })
+            .then(function(vdata) {
+                var isDirect = !!vdata.valid;
+                var height = vdata.height || null;
+                var duration_sec = vdata.duration_sec || null;
+                return fetch('/api/movies/video-url?url=' + encodeURIComponent(movie.url))
+                    .then(function(r) { return r.json(); })
+                    .then(function(data) {
+                        if (!data.success || !data.video_url) return;
+                        resolvedSources[movie.url] = {
+                            video_url: data.video_url.replace(/&amp;/g, '&'),
+                            subtitles: data.subtitles || [],
+                            isDirect: isDirect,
+                            height: height,
+                            duration_sec: duration_sec,
+                        };
+                        renderPrehrajto();
+                    });
+            })
+            .catch(function() {});
+    });
+}
+
+function playPrehrajtoEpisode(movie, item) {
+    var player = document.getElementById('series-player');
+    var status = document.getElementById('source-status');
+    if (!player) return;
+    document.getElementById('player-section') && document.querySelector('.player-section').scrollIntoView({ behavior: 'smooth', block: 'start' });
+
+    function useResolved(resolved) {
+        var url = resolved.video_url;
+        var isHls = url.indexOf('.m3u8') !== -1;
+        state.source2 = {
+            movie: movie, url: url, isHls: isHls,
+            subtitles: resolved.subtitles || [], activeItem: item, label: movie.title || 'Externí zdroj',
+        };
+        ensureSource2Tab();
+        switchToSource2();
+    }
+    var cached = resolvedSources[movie.url];
+    if (cached) { useResolved(cached); return; }
+
+    item.classList.add('loading');
+    if (status) status.textContent = 'Načítání...';
+    fetch('/api/movies/video-url?url=' + encodeURIComponent(movie.url))
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+            item.classList.remove('loading');
+            if (!data.success || !data.video_url) { if (status) status.textContent = 'Zdroj nedostupný'; return; }
+            var resolved = { video_url: data.video_url.replace(/&amp;/g, '&'), subtitles: data.subtitles || [] };
+            resolvedSources[movie.url] = resolved;
+            useResolved(resolved);
+        })
+        .catch(function(e) { item.classList.remove('loading'); if (status) status.textContent = 'Chyba: ' + e.message; });
+}
+
+function playUrl(url, format) {
+    var player = document.getElementById('series-player');
+    if (window._hls) { window._hls.destroy(); window._hls = null; }
+    if (format === 'hls' && window.Hls && Hls.isSupported()) {
+        var hls = new Hls(); hls.loadSource(url); hls.attachMedia(player);
+        hls.on(Hls.Events.MANIFEST_PARSED, function() { player.play().catch(function(){}); });
+        window._hls = hls;
+    } else {
+        player.src = url; player.play().catch(function(){});
+    }
+}
+
+function applySubtitles(subtitles) {
+    var player = document.getElementById('series-player');
+    player.querySelectorAll('track').forEach(function(t) { t.remove(); });
+    if (!subtitles || !subtitles.length) {
+        var c0 = document.getElementById('subtitle-controls');
+        if (c0) c0.style.display = 'none';
+        if (_subPoll) { clearInterval(_subPoll); _subPoll = null; }
+        return;
+    }
+    subtitles.forEach(function(sub) {
+        var track = document.createElement('track');
+        track.kind = 'subtitles';
+        track.label = sub.label || (sub.lang || '').toUpperCase();
+        track.srclang = sub.lang || '';
+        track.src = '/api/movies/subtitle?url=' + encodeURIComponent(sub.url);
+        if (sub.lang === 'cze' || sub.lang === 'cs') track.default = true;
+        player.appendChild(track);
+    });
+    var tt = player.textTracks;
+    var cz = false;
+    for (var i = 0; i < tt.length; i++) {
+        if (!cz && (tt[i].language === 'cze' || tt[i].language === 'cs')) { tt[i].mode = 'showing'; cz = true; }
+        else tt[i].mode = 'hidden';
+    }
+    if (!cz && tt.length > 0) tt[0].mode = 'showing';
+    setSubSize(document.getElementById('sub-size-select').value || 20);
+    var controls = document.getElementById('subtitle-controls');
+    if (controls) {
+        function update() {
+            var any = false;
+            for (var j = 0; j < tt.length; j++) if (tt[j].mode === 'showing') { any = true; break; }
+            controls.style.display = any ? 'flex' : 'none';
+        }
+        for (var k = 0; k < tt.length; k++) tt[k].addEventListener('cuechange', update);
+        if (_subPoll) clearInterval(_subPoll);
+        _subPoll = setInterval(update, 1000);
+        update();
+    }
+}
+
+function setSubSize(px) {
+    var style = document.getElementById('sub-cue-style');
+    if (!style) { style = document.createElement('style'); style.id = 'sub-cue-style'; document.head.appendChild(style); }
+    style.textContent = 'video::cue { font-size: ' + px + 'px !important; }';
+}
+
+/* SK Torrent CDN fallback */
+(function() {
+    var player = document.getElementById('series-player');
+    var tried = false;
+    player.addEventListener('error', function() {
+        if (tried || state.activeSource !== 1) return;
+        var vid = player.dataset.fallbackVideoId;
+        if (!vid || !player.src || player.src.indexOf('sktorrent.eu') === -1) return;
+        tried = true;
+        document.getElementById('source-status').textContent = 'Hledám aktuální zdroj...';
+        fetch('/api/films/sktorrent-resolve?video_id=' + vid)
+            .then(function(r) { return r.json(); })
+            .then(function(data) {
+                if (!data.sources || !data.sources.length) {
+                    document.getElementById('source-status').textContent = 'Zdroj nedostupný';
+                    return;
+                }
+                var fresh = data.sources.map(function(s) { return { url: s.url, quality: s.quality, res: s.res }; });
+                fresh.sort(function(a, b) { return b.res - a.res; });
+                state.source1.sources = fresh;
+                state.source1.currentIndex = 0;
+                renderQualityButtons1();
+                playQuality1(0, true);
+                setTimeout(function() { tried = false; }, 5000);
+            })
+            .catch(function() { document.getElementById('source-status').textContent = 'Chyba obnovy zdroje'; });
+    }, true);
+})();
+
+/* Header search autocomplete */
+function doSearch() {
+    var q = document.getElementById('series-search').value.trim();
+    if (q.length >= 2) window.location = '/serialy-online/?q=' + encodeURIComponent(q);
+}
+(function() {
+    var input = document.getElementById('series-search');
+    var dd = document.getElementById('search-results');
+    var timer = null;
+    if (!input || !dd) return;
+    input.addEventListener('input', function() {
+        clearTimeout(timer);
+        var q = this.value.trim();
+        if (q.length < 2) { dd.classList.remove('open'); return; }
+        timer = setTimeout(function() {
+            fetch('/api/series/search?q=' + encodeURIComponent(q))
+                .then(function(r) { return r.json(); })
+                .then(function(results) {
+                    if (!results.length) { dd.innerHTML = '<div style="padding:0.8rem;color:#888;text-align:center">Nic nenalezeno</div>'; }
+                    else {
+                        dd.innerHTML = results.map(function(r) {
+                            var cover = r.cover
+                                ? '<img src="/serialy-online/' + r.slug + '.webp" alt="' + r.title + '" title="' + r.title + '">'
+                                : '<div class="si-placeholder"></div>';
+                            var yr = r.year ? ' (' + r.year + ')' : '';
+                            var rat = r.imdb_rating ? ' — IMDB ' + r.imdb_rating : '';
+                            return '<a href="/serialy-online/' + r.slug + '/" class="search-item" alt="' + r.title + '" title="' + r.title + '">'
+                                + cover + '<div class="si-info"><span class="si-title">' + r.title + yr + '</span>'
+                                + '<span class="si-meta">' + rat + '</span></div></a>';
+                        }).join('');
+                    }
+                    dd.classList.add('open');
+                })
+                .catch(function() { dd.classList.remove('open'); });
+        }, 200);
+    });
+    document.addEventListener('click', function(e) { if (!e.target.closest('#header-search-box')) dd.classList.remove('open'); });
+    input.addEventListener('keydown', function(e) { if (e.key === 'Enter') { e.preventDefault(); doSearch(); } });
+})();
+
+initPlayer();
+</script>
+{% endblock %}

--- a/cr-web/templates/film_detail.html
+++ b/cr-web/templates/film_detail.html
@@ -4,20 +4,50 @@
 
 {% block meta_description %}{% match film.description %}{% when Some with (d) %}{{ d }}{% when None %}{{ film.title }}{% match film.year %}{% when Some with (y) %} ({{ y }}){% when None %}{% endmatch %} — sledujte online na ceskarepublika.wiki{% endmatch %}{% endblock %}
 
+{% block og_title %}{{ film.title }}{% match film.year %}{% when Some with (y) %} ({{ y }}){% when None %}{% endmatch %} — film online{% endblock %}
+{% block og_description %}{% match film.description %}{% when Some with (d) %}{{ d }}{% when None %}{{ film.title }}{% match film.year %}{% when Some with (y) %} ({{ y }}){% when None %}{% endmatch %} — sledujte online zdarma na ceskarepublika.wiki{% endmatch %}{% endblock %}
+{% block og_image %}{% match film.cover_filename %}{% when Some with (c) %}https://ceskarepublika.wiki/filmy-online/{{ film.slug }}-large.webp{% when None %}https://ceskarepublika.wiki/static/img/og-filmy-online-v1.png{% endmatch %}{% endblock %}
+{% block og_type %}video.movie{% endblock %}
+
+{# Portrait poster dimensions (780×1170, 2:3 aspect) trigger Discord's
+   "movie card" layout — cover on the LEFT, title/description on the RIGHT.
+   Without these overrides the page inherits the default landscape 1200×630
+   card dimensions and Discord renders the cover as a tiny top-right thumbnail. #}
+{% block og_extra %}
+{% match film.cover_filename %}
+{% when Some with (c) %}
+<meta property="og:image:type" content="image/webp">
+<meta property="og:image:width" content="780">
+<meta property="og:image:height" content="1170">
+<meta property="og:image:alt" content="{{ film.title }}{% match film.year %}{% when Some with (y) %} ({{ y }}){% when None %}{% endmatch %}">
+{% when None %}
+<meta property="og:image:type" content="image/png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:alt" content="{{ film.title }} — ceskarepublika.wiki">
+{% endmatch %}
+<meta property="og:site_name" content="ceskarepublika.wiki">
+{# Override base.html's summary_large_image — portrait `summary` card
+   renders as small left thumbnail + text on right, which is what we want
+   for a film poster. Later tag overrides earlier on Discord/Slack scrapers. #}
+<meta name="twitter:card" content="summary">
+{% endblock %}
+
 {% block leaflet %}{% endblock %}
 
 {% block head %}
 <link rel="icon" type="image/svg+xml" href="/static/img/logo-filmy-a-serialy.svg?v=6">
 <script src="https://cdn.jsdelivr.net/npm/hls.js@1.5.8/dist/hls.min.js"></script>
+<meta property="og:url" content="https://ceskarepublika.wiki/filmy-online/{{ film.slug }}/">
 {% endblock %}
 
 {% block header_left %}
-<div class="logo-group">
-    <a href="/filmy-online/" style="display:flex;align-items:center;gap:0.5rem;text-decoration:none;color:inherit;">
+<div class="logo-group" style="display:flex;align-items:center;gap:0.5rem;">
+    <a href="/filmy-online/" style="display:flex;align-items:center;text-decoration:none;">
         <img src="/static/img/logo-filmy-a-serialy.svg?v=6"
             alt="Logo Filmy online" title="Filmy online" class="header-emblem">
-        <h1>{{ film.title }}</h1>
     </a>
+    <h1>{{ film.title }}</h1>
 </div>
 {% endblock %}
 
@@ -46,12 +76,11 @@
            Bombuj providers (Filemoon/Streamtape/Mixdrop) removed — CDN URLs
            are session-bound, proxy-streaming doesn't scale (#407).
            Přehraj.to section below provides additional sources. #}
-        <div class="source-tabs">
-            {% match film.sktorrent_video_id %}
-            {% when Some with (vid) %}
-            <button class="source-tab active">SK Torrent</button>
-            {% when None %}
-            {% endmatch %}
+        {# Same "Zdroj 1 / Zdroj 2" pattern as episode_detail.html.
+           "Zdroj 1" = primary (SK Torrent, or cached Přehraj.to when SKT missing);
+           "Zdroj 2" appears when the user picks an alternative from "Další zdroje". #}
+        <div class="source-tabs" id="source-tabs">
+            <button class="source-tab active" id="tab-source-1" onclick="switchBackToSource1()">Zdroj 1</button>
         </div>
 
         {# Video player — auto-select best available quality #}
@@ -65,6 +94,20 @@
                 </div>
                 {% when None %}
                 {% endmatch %}
+                <div id="subtitle-controls" class="subtitle-controls" style="display:none;">
+                    <span class="sub-label">Velikost titulků</span>
+                    <select id="sub-size-select" class="sub-select" onchange="setSubSize(this.value)">
+                        <option value="14">14 px</option>
+                        <option value="16">16 px</option>
+                        <option value="18">18 px</option>
+                        <option value="20" selected>20 px</option>
+                        <option value="24">24 px</option>
+                        <option value="28">28 px</option>
+                        <option value="32">32 px</option>
+                        <option value="36">36 px</option>
+                        <option value="40">40 px</option>
+                    </select>
+                </div>
                 <div id="source-status" class="source-status"></div>
             </div>
         </div>
@@ -79,13 +122,25 @@
         </script>
         {% when None %}
         {% endmatch %}
+        {# Cached Přehraj.to URL — primary source when SK Torrent is absent.
+           filmRuntime is used to filter out mismatched-duration candidates
+           in the "Další zdroje" live search. #}
+        <script>
+        var cachedPrehrajtoUrl = {% match film.prehrajto_url %}{% when Some with (u) %}"{{ u }}"{% when None %}null{% endmatch %};
+        var filmRuntime = {% match film.runtime_min %}{% when Some with (m) %}{{ m }}{% when None %}null{% endmatch %};
+        </script>
     </div>
 
     <div class="film-hero">
         <div class="film-cover">
             {% match film.cover_filename %}
             {% when Some with (cover) %}
-            <img src="/filmy-online/{{ film.slug }}.webp" alt="{{ film.title }}" width="200" height="300">
+            <div class="cover-zoom" data-gallery-open="film" data-index="0"
+                 data-gallery-photos="[&quot;/filmy-online/{{ film.slug }}-large.webp&quot;]"
+                 title="Zobrazit větší obrázek">
+                <img src="/filmy-online/{{ film.slug }}.webp" alt="{{ film.title }}" width="200" height="300">
+                <span class="zoom-icon" aria-hidden="true">&#128269;</span>
+            </div>
             {% when None %}
             <div class="no-cover">{{ film.title }}</div>
             {% endmatch %}
@@ -182,13 +237,34 @@
 .quality-btn.active { background: #D7141A; color: white; }
 .source-status { font-size: 0.78rem; color: #888; margin-left: auto; }
 
+/* Subtitle controls */
+.subtitle-controls { display: flex; align-items: center; gap: 0.4rem; }
+.sub-label { color: #888; font-size: 0.75rem; }
+.sub-select { background: #333; color: #ccc; border: 1px solid #555; border-radius: 4px; padding: 0.15rem 0.4rem; font-size: 0.78rem; cursor: pointer; }
+.sub-select:focus { outline: 1px solid #D7141A; }
+
+/* Subtitle cue styling */
+video::cue { background: rgba(0,0,0,0.7); color: white; font-family: sans-serif; }
+
 /* Film hero */
 .film-hero { display: flex; gap: 1.5rem; }
 @media (max-width: 600px) { .film-hero { flex-direction: column; align-items: center; } }
 
 .film-cover { flex-shrink: 0; width: 200px; }
-.film-cover img { width: 200px; border-radius: 8px; box-shadow: 0 2px 12px rgba(0,0,0,0.2); }
+.film-cover img { width: 200px; border-radius: 8px; box-shadow: 0 2px 12px rgba(0,0,0,0.2); display: block; }
 .no-cover { width: 200px; height: 300px; background: #222; border-radius: 8px; display: flex; align-items: center; justify-content: center; color: #888; text-align: center; padding: 1rem; }
+
+/* Cover zoom overlay */
+.cover-zoom { position: relative; cursor: zoom-in; display: inline-block; border-radius: 8px; overflow: hidden; }
+.cover-zoom .zoom-icon {
+    position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);
+    font-size: 2rem; color: white; text-shadow: 0 2px 8px rgba(0,0,0,0.8);
+    opacity: 0; transition: opacity 0.2s ease; pointer-events: none;
+    background: rgba(0,0,0,0.5); border-radius: 50%; width: 3rem; height: 3rem;
+    display: flex; align-items: center; justify-content: center;
+}
+.cover-zoom:hover .zoom-icon { opacity: 1; }
+.cover-zoom:hover img { filter: brightness(0.75); transition: filter 0.2s ease; }
 
 .film-meta h2 { margin: 0 0 0.4rem; font-size: 1.5rem; }
 .film-meta .year { color: #888; font-weight: 400; }
@@ -218,6 +294,21 @@
 .prehrajto-item .pt-title { font-weight: 500; font-size: 0.9rem; display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .prehrajto-item .pt-meta { font-size: 0.8rem; color: #888; }
 .prehrajto-item.loading { opacity: 0.5; cursor: wait; }
+
+/* Active-source highlight — same gold treatment as episode_detail.html.
+   Gold background + play arrow means: "THIS is what you're watching right now." */
+.prehrajto-item.active { background: #C5A059; border-color: #C5A059; color: white; }
+.prehrajto-item.active .pt-title { color: white; }
+.prehrajto-item .play-indicator { display: none; flex-shrink: 0; width: 22px; height: 22px; align-items: center; justify-content: center; background: rgba(255,255,255,0.2); border-radius: 50%; color: white; font-size: 0.7rem; margin-left: 0.3rem; }
+.prehrajto-item.active .play-indicator { display: inline-flex; }
+.prehrajto-item.active .pt-badge { background: rgba(255,255,255,0.25); color: white; }
+
+.pt-badge { display: inline-block; padding: 0.1rem 0.45rem; border-radius: 999px; font-size: 0.72rem; font-weight: 600; margin-right: 0.3rem; }
+.pt-badge.direct { background: #d1fae5; color: #065f46; }
+.pt-badge.proxy { background: #fee2e2; color: #991b1b; }
+.pt-badge.quality-hd { background: #dbeafe; color: #1e40af; }
+.pt-badge.quality-sd { background: #fef3c7; color: #92400e; }
+.pt-badge.quality-low { background: #f3f4f6; color: #6b7280; }
 .pt-badge { display: inline-block; padding: 0.1rem 0.4rem; border-radius: 3px; font-size: 0.7rem; font-weight: 600; margin-left: 0.3rem; }
 .pt-badge.direct { background: #27ae60; color: white; }
 .pt-badge.proxy { background: #f39c12; color: white; }
@@ -294,6 +385,39 @@ function showSktorrent(btn) {
     }
 }
 
+/* --- Cached Přehraj.to URL: primary source when SK Torrent is absent --- */
+var cachedPrehrajtoPlayed = false;
+(function() {
+    var hasSktorrent = typeof sktorrentVideoId !== 'undefined' && sktorrentCdn;
+    if (hasSktorrent) return;                      // SK Torrent owns primary
+    if (!cachedPrehrajtoUrl) return;               // Nothing to play
+    var player = document.getElementById('film-player');
+    var status = document.getElementById('source-status');
+    if (!player) return;
+
+    cachedPrehrajtoPlayed = true;
+    status.textContent = 'Načítání Přehraj.to...';
+    fetch('/api/movies/video-url?url=' + encodeURIComponent(cachedPrehrajtoUrl))
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+            if (!data.success || !data.video_url) {
+                status.textContent = 'Zdroj nedostupný';
+                cachedPrehrajtoPlayed = false;     // let live-search take over
+                return;
+            }
+            var url = data.video_url.replace(/&amp;/g, '&');
+            playUrl(url, url.indexOf('.m3u8') !== -1 ? 'hls' : 'mp4');
+            status.textContent = 'Přehraj.to';
+            if (data.subtitles && data.subtitles.length) {
+                addSubtitles(player, data.subtitles);
+            }
+        })
+        .catch(function() {
+            status.textContent = 'Zdroj nedostupný';
+            cachedPrehrajtoPlayed = false;
+        });
+})();
+
 /* --- Přehraj.to: search, validate (direct vs proxy), auto-play if no SK Torrent --- */
 (function() {
     var filmTitle = "{{ film.title }}";
@@ -309,10 +433,26 @@ function showSktorrent(btn) {
 
             section.style.display = '';
             var movies = data.movies;
-            var directMovies = [];
-            var proxyMovies = [];
             var checked = 0;
             var autoPlayed = false;
+            var autoplayTimer = null;
+
+            // Autoplay strategy: collect direct candidates for a short window
+            // (800 ms after first hit), then pick the highest-resolution one.
+            // This beats "first direct wins" because a 1080p candidate often
+            // validates a beat later than a 480p one.
+            function scheduleAutoplay() {
+                if (autoPlayed || hasSktorrent || cachedPrehrajtoPlayed) return;
+                if (autoplayTimer) return;
+                autoplayTimer = setTimeout(function() {
+                    if (autoPlayed || hasSktorrent || cachedPrehrajtoPlayed) return;
+                    var best = container.querySelector('.prehrajto-item:not(.proxy-item)');
+                    if (!best) return;
+                    autoPlayed = true;
+                    // Simulate click to reuse playPrehrajto logic
+                    best.click();
+                }, 800);
+            }
 
             // Validate each result (direct vs proxy) in batches of 3
             function validateBatch(startIdx) {
@@ -324,24 +464,33 @@ function showSktorrent(btn) {
                         .then(function(r) { return r.json(); })
                         .then(function(vdata) {
                             checked++;
-                            if (vdata.valid) {
-                                var item = createItem(movie, true);
-                                directMovies.push(item);
-                                // Insert before proxy items
-                                var firstProxy = container.querySelector('.proxy-item');
-                                if (firstProxy) container.insertBefore(item, firstProxy);
-                                else container.appendChild(item);
-
-                                // Auto-play first direct result if no SK Torrent
-                                if (!hasSktorrent && !autoPlayed) {
-                                    autoPlayed = true;
-                                    playPrehrajto(movie, item);
+                            // Runtime mismatch guard — if we know the film's
+                            // runtime and the candidate's duration differs by
+                            // more than ~40 %, it's almost certainly a different
+                            // film (e.g. 14-minute 1902 short vs 80-minute remake).
+                            if (filmRuntime && vdata.duration_sec) {
+                                var expected = filmRuntime * 60;
+                                var ratio = vdata.duration_sec / expected;
+                                if (ratio < 0.6 || ratio > 1.6) {
+                                    if (checked >= movies.length || checked >= 15) return;
+                                    if (checked === startIdx + batch.length) validateBatch(startIdx + 3);
+                                    return; // skip — wrong film
                                 }
+                            }
+
+                            if (vdata.valid) {
+                                var item = createItem(movie, true, vdata.duration_sec, vdata.height);
+                                // Sort direct items by height DESC — 1080p appears
+                                // above 720p, above 480p, above 304p, etc.
+                                insertSortedByHeight(container, item, vdata.height || 0);
+                                // Store movie reference on the DOM node so the
+                                // autoplay simulated-click can find it back.
+                                item._movie = movie;
+                                scheduleAutoplay();
                             } else {
                                 // Proxy needed — add at end
-                                var item = createItem(movie, false);
+                                var item = createItem(movie, false, vdata.duration_sec, vdata.height);
                                 item.classList.add('proxy-item');
-                                proxyMovies.push(item);
                                 container.appendChild(item);
                             }
 
@@ -356,9 +505,10 @@ function showSktorrent(btn) {
         })
         .catch(function() {});
 
-    function createItem(movie, isDirect) {
+    function createItem(movie, isDirect, durationSec, height) {
         var item = document.createElement('div');
         item.className = 'prehrajto-item';
+        item.dataset.height = height || 0;
         item.onclick = function() { playPrehrajto(movie, item); };
 
         var thumb = movie.thumbnail
@@ -366,23 +516,111 @@ function showSktorrent(btn) {
             : '';
         var year = movie.year ? ' (' + movie.year + ')' : '';
         var badge = isDirect ? '<span class="pt-badge direct">přímý</span>' : '<span class="pt-badge proxy">proxy</span>';
+        // Real resolution from prehraj.to microdata — unlike the name ("1080p"
+        // in the filename is often a lie), this is the actual stream height.
+        var qualityLabel = '';
+        if (height) {
+            var cls = height >= 1080 ? 'quality-hd' : (height >= 720 ? 'quality-sd' : 'quality-low');
+            qualityLabel = ' <span class="pt-badge ' + cls + '">' + height + 'p</span>';
+        }
+        var durLabel = '';
+        if (durationSec) {
+            var mm = Math.round(durationSec / 60);
+            durLabel = ' · ' + mm + ' min';
+        }
 
         item.innerHTML = thumb
             + '<div class="pt-info">'
             + '<span class="pt-title">' + movie.title + year + '</span>'
-            + '<span class="pt-meta">' + badge + '</span>'
-            + '</div>';
+            + '<span class="pt-meta">' + badge + qualityLabel + durLabel + '</span>'
+            + '</div>'
+            + '<span class="play-indicator">&#9654;</span>';
         return item;
     }
+
+    /* Insert `item` into `container` so that direct items stay above proxy
+       items and, within direct items, heights descend (1080p on top). */
+    function insertSortedByHeight(container, item, height) {
+        var siblings = container.querySelectorAll('.prehrajto-item:not(.proxy-item)');
+        for (var i = 0; i < siblings.length; i++) {
+            var sh = parseInt(siblings[i].dataset.height || '0', 10);
+            if (height > sh) {
+                container.insertBefore(item, siblings[i]);
+                return;
+            }
+        }
+        // All existing direct items have higher/equal height — insert before first proxy
+        var firstProxy = container.querySelector('.proxy-item');
+        if (firstProxy) container.insertBefore(item, firstProxy);
+        else container.appendChild(item);
+    }
 })();
+
+/* Tabs & active-source helpers — mirror of episode_detail.html */
+function setActiveTab(n) {
+    var t1 = document.getElementById('tab-source-1');
+    var t2 = document.getElementById('tab-source-2');
+    if (t1) t1.classList.toggle('active', n === 1);
+    if (t2) t2.classList.toggle('active', n === 2);
+}
+function ensureSource2Tab() {
+    if (document.getElementById('tab-source-2')) return;
+    var tabs = document.getElementById('source-tabs');
+    if (!tabs) return;
+    var btn = document.createElement('button');
+    btn.className = 'source-tab';
+    btn.id = 'tab-source-2';
+    btn.textContent = 'Zdroj 2';
+    btn.onclick = function() {
+        // Clicking Zdroj 2 tab re-activates the last-played prehrajto item
+        var last = document.querySelector('.prehrajto-item.active');
+        if (last && last._movie) playPrehrajto(last._movie, last);
+    };
+    tabs.appendChild(btn);
+}
+function switchBackToSource1() {
+    // Hide "Zdroj 1" tab click handler: replay the primary source.
+    // Primary is either SK Torrent (cachedPrehrajtoPlayed=false) or cached
+    // prehrajto_url (cachedPrehrajtoPlayed=true).
+    setActiveTab(1);
+    document.querySelectorAll('.prehrajto-item.active').forEach(function(el) { el.classList.remove('active'); });
+    var sktQ = document.getElementById('sktorrent-quality');
+    if (typeof sktorrentSources !== 'undefined' && sktorrentSources.length) {
+        if (sktQ) sktQ.style.display = '';
+        playSktorrent(0, sktQ ? sktQ.querySelector('.quality-btn') : null);
+    } else if (cachedPrehrajtoUrl) {
+        // Re-resolve the cached URL (token-bound, short TTL)
+        var player = document.getElementById('film-player');
+        var status = document.getElementById('source-status');
+        status.textContent = 'Načítání Přehraj.to...';
+        fetch('/api/movies/video-url?url=' + encodeURIComponent(cachedPrehrajtoUrl))
+            .then(function(r) { return r.json(); })
+            .then(function(data) {
+                if (data.success && data.video_url) {
+                    var url = data.video_url.replace(/&amp;/g, '&');
+                    playUrl(url, url.indexOf('.m3u8') !== -1 ? 'hls' : 'mp4');
+                    status.textContent = 'Přehraj.to';
+                    if (data.subtitles && data.subtitles.length) {
+                        addSubtitles(player, data.subtitles);
+                    }
+                } else { status.textContent = 'Zdroj nedostupný'; }
+            });
+    }
+}
 
 function playPrehrajto(movie, item) {
     var player = document.getElementById('film-player');
     var status = document.getElementById('source-status');
     if (!player) return;
 
-    // Deactivate all source tabs
-    document.querySelectorAll('.source-tab').forEach(function(t) { t.classList.remove('active'); });
+    // Mark clicked item as the active source (gold + play arrow);
+    // append "Zdroj 2" tab and switch focus to it so the user sees which
+    // source is playing. Mirror of episode_detail.html behaviour.
+    document.querySelectorAll('.prehrajto-item.active').forEach(function(el) { el.classList.remove('active'); });
+    item.classList.add('active');
+    item._movie = movie;
+    ensureSource2Tab();
+    setActiveTab(2);
     var sktQ = document.getElementById('sktorrent-quality');
     if (sktQ) sktQ.style.display = 'none';
 
@@ -401,6 +639,11 @@ function playPrehrajto(movie, item) {
                 var url = data.video_url.replace(/&amp;/g, '&');
                 playUrl(url, url.indexOf('.m3u8') !== -1 ? 'hls' : 'mp4');
                 status.textContent = movie.title;
+
+                // Add subtitle tracks if available
+                if (data.subtitles && data.subtitles.length) {
+                    addSubtitles(player, data.subtitles);
+                }
             } else {
                 status.textContent = 'Zdroj nedostupný';
             }
@@ -409,6 +652,82 @@ function playPrehrajto(movie, item) {
             item.classList.remove('loading');
             status.textContent = 'Chyba: ' + e.message;
         });
+}
+
+/* --- Subtitle support --- */
+function addSubtitles(player, subtitles) {
+    // Remove existing tracks
+    var existing = player.querySelectorAll('track');
+    existing.forEach(function(t) { t.remove(); });
+
+    subtitles.forEach(function(sub) {
+        var track = document.createElement('track');
+        track.kind = 'subtitles';
+        track.label = sub.label || sub.lang.toUpperCase();
+        track.srclang = sub.lang || '';
+        // Proxy VTT through our server (CORS requirement)
+        track.src = '/api/movies/subtitle?url=' + encodeURIComponent(sub.url);
+        // Default to Czech if available
+        if (sub.lang === 'cze' || sub.lang === 'cs') {
+            track.default = true;
+        }
+        player.appendChild(track);
+    });
+
+    // Enable first Czech track, or first track if no Czech
+    var textTracks = player.textTracks;
+    var czFound = false;
+    for (var i = 0; i < textTracks.length; i++) {
+        if ((textTracks[i].language === 'cze' || textTracks[i].language === 'cs') && !czFound) {
+            textTracks[i].mode = 'showing';
+            czFound = true;
+        } else {
+            textTracks[i].mode = 'hidden';
+        }
+    }
+    if (!czFound && textTracks.length > 0) {
+        textTracks[0].mode = 'showing';
+    }
+
+    // Set default subtitle size
+    setSubSize(20);
+
+    // Watch textTracks for mode changes (user toggles via native CC menu)
+    // Show size controls only when any subtitle track is active
+    var controls = document.getElementById('subtitle-controls');
+    if (controls) {
+        function updateSubControls() {
+            var anyShowing = false;
+            for (var j = 0; j < textTracks.length; j++) {
+                if (textTracks[j].mode === 'showing') { anyShowing = true; break; }
+            }
+            controls.style.display = anyShowing ? 'flex' : 'none';
+        }
+        for (var k = 0; k < textTracks.length; k++) {
+            textTracks[k].addEventListener('cuechange', updateSubControls);
+        }
+        // Also listen for mode changes via MutationObserver on track elements
+        var trackEls = player.querySelectorAll('track');
+        trackEls.forEach(function(t) {
+            if (t.track) {
+                var origMode = t.track.mode;
+                Object.defineProperty(t.track, '_mode', { value: origMode, writable: true });
+            }
+        });
+        // Poll for mode changes (native CC menu doesn't fire events reliably)
+        setInterval(updateSubControls, 1000);
+        updateSubControls();
+    }
+}
+
+function setSubSize(px) {
+    var style = document.getElementById('sub-cue-style');
+    if (!style) {
+        style = document.createElement('style');
+        style.id = 'sub-cue-style';
+        document.head.appendChild(style);
+    }
+    style.textContent = 'video::cue { font-size: ' + px + 'px !important; }';
 }
 
 /* --- Initialize sktorrent player from static CDN URLs --- */
@@ -452,10 +771,59 @@ function playSktorrent(index, btn) {
     var source = sktorrentSources[index];
     player.src = source.url;
     player.dataset.sktorrentSrc = source.url;
+    player.dataset.sktorrentQuality = source.quality;
     document.querySelectorAll('#sktorrent-quality .quality-btn').forEach(function(b) { b.classList.remove('active'); });
     if (btn) btn.classList.add('active');
     document.getElementById('source-status').textContent = '';
 }
+
+/* Fallback: if static CDN URL fails, fetch fresh URL from sktorrent */
+(function() {
+    var player = document.getElementById('film-player');
+    if (!player || typeof sktorrentVideoId === 'undefined') return;
+
+    var fallbackTried = false;
+    player.addEventListener('error', function(e) {
+        if (fallbackTried) return;
+        var status = document.getElementById('source-status');
+        // Only fallback for sktorrent URLs
+        if (!player.src || player.src.indexOf('sktorrent.eu') === -1) return;
+        fallbackTried = true;
+        if (status) status.textContent = 'Obnovuji zdroj...';
+
+        fetch('/api/films/sktorrent-resolve?video_id=' + sktorrentVideoId)
+            .then(function(r) { return r.json(); })
+            .then(function(data) {
+                if (!data.sources || !data.sources.length) {
+                    if (status) status.textContent = 'Zdroj nedostupný';
+                    return;
+                }
+                // Rebuild sktorrentSources with fresh URLs
+                sktorrentSources = data.sources.map(function(s) {
+                    return { url: s.url, quality: s.quality, res: s.res };
+                });
+                sktorrentSources.sort(function(a, b) { return b.res - a.res; });
+                // Rebuild quality buttons
+                var qualDiv = document.getElementById('sktorrent-quality');
+                if (qualDiv) {
+                    qualDiv.innerHTML = '';
+                    sktorrentSources.forEach(function(s, i) {
+                        var btn = document.createElement('button');
+                        btn.className = 'quality-btn' + (i === 0 ? ' active' : '');
+                        btn.textContent = s.quality;
+                        btn.onclick = function() { playSktorrent(i, btn); };
+                        qualDiv.appendChild(btn);
+                    });
+                }
+                // Play best quality from fresh URLs
+                playSktorrent(0, qualDiv ? qualDiv.querySelector('.quality-btn') : null);
+                if (status) status.textContent = 'Obnoveno';
+            })
+            .catch(function() {
+                if (status) status.textContent = 'Zdroj nedostupný';
+            });
+    }, true);
+})();
 
 /* --- Search --- */
 function doSearch() {

--- a/cr-web/templates/films_list.html
+++ b/cr-web/templates/films_list.html
@@ -4,26 +4,35 @@
 
 {% block meta_description %}{% match current_genre %}{% when Some with (g) %}{{ g.name_cs }} filmy online zdarma — {{ total_count }} filmů ke zhlédnutí.{% when None %}Filmy online zdarma — {{ total_count }} filmů ke zhlédnutí na ceskarepublika.wiki.{% endmatch %}{% endblock %}
 
+{% block og_title %}{% match current_genre %}{% when Some with (g) %}{{ g.name_cs }} filmy online — ceskarepublika.wiki{% when None %}Filmy online — ceskarepublika.wiki{% endmatch %}{% endblock %}
+{% block og_description %}{% match current_genre %}{% when Some with (g) %}{{ g.name_cs }} filmy online zdarma. {{ total_count }} filmů ke zhlédnutí přímo v prohlížeči, bez registrace.{% when None %}Filmy online zdarma — {{ total_count }} filmů ke zhlédnutí přímo v prohlížeči, bez registrace. České i zahraniční filmy s českým dabingem nebo titulky.{% endmatch %}{% endblock %}
+{% block og_image %}https://ceskarepublika.wiki/static/img/og-filmy-online-v1.png{% endblock %}
+{% block og_type %}article{% endblock %}
+
 {% block leaflet %}{% endblock %}
 
 {% block head %}
 <link rel="icon" type="image/svg+xml" href="/static/img/logo-filmy-a-serialy.svg?v=6">
+<meta property="og:image:secure_url" content="https://ceskarepublika.wiki/static/img/og-filmy-online-v1.png">
+<meta property="og:image:type" content="image/png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:alt" content="Filmy online — ceskarepublika.wiki">
+<meta property="og:url" content="https://ceskarepublika.wiki/filmy-online/">
 {% endblock %}
 
 {% block header_left %}
-<div class="logo-group">
-    <a href="/filmy-online/" style="display:flex;align-items:center;gap:0.5rem;text-decoration:none;color:inherit;">
-        <img src="/static/img/logo-filmy-a-serialy.svg?v=6"
-            alt="Logo Filmy online" title="Filmy online" class="header-emblem">
-        <h1>Filmy online</h1>
-    </a>
+<div class="logo-group" style="display:flex;align-items:center;gap:0.5rem;">
+    <img src="/static/img/logo-filmy-a-serialy.svg?v=6"
+        alt="Logo Filmy online" title="Filmy online" class="header-emblem">
+    <h1>Filmy online</h1>
 </div>
 {% endblock %}
 
-{# Search in header — same style as main site search #}
+{# Search in header #}
 {% block header_search %}
 <div class="search-container" id="header-search-box">
-    <input type="text" id="film-search" class="search-input" placeholder="Hledat film..." autocomplete="off">
+    <input type="text" id="film-search" class="search-input" placeholder="Hledat film..." autocomplete="off"{% match search_query %}{% when Some with (q) %} value="{{ q }}"{% when None %}{% endmatch %}>
     <button class="search-btn" id="film-search-btn" onclick="doSearch()">Hledat</button>
     <div id="search-results" class="search-dropdown"></div>
 </div>
@@ -33,28 +42,70 @@
 
 {% block content %}
 <main class="films-page">
-    {# Toolbar: title + view toggle + sort #}
+    {# Breadcrumb #}
+    <nav class="breadcrumb">
+        <a href="/">Česká republika</a>
+        <span>›</span>
+        {% match current_genre %}
+        {% when Some with (g) %}
+        <a href="/filmy-online/">Filmy online</a> <span>›</span> <span>{{ g.name_cs }}</span>
+        {% when None %}
+        <span>Filmy online</span>
+        {% endmatch %}
+    </nav>
+
+    {# Header — different text for search results vs browse #}
     <div class="films-header">
+        {% match search_query %}
+        {% when Some with (q) %}
+        <h2>Výsledky hledání pro „{{ q }}" <span class="count">({{ total_count }})</span></h2>
+        {% when None %}
         <h2>
             {% match current_genre %}
             {% when Some with (g) %}
                 {{ g.name_cs }} <span class="count">({{ total_count }})</span>
             {% when None %}
-                Filmy online <span class="count">({{ total_count }})</span>
+                Vyberte si z {{ total_count }} filmů, které si můžete pustit online
             {% endmatch %}
         </h2>
+        {% endmatch %}
         <div class="films-toolbar">
-            <select id="sort-select" onchange="applySort(this.value)" title="Řazení">
-                <option value="rok"{% if sort_key == "rok" %} selected{% endif %}>Nejnovější</option>
-                <option value="imdb"{% if sort_key == "imdb" %} selected{% endif %}>IMDB hodnocení</option>
-                <option value="csfd"{% if sort_key == "csfd" %} selected{% endif %}>ČSFD hodnocení</option>
-                <option value="nazev"{% if sort_key == "nazev" %} selected{% endif %}>Název A-Z</option>
-            </select>
-            <button class="view-btn active" id="btn-grid" onclick="setView('grid')" title="Mřížka">
-                <svg width="18" height="18" viewBox="0 0 18 18"><rect x="1" y="1" width="7" height="7" rx="1" fill="currentColor"/><rect x="10" y="1" width="7" height="7" rx="1" fill="currentColor"/><rect x="1" y="10" width="7" height="7" rx="1" fill="currentColor"/><rect x="10" y="10" width="7" height="7" rx="1" fill="currentColor"/></svg>
-            </button>
-            <button class="view-btn" id="btn-list" onclick="setView('list')" title="Seznam">
-                <svg width="18" height="18" viewBox="0 0 18 18"><rect x="1" y="2" width="16" height="3" rx="1" fill="currentColor"/><rect x="1" y="7.5" width="16" height="3" rx="1" fill="currentColor"/><rect x="1" y="13" width="16" height="3" rx="1" fill="currentColor"/></svg>
+            <label class="toolbar-group">
+                <span class="toolbar-label">Řazení:</span>
+                <select id="sort-select" onchange="applySortCombined(this.value)" title="Řazení filmů" class="sort-select-combined">
+                    <optgroup label="Podle přidání">
+                        <option value="pridano:desc">Naposledy přidané</option>
+                        <option value="pridano:asc">Nejdříve přidané</option>
+                    </optgroup>
+                    <optgroup label="Podle roku vydání">
+                        <option value="rok:desc">Od nejnovějších</option>
+                        <option value="rok:asc">Od nejstarších</option>
+                    </optgroup>
+                    <optgroup label="Podle hodnocení IMDB">
+                        <option value="imdb:desc">Nejlépe hodnocené první</option>
+                        <option value="imdb:asc">Nejhůře hodnocené první</option>
+                    </optgroup>
+                    <optgroup label="Podle hodnocení ČSFD">
+                        <option value="csfd:desc">Nejlépe hodnocené ČSFD</option>
+                        <option value="csfd:asc">Nejhůře hodnocené ČSFD</option>
+                    </optgroup>
+                    <optgroup label="Podle abecedy">
+                        <option value="nazev:asc">Podle názvu A–Z</option>
+                        <option value="nazev:desc">Podle názvu Z–A</option>
+                    </optgroup>
+                </select>
+            </label>
+            <label class="toolbar-group">
+                <span class="toolbar-label">Jazyk:</span>
+                <select id="quick-audio" onchange="applyQuickAudio(this.value)" title="Zvuková verze" class="quick-audio-select">
+                    <option value="vse">Vše</option>
+                    <option value="dub">Jen dabované</option>
+                    <option value="sub">Jen s titulky</option>
+                </select>
+            </label>
+            <button class="view-btn view-toggle" id="btn-view-toggle" onclick="toggleView()" title="Přepnout zobrazení mřížka / seznam" aria-label="Zobrazení">
+                <svg class="view-icon-grid" width="18" height="18" viewBox="0 0 18 18"><rect x="1" y="2" width="16" height="3" rx="1" fill="currentColor"/><rect x="1" y="7.5" width="16" height="3" rx="1" fill="currentColor"/><rect x="1" y="13" width="16" height="3" rx="1" fill="currentColor"/></svg>
+                <svg class="view-icon-list" width="18" height="18" viewBox="0 0 18 18" style="display:none;"><rect x="1" y="1" width="7" height="7" rx="1" fill="currentColor"/><rect x="10" y="1" width="7" height="7" rx="1" fill="currentColor"/><rect x="1" y="10" width="7" height="7" rx="1" fill="currentColor"/><rect x="10" y="10" width="7" height="7" rx="1" fill="currentColor"/></svg>
             </button>
             <button class="view-btn" id="btn-filter-toggle" onclick="toggleFilter()" title="Filtrování">
                 <svg width="18" height="18" viewBox="0 0 18 18"><path d="M1 3h16M4 9h10M7 15h4" stroke="currentColor" stroke-width="2" stroke-linecap="round" fill="none"/></svg>
@@ -63,39 +114,61 @@
     </div>
 
     {# Advanced filter panel — hidden by default #}
-    <div class="filter-panel" id="filter-panel" style="display:none;">
+    <div class="filter-panel" id="filter-panel" style="display:none;"
+         {% match current_genre %}{% when Some with (cg) %}data-current-genre="{{ cg.slug }}"{% when None %}{% endmatch %}>
         <div class="filter-section">
-            <label>Žánry (zaškrtněte které chcete):</label>
+            <div class="filter-label-row">
+                <label>Zahrnout žánry (zaškrtněte, které chcete):</label>
+                <div class="genre-mode">
+                    <label class="mode-option">
+                        <input type="radio" name="rezim" value="or" checked>
+                        <span>Alespoň jeden</span>
+                    </label>
+                    <label class="mode-option">
+                        <input type="radio" name="rezim" value="and">
+                        <span>Všechny</span>
+                    </label>
+                    <span class="help-icon" tabindex="0" onclick="this.classList.toggle('show')">?<span class="help-popup"><strong>Alespoň jeden:</strong> zobrazí filmy, které mají některý z&nbsp;vybraných žánrů.<br><strong>Všechny:</strong> zobrazí jen filmy, které mají všechny vybrané žánry současně.</span></span>
+                </div>
+            </div>
             <div class="filter-genres" id="filter-genres-include">
                 {% for g in genres %}
-                <label class="filter-chip"><input type="checkbox" value="{{ g.slug }}" data-filter="include"> {{ g.name_cs }}</label>
+                {% match current_genre %}
+                {% when Some with (cg) %}{% if cg.id != g.id %}<label class="filter-chip"><input type="checkbox" value="{{ g.slug }}" data-filter="include"> {{ g.name_cs }}</label>{% endif %}
+                {% when None %}<label class="filter-chip"><input type="checkbox" value="{{ g.slug }}" data-filter="include"> {{ g.name_cs }}</label>
+                {% endmatch %}
                 {% endfor %}
             </div>
         </div>
         <div class="filter-section">
-            <label>Vyloučit žánry:</label>
+            <div class="filter-label-row">
+                <label>Vyloučit žánry:</label>
+                <span class="help-icon" tabindex="0" onclick="this.classList.toggle('show')">?<span class="help-popup"><strong>Vyloučit žánry:</strong> zaškrtnuté žánry nebudou mezi filmy zobrazeny. Například: pokud vyloučíte Horor, nezobrazí se žádné horory.</span></span>
+            </div>
             <div class="filter-genres" id="filter-genres-exclude">
                 {% for g in genres %}
-                <label class="filter-chip exclude"><input type="checkbox" value="{{ g.slug }}" data-filter="exclude"> {{ g.name_cs }}</label>
+                {% match current_genre %}
+                {% when Some with (cg) %}{% if cg.id != g.id %}<label class="filter-chip exclude"><input type="checkbox" value="{{ g.slug }}" data-filter="exclude"> {{ g.name_cs }}</label>{% endif %}
+                {% when None %}<label class="filter-chip exclude"><input type="checkbox" value="{{ g.slug }}" data-filter="exclude"> {{ g.name_cs }}</label>
+                {% endmatch %}
                 {% endfor %}
             </div>
         </div>
-        <div class="filter-row">
-            <div class="filter-section">
-                <label for="filter-year">Rok vydání:</label>
-                <select id="filter-year">
-                    <option value="">Všechny roky</option>
-                </select>
+        <div class="filter-section">
+            <div class="filter-label-row">
+                <label>Zvuková verze:</label>
+                <span class="help-icon" tabindex="0" onclick="this.classList.toggle('show')">?<span class="help-popup"><strong>Dabovaný (CZ/SK):</strong> film má český nebo slovenský dabing.<br><strong>S českými titulky:</strong> film je v původním jazyce s českými titulky.<br>Pokud nic nevyberete, zobrazí se všechny verze.</span></span>
             </div>
-            <div class="filter-section">
-                <label for="filter-lang">Jazyk:</label>
-                <select id="filter-lang">
-                    <option value="">Vše</option>
-                    <option value="CZ">Český dabing</option>
-                    <option value="SK">Slovenský dabing</option>
-                    <option value="titulky">S titulky</option>
-                </select>
+            <div class="filter-genres" id="filter-langs">
+                <label class="filter-chip lang"><input type="checkbox" value="dub" data-filter="lang"> Dabovaný (CZ/SK)</label>
+                <label class="filter-chip lang"><input type="checkbox" value="sub" data-filter="lang"> S českými titulky</label>
             </div>
+        </div>
+        <div class="filter-section">
+            <label for="filter-year">Rok vydání:</label>
+            <select id="filter-year">
+                <option value="">Všechny roky</option>
+            </select>
         </div>
         <div class="filter-actions">
             <button class="btn-apply" onclick="applyFilters()">Použít filtr</button>
@@ -105,9 +178,19 @@
 
     {# Quick genre tags #}
     <nav class="genre-nav">
-        <a href="/filmy-online/" class="genre-tag{% if current_genre.is_none() %} active{% endif %}">Vše</a>
+        {% if current_genre.is_none() %}
+        <span class="genre-tag current">Vše</span>
+        {% else %}
+        <a href="/filmy-online/" class="genre-tag">Vše</a>
+        {% endif %}
         {% for g in genres %}
-        <a href="/filmy-online/{{ g.slug }}/" class="genre-tag{% match current_genre %}{% when Some with (cg) %}{% if cg.id == g.id %} active{% endif %}{% when None %}{% endmatch %}">{{ g.name_cs }}</a>
+        {% match current_genre %}{% when Some with (cg) %}{% if cg.id == g.id %}
+        <span class="genre-tag current">{{ g.name_cs }}</span>
+        {% else %}
+        <a href="/filmy-online/{{ g.slug }}/" class="genre-tag">{{ g.name_cs }}</a>
+        {% endif %}{% when None %}
+        <a href="/filmy-online/{{ g.slug }}/" class="genre-tag">{{ g.name_cs }}</a>
+        {% endmatch %}
         {% endfor %}
     </nav>
 
@@ -209,25 +292,64 @@
 .filter-section { margin-bottom: 0.8rem; }
 .filter-section > label { display: block; font-weight: 600; font-size: 0.85rem; color: #555; margin-bottom: 0.4rem; }
 .filter-genres { display: flex; flex-wrap: wrap; gap: 0.3rem; }
-.filter-chip { display: inline-flex; align-items: center; gap: 0.25rem; padding: 0.25rem 0.6rem; border-radius: 16px; background: white; border: 1px solid #ddd; font-size: 0.8rem; cursor: pointer; transition: all 0.15s; user-select: none; }
-.filter-chip:hover { border-color: #aaa; }
-.filter-chip:has(input:checked) { background: #D7141A; color: white; border-color: #D7141A; }
-.filter-chip.exclude:has(input:checked) { background: #555; color: white; border-color: #555; }
+/* Unified chip design — gray default, gold when selected (same as active category pill) */
+.filter-chip { display: inline-flex; align-items: center; gap: 0.25rem; padding: 0.3rem 0.8rem; border-radius: 999px; background: #f1f5f9; border: 1px solid transparent; color: #555; font-size: 0.82rem; cursor: pointer; transition: all 0.15s; user-select: none; }
+.filter-chip:hover { background: #e2e8f0; color: #333; }
+.filter-chip:has(input:checked) { background: #C5A059; color: white; border-color: #C5A059; font-weight: 600; }
 .filter-chip input { display: none; }
 .filter-row { display: flex; gap: 1rem; flex-wrap: wrap; }
 .filter-row .filter-section { flex: 1; min-width: 150px; }
 .filter-row select { width: 100%; padding: 0.4rem 0.6rem; border: 1px solid #ddd; border-radius: 6px; font-size: 0.85rem; }
 .filter-actions { display: flex; gap: 0.5rem; margin-top: 0.5rem; }
-.btn-apply { padding: 0.4rem 1.2rem; background: #D7141A; color: white; border: none; border-radius: 6px; font-size: 0.85rem; cursor: pointer; font-weight: 600; }
-.btn-apply:hover { background: #b8111a; }
+.btn-apply { padding: 0.4rem 1.2rem; background: #D7141A; color: white; border: none; border-radius: 6px; font-size: 0.85rem; cursor: pointer; font-weight: 600; transition: background 0.2s; }
+.btn-apply:hover { background: #11457E; }
+
+/* Filter counter badge on toggle button */
+#btn-filter-toggle { position: relative; }
+#btn-filter-toggle .filter-count { position: absolute; top: -5px; right: -5px; background: #D7141A; color: white; font-size: 0.65rem; font-weight: 700; min-width: 16px; height: 16px; border-radius: 50%; display: flex; align-items: center; justify-content: center; padding: 0 3px; box-shadow: 0 1px 3px rgba(0,0,0,0.2); }
+
+/* Genre mode toggle (AND/OR) */
+.filter-label-row { display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 0.4rem; }
+.filter-label-row > label { margin-bottom: 0 !important; }
+.genre-mode { display: flex; align-items: center; gap: 0.5rem; font-size: 0.8rem; }
+.genre-mode .mode-option { display: inline-flex; align-items: center; gap: 0.25rem; cursor: pointer; padding: 0.2rem 0.5rem; border-radius: 4px; transition: background 0.15s; }
+.genre-mode .mode-option:hover { background: #e8e8e8; }
+.genre-mode .mode-option input { margin: 0; cursor: pointer; }
+.genre-mode .mode-option input:checked + span { font-weight: 600; color: #11457E; }
+.help-icon { position: relative; display: inline-flex; align-items: center; justify-content: center; width: 18px; height: 18px; border-radius: 50%; background: #888; color: white; font-size: 0.75rem; font-weight: 700; cursor: help; user-select: none; }
+.help-icon:hover, .help-icon:focus { background: #11457E; outline: none; }
+.help-icon .help-popup { display: none; position: absolute; top: 24px; right: 0; background: #222; color: white; padding: 0.6rem 0.8rem; border-radius: 6px; font-size: 0.75rem; font-weight: 400; width: 280px; max-width: 80vw; line-height: 1.4; z-index: 20; box-shadow: 0 4px 16px rgba(0,0,0,0.3); white-space: normal; text-align: left; }
+.help-icon.show .help-popup, .help-icon:hover .help-popup { display: block; }
+
+/* Language filter chip — distinct style */
+.filter-chip.lang:has(input:checked) { background: #11457E; color: white; border-color: #11457E; }
+
+/* Combined sort select (field + direction) */
+.sort-select-combined { padding: 0.4rem 0.7rem; border: 1px solid #ddd; border-radius: 6px; font-size: 0.85rem; cursor: pointer; background: white; min-width: 200px; }
+.sort-select-combined:focus { outline: 1px solid #11457E; }
+
+/* Toolbar groups with labels */
+.toolbar-group { display: inline-flex; align-items: center; gap: 0.4rem; margin-right: 0.5rem; }
+.toolbar-label { font-size: 0.82rem; color: #555; font-weight: 500; }
+.view-toggle { background: #f1f5f9; color: #555; border: none; border-radius: 6px; padding: 0.4rem 0.7rem; cursor: pointer; transition: all 0.15s; display: inline-flex; align-items: center; }
+.view-toggle:hover { background: #e2e8f0; }
+
+/* Quick audio version select (next to sort) */
+.quick-audio-select { padding: 0.4rem 0.7rem; border: 1px solid #ddd; border-radius: 6px; font-size: 0.85rem; cursor: pointer; background: white; }
+.quick-audio-select:focus { outline: 1px solid #11457E; }
 .btn-reset { padding: 0.4rem 1rem; background: #f0f0f0; color: #333; border: none; border-radius: 6px; font-size: 0.85rem; cursor: pointer; }
 .btn-reset:hover { background: #e0e0e0; }
 
 /* --- Genre tags --- */
 .genre-nav { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-bottom: 1.2rem; }
-.genre-tag { display: inline-block; padding: 0.3rem 0.7rem; border-radius: 20px; background: #f0f0f0; color: #333; text-decoration: none; font-size: 0.82rem; transition: background 0.2s; }
-.genre-tag:hover { background: #e0e0e0; }
-.genre-tag.active { background: #D7141A; color: white; }
+.genre-tag { display: inline-flex; align-items: center; padding: 0.4rem 0.9rem; border-radius: 999px; background: #f1f5f9; color: #11457E; text-decoration: none; font-size: 0.85rem; font-weight: 600; transition: background 0.15s, color 0.15s; cursor: pointer; }
+.genre-tag:hover { background: #11457E; color: white; }
+.genre-tag.current { background: #C5A059; color: white; cursor: default; }
+
+/* Breadcrumb */
+.breadcrumb { font-size: 0.85rem; color: #888; margin-bottom: 0.8rem; }
+.breadcrumb a { color: #11457E; text-decoration: none; }
+.breadcrumb a:hover { text-decoration: underline; }
 
 /* --- Grid view --- */
 .films-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 1rem; }
@@ -274,32 +396,106 @@
 .films-grid.list-view .film-desc { font-size: 0.85rem; color: #555; line-height: 1.6; margin: 0.3rem 0 0; display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
 
 /* --- Pagination --- */
-.pagination { display: flex; justify-content: center; align-items: center; gap: 0.25rem; margin: 2rem 0; flex-wrap: wrap; }
-.page-link { display: inline-block; padding: 0.35rem 0.7rem; border-radius: 6px; background: #f0f0f0; color: #333; text-decoration: none; font-size: 0.85rem; min-width: 2rem; text-align: center; }
-.page-link:hover { background: #e0e0e0; }
-.page-link.current { background: #D7141A; color: white; }
-.page-dots { padding: 0.35rem 0.2rem; color: #888; }
+.pagination { display: flex; justify-content: center; align-items: center; gap: 0.3rem; margin: 2rem 0; flex-wrap: wrap; }
+.page-link { display: inline-flex; align-items: center; justify-content: center; padding: 0.4rem 0.8rem; border-radius: 999px; background: #f1f5f9; color: #11457E; text-decoration: none; font-size: 0.85rem; font-weight: 600; min-width: 2.2rem; transition: background 0.15s, color 0.15s; }
+.page-link:hover { background: #11457E; color: white; }
+.page-link.current { background: #C5A059; color: white; cursor: default; }
+.page-dots { padding: 0.4rem 0.2rem; color: #888; }
 </style>
 
 <script>
-/* --- View toggle --- */
+/* --- View toggle (single button, switches icon) --- */
 function setView(mode) {
     const c = document.getElementById('films-container');
-    const bG = document.getElementById('btn-grid');
-    const bL = document.getElementById('btn-list');
-    if (mode === 'list') { c.classList.add('list-view'); bL.classList.add('active'); bG.classList.remove('active'); }
-    else { c.classList.remove('list-view'); bG.classList.add('active'); bL.classList.remove('active'); }
+    const iconGrid = document.querySelector('.view-icon-grid');
+    const iconList = document.querySelector('.view-icon-list');
+    if (mode === 'list') {
+        c.classList.add('list-view');
+        // In list view, show the "switch to grid" icon (grid squares)
+        if (iconGrid) iconGrid.style.display = 'none';
+        if (iconList) iconList.style.display = '';
+    } else {
+        c.classList.remove('list-view');
+        // In grid view, show the "switch to list" icon (hamburger)
+        if (iconGrid) iconGrid.style.display = '';
+        if (iconList) iconList.style.display = 'none';
+    }
     localStorage.setItem('filmsView', mode);
 }
+
+function toggleView() {
+    var current = localStorage.getItem('filmsView') || 'grid';
+    setView(current === 'list' ? 'grid' : 'list');
+}
+
 (function(){ var s = localStorage.getItem('filmsView'); if (s === 'list') setView('list'); })();
 
-/* --- Sort --- */
-function applySort(v) {
+/* --- Sort (combined field + direction) --- */
+function applySortCombined(v) {
+    // v format: "field:dir" e.g. "rok:desc" or "nazev:asc"
+    var parts = v.split(':');
+    var field = parts[0];
+    var dir = parts[1] || 'desc';
     var u = new URL(window.location);
-    u.searchParams.set('razeni', v);
+    if (field === 'pridano' && dir === 'desc') u.searchParams.delete('razeni');
+    else u.searchParams.set('razeni', field);
+    if (dir === 'asc') u.searchParams.set('smer', 'asc');
+    else u.searchParams.delete('smer');
     u.searchParams.delete('strana');
     window.location = u.toString();
 }
+
+function applySort() { applySortCombined(document.getElementById('sort-select').value); }
+
+function applyQuickAudio(v) {
+    var u = new URL(window.location);
+    if (v === 'dub' || !v) {
+        // Default is dubbed - remove param
+        u.searchParams.delete('jazyk');
+    } else {
+        // "vse" or "sub" - set explicitly
+        u.searchParams.set('jazyk', v);
+    }
+    u.searchParams.delete('strana');
+    window.location = u.toString();
+}
+
+// Prefill sort select + quick audio from URL
+(function() {
+    var urlParams = new URLSearchParams(window.location.search);
+    var razeni = urlParams.get('razeni') || 'pridano';
+    var smer = urlParams.get('smer') === 'asc' ? 'asc' : 'desc';
+    var sortSel = document.getElementById('sort-select');
+    if (sortSel) {
+        var target = razeni + ':' + smer;
+        // Default A-Z for name is asc
+        if (razeni === 'nazev' && !urlParams.get('smer')) target = 'nazev:asc';
+        for (var i = 0; i < sortSel.options.length; i++) {
+            if (sortSel.options[i].value === target) {
+                sortSel.selectedIndex = i;
+                break;
+            }
+        }
+    }
+    // Default is "dub" (dubbed only). Only change select if user set non-default.
+    var jazyk = urlParams.get('jazyk');
+    var qa = document.getElementById('quick-audio');
+    if (qa) {
+        if (jazyk === 'vse' || jazyk === 'sub') {
+            qa.value = jazyk;
+        } else {
+            qa.value = 'dub';  // default
+        }
+    }
+    // Also prefill detailed filter lang checkboxes to match default
+    if (!jazyk || jazyk === 'dub') {
+        var filterPanel = document.getElementById('filter-panel');
+        if (filterPanel) {
+            var dubCb = filterPanel.querySelector('#filter-langs input[value="dub"]');
+            if (dubCb) dubCb.checked = true;
+        }
+    }
+})();
 
 /* --- Filter panel toggle --- */
 function toggleFilter() {
@@ -320,27 +516,163 @@ function toggleFilter() {
     }
 })();
 
-/* --- Apply / Reset filters (placeholder — will become real server query) --- */
+/* --- Apply / Reset filters --- */
 function applyFilters() {
-    // Collect checked include genres
-    var inc = Array.from(document.querySelectorAll('#filter-genres-include input:checked')).map(i => i.value);
-    var exc = Array.from(document.querySelectorAll('#filter-genres-exclude input:checked')).map(i => i.value);
+    var incEls = document.querySelectorAll('#filter-genres-include input:checked');
+    var excEls = document.querySelectorAll('#filter-genres-exclude input:checked');
+    var langEls = document.querySelectorAll('#filter-langs input:checked');
+    var inc = Array.from(incEls).map(i => i.value);
+    var exc = Array.from(excEls).map(i => i.value);
+    var langs = Array.from(langEls).map(i => i.value);
     var year = document.getElementById('filter-year').value;
-    var lang = document.getElementById('filter-lang').value;
     var sort = document.getElementById('sort-select').value;
+    var rezimEl = document.querySelector('input[name="rezim"]:checked');
+    var rezim = rezimEl ? rezimEl.value : 'or';
+    var sortDir = document.getElementById('sort-dir-btn');
+    var dir = sortDir && sortDir.classList.contains('asc') ? 'asc' : 'desc';
 
-    var u = new URL(window.location.pathname, window.location.origin);
-    if (inc.length) u.searchParams.set('zanry', inc.join(','));
+    // If we're on a genre subpage, include that genre implicitly
+    var panel = document.getElementById('filter-panel');
+    var currentGenre = panel ? panel.getAttribute('data-current-genre') : null;
+    if (currentGenre && !inc.includes(currentGenre)) {
+        inc.unshift(currentGenre);
+    }
+
+    var path = window.location.pathname;
+    // If user selected multiple include genres, go to /filmy-online/ with zanry= filter
+    // If only one include genre, go to its subpage /filmy-online/{slug}/
+    // Convert langs to backend format
+    // If user has both dub and sub checked → "vse", none → default (dub only), dub only → nothing, sub only → "sub"
+    var langParam = null;
+    if (langs.length === 0) {
+        langParam = 'vse';  // user explicitly deselected = show all
+    } else if (langs.length === 1 && langs[0] === 'dub') {
+        langParam = null;  // default
+    } else if (langs.length === 1) {
+        langParam = langs[0];  // sub
+    } else {
+        langParam = 'vse';  // both = all
+    }
+
+    if (inc.length === 1) {
+        path = '/filmy-online/' + inc[0] + '/';
+        var u = new URL(path, window.location.origin);
+        if (exc.length) u.searchParams.set('bez', exc.join(','));
+        if (year) u.searchParams.set('rok', year);
+        if (langParam) u.searchParams.set('jazyk', langParam);
+        if (sort && sort !== 'pridano') u.searchParams.set('razeni', sort);
+        if (dir === 'asc') u.searchParams.set('smer', 'asc');
+        window.location = u.toString();
+        return;
+    }
+
+    // Multi-include or no include → listing page with filter
+    var u = new URL('/filmy-online/', window.location.origin);
+    if (inc.length > 1) u.searchParams.set('zanry', inc.join(','));
+    if (inc.length > 1 && rezim === 'and') u.searchParams.set('rezim', 'and');
     if (exc.length) u.searchParams.set('bez', exc.join(','));
     if (year) u.searchParams.set('rok', year);
-    if (lang) u.searchParams.set('jazyk', lang);
-    if (sort && sort !== 'rok') u.searchParams.set('razeni', sort);
+    if (langParam) u.searchParams.set('jazyk', langParam);
+    if (sort && sort !== 'pridano') u.searchParams.set('razeni', sort);
+    if (dir === 'asc') u.searchParams.set('smer', 'asc');
     window.location = u.toString();
 }
 
 function resetFilters() {
-    window.location = '/filmy-online/';
+    // Reset to current page (remove all query params)
+    window.location = window.location.pathname;
 }
+
+/* --- Filter: prefill from URL + mutual exclusion + badge counter --- */
+(function() {
+    var panel = document.getElementById('filter-panel');
+    if (!panel) return;
+
+    // Prefill checkboxes from URL params
+    var urlParams = new URLSearchParams(window.location.search);
+    var incParam = urlParams.get('zanry');
+    var excParam = urlParams.get('bez');
+    var yearParam = urlParams.get('rok');
+    var langParam = urlParams.get('jazyk');
+
+    if (incParam) {
+        incParam.split(',').forEach(function(slug) {
+            var cb = panel.querySelector('#filter-genres-include input[value="' + slug + '"]');
+            if (cb) cb.checked = true;
+        });
+    }
+    var rezimParam = urlParams.get('rezim');
+    if (rezimParam === 'and') {
+        var rb = panel.querySelector('input[name="rezim"][value="and"]');
+        if (rb) rb.checked = true;
+    }
+    if (excParam) {
+        excParam.split(',').forEach(function(slug) {
+            var cb = panel.querySelector('#filter-genres-exclude input[value="' + slug + '"]');
+            if (cb) cb.checked = true;
+        });
+    }
+    if (yearParam) {
+        var yrSel = document.getElementById('filter-year');
+        if (yrSel) yrSel.value = yearParam;
+    }
+    if (langParam) {
+        langParam.split(',').forEach(function(l) {
+            var cb = panel.querySelector('#filter-langs input[value="' + l + '"]');
+            if (cb) cb.checked = true;
+        });
+    }
+
+    // Update filter toggle button with count of active filters
+    function updateFilterBadge() {
+        var checked = panel.querySelectorAll('input[type="checkbox"]:checked').length;
+        var yr = document.getElementById('filter-year');
+        var lg = document.getElementById('filter-lang');
+        if (yr && yr.value) checked++;
+        if (lg && lg.value) checked++;
+
+        var btn = document.getElementById('btn-filter-toggle');
+        if (btn) {
+            var badge = btn.querySelector('.filter-count');
+            if (checked > 0) {
+                if (!badge) {
+                    badge = document.createElement('span');
+                    badge.className = 'filter-count';
+                    btn.appendChild(badge);
+                }
+                badge.textContent = checked;
+            } else if (badge) {
+                badge.remove();
+            }
+        }
+    }
+    updateFilterBadge();
+
+    // Mutual exclusion + badge update on change
+    panel.addEventListener('change', function(e) {
+        var cb = e.target;
+        if (cb.type === 'checkbox' && cb.dataset.filter) {
+            var otherSection = cb.dataset.filter === 'include' ? 'exclude' : 'include';
+            if (cb.checked) {
+                var sibling = panel.querySelector(
+                    '#filter-genres-' + otherSection + ' input[value="' + cb.value + '"]'
+                );
+                if (sibling) sibling.checked = false;
+            }
+        }
+        updateFilterBadge();
+    });
+
+    // Filter panel opens only on user click, not automatically
+
+    // Enter key triggers apply
+    panel.addEventListener('keydown', function(e) {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            applyFilters();
+        }
+    });
+})();
 
 /* --- Search: button click → navigate to results --- */
 function doSearch() {

--- a/cr-web/templates/homepage.html
+++ b/cr-web/templates/homepage.html
@@ -24,6 +24,14 @@
         <span class="portal-category-icon">🎬</span>
         <span>Filmy a seriály</span>
     </a>
+    <a href="/filmy-online/" class="portal-category-link">
+        <span class="portal-category-icon">🎞️</span>
+        <span>Filmy online</span>
+    </a>
+    <a href="/serialy-online/" class="portal-category-link">
+        <span class="portal-category-icon">📺</span>
+        <span>Seriály online</span>
+    </a>
 </nav>
 
 <section class="active-hub">

--- a/cr-web/templates/series_detail.html
+++ b/cr-web/templates/series_detail.html
@@ -1,0 +1,334 @@
+{% extends "base.html" %}
+
+{% block title %}{{ series.title }}{% match series.first_air_year %}{% when Some with (y) %} ({{ y }}){% when None %}{% endmatch %} — seriál online{% endblock %}
+
+{% block meta_description %}{% match series.description %}{% when Some with (d) %}{{ d }}{% when None %}{{ series.title }} — sledujte seriál online na ceskarepublika.wiki{% endmatch %}{% endblock %}
+
+{% block og_title %}{{ series.title }}{% match series.first_air_year %}{% when Some with (y) %} ({{ y }}){% when None %}{% endmatch %} — seriál online{% endblock %}
+{% block og_description %}{% match series.description %}{% when Some with (d) %}{{ d }}{% when None %}{{ series.title }} — seriál online zdarma{% endmatch %}{% endblock %}
+{% block og_image %}{% match series.cover_filename %}{% when Some with (c) %}https://ceskarepublika.wiki/serialy-online/{{ series.slug }}.webp{% when None %}https://ceskarepublika.wiki/static/img/og-filmy-a-serialy-v6.png{% endmatch %}{% endblock %}
+{% block og_type %}video.tv_show{% endblock %}
+
+{% block leaflet %}{% endblock %}
+
+{% block head %}
+<link rel="icon" type="image/svg+xml" href="/static/img/logo-filmy-a-serialy.svg?v=6">
+<meta property="og:url" content="https://ceskarepublika.wiki/serialy-online/{{ series.slug }}/">
+{% endblock %}
+
+{% block header_left %}
+<div class="logo-group" style="display:flex;align-items:center;gap:0.5rem;">
+    <a href="/serialy-online/" style="display:flex;align-items:center;text-decoration:none;" alt="Seriály online" title="Seriály online">
+        <img src="/static/img/logo-filmy-a-serialy.svg?v=6" alt="Logo Seriály online" title="Seriály online" class="header-emblem">
+    </a>
+    <h1>{{ series.title }}</h1>
+</div>
+{% endblock %}
+
+{% block header_search %}
+<div class="search-container" id="header-search-box">
+    <input type="text" id="series-search" class="search-input" placeholder="Hledat seriál..." autocomplete="off">
+    <button class="search-btn" onclick="doSearch()" alt="Hledat" title="Hledat">Hledat</button>
+    <div id="search-results" class="search-dropdown"></div>
+</div>
+{% endblock %}
+
+{% block header_right %}<div class="context-emblem"></div>{% endblock %}
+
+{% block content %}
+<main class="series-detail-page">
+    <nav class="breadcrumb">
+        <a href="/" alt="Česká republika" title="Česká republika">Česká republika</a>
+        <span>›</span> <a href="/serialy-online/" alt="Seriály online" title="Seriály online">Seriály online</a>
+        <span>›</span> <span>{{ series.title }}</span>
+    </nav>
+
+    <div class="film-hero">
+        <div class="film-cover">
+            {% match series.cover_filename %}
+            {% when Some with (c) %}
+            <div class="cover-zoom" data-gallery-open="series" data-index="0"
+                 data-gallery-photos="[&quot;/serialy-online/{{ series.slug }}-large.webp&quot;]">
+                <img src="/serialy-online/{{ series.slug }}.webp" alt="{{ series.title }}" title="{{ series.title }}" width="200" height="300">
+            </div>
+            {% when None %}
+            <div class="no-cover">{{ series.title }}</div>
+            {% endmatch %}
+        </div>
+        <div class="film-meta">
+            <h2>{{ series.title }}{% match series.first_air_year %}{% when Some with (y) %} <span class="year">({{ y }}{% match series.last_air_year %}{% when Some with (ly) %}{% if ly != y %}–{{ ly }}{% endif %}{% when None %}{% endmatch %})</span>{% when None %}{% endmatch %}</h2>
+            {% match series.original_title %}
+            {% when Some with (ot) %}{% if ot.as_str() != series.title.as_str() %}<p class="original-title">{{ ot }}</p>{% endif %}
+            {% when None %}{% endmatch %}
+            <div class="meta-row">
+                {% match series.imdb_rating %}
+                {% when Some with (r) %}<span class="meta-badge imdb" title="IMDB hodnocení">IMDB {{ r }}</span>
+                {% when None %}{% endmatch %}
+                {% match series.csfd_rating %}
+                {% when Some with (r) %}<span class="meta-badge csfd" title="ČSFD hodnocení">ČSFD {{ r }}%</span>
+                {% when None %}{% endmatch %}
+            </div>
+            {% if !genres.is_empty() %}
+            <div class="genre-tags">
+                {% for g in genres %}
+                <a href="/serialy-online/{{ g.slug }}/" class="genre-tag" alt="{{ g.name_cs }} seriály" title="{{ g.name_cs }} seriály">{{ g.name_cs }}</a>
+                {% endfor %}
+            </div>
+            {% endif %}
+            {% match series.description %}
+            {% when Some with (d) %}<div class="film-description"><p>{{ d }}</p></div>
+            {% when None %}{% endmatch %}
+        </div>
+    </div>
+
+    {% if !creators.is_empty() %}
+    <section class="crew-section">
+        <h3>Tvůrci</h3>
+        <div class="people-row">
+            {% for p in creators %}
+            <div class="person-card">
+                {% match p.profile_filename %}
+                {% when Some with (f) %}
+                <img class="person-photo" src="/serialy-online/person/{{ f }}" alt="{{ p.name }}" title="{{ p.name }}">
+                {% when None %}
+                <div class="person-photo placeholder">{{ p.name }}</div>
+                {% endmatch %}
+                <span class="person-name">{{ p.name }}</span>
+            </div>
+            {% endfor %}
+        </div>
+    </section>
+    {% endif %}
+
+    {% if !actors.is_empty() %}
+    <section class="crew-section">
+        <h3>Herci</h3>
+        <div class="people-row">
+            {% for p in actors %}
+            <div class="person-card">
+                {% match p.profile_filename %}
+                {% when Some with (f) %}
+                <img class="person-photo" src="/serialy-online/person/{{ f }}" alt="{{ p.name }}" title="{{ p.name }}">
+                {% when None %}
+                <div class="person-photo placeholder">{{ p.name }}</div>
+                {% endmatch %}
+                <span class="person-name" title="{{ p.name }}">{{ p.name }}</span>
+                {% match p.character_name %}{% when Some with (c) %}<span class="person-char" title="{{ c }}">{{ c }}</span>{% when None %}{% endmatch %}
+            </div>
+            {% endfor %}
+        </div>
+    </section>
+    {% endif %}
+
+    <div class="seasons-section">
+        <div class="seasons-header">
+            <h3>Epizody</h3>
+            <div class="films-toolbar">
+                <button class="view-btn view-toggle" id="btn-view-toggle" onclick="toggleEpView()" alt="Přepnout zobrazení" title="Přepnout zobrazení mřížka / seznam">
+                    <svg class="view-icon-grid" width="18" height="18" viewBox="0 0 18 18"><rect x="1" y="2" width="16" height="3" rx="1" fill="currentColor"/><rect x="1" y="7.5" width="16" height="3" rx="1" fill="currentColor"/><rect x="1" y="13" width="16" height="3" rx="1" fill="currentColor"/></svg>
+                    <svg class="view-icon-list" width="18" height="18" viewBox="0 0 18 18" style="display:none;"><rect x="1" y="1" width="7" height="7" rx="1" fill="currentColor"/><rect x="10" y="1" width="7" height="7" rx="1" fill="currentColor"/><rect x="1" y="10" width="7" height="7" rx="1" fill="currentColor"/><rect x="10" y="10" width="7" height="7" rx="1" fill="currentColor"/></svg>
+                </button>
+            </div>
+        </div>
+
+        {% for season in seasons %}
+        <div class="season-block collapsed" data-season="{{ season.number }}">
+            <button class="season-title season-toggle" type="button" onclick="toggleSeason({{ season.number }})"
+                    alt="Sbalit nebo rozbalit sérii" title="Sbalit nebo rozbalit sérii">
+                <span class="chev">▾</span>
+                {% if season.number == 0 %}Speciály{% else %}{{ season.number }}. série{% endif %}
+                <span class="ep-count">({{ season.episodes.len() }} epizod)</span>
+            </button>
+            <div class="episode-grid" id="season-{{ season.number }}">
+                {% for ep in season.episodes %}
+                <a class="episode-card" href="/serialy-online/{{ series.slug }}/{{ ep.season }}x{{ ep.episode }}/"
+                   alt="S{{ ep.season }}E{{ ep.episode }}{% match ep.episode_name %}{% when Some with (n) %} — {{ n }}{% when None %}{% endmatch %}"
+                   title="S{{ ep.season }}E{{ ep.episode }}{% match ep.episode_name %}{% when Some with (n) %} — {{ n }}{% when None %}{% endmatch %}">
+                    <div class="ep-head">
+                        <span class="ep-badge">S{{ ep.season }}E{{ ep.episode }}</span>
+                        <h5 class="ep-title">{% match ep.episode_name %}{% when Some with (n) %}{{ n }}{% when None %}Epizoda {{ ep.episode }}{% endmatch %}</h5>
+                    </div>
+                    <div class="ep-meta">
+                        {% match ep.air_date %}{% when Some with (d) %}<span>📅 {{ d }}</span>{% when None %}{% endmatch %}
+                        {% match ep.runtime %}{% when Some with (r) %}<span>⏱ {{ r }} min</span>{% when None %}{% endmatch %}
+                    </div>
+                    {% match ep.overview %}{% when Some with (o) %}<p class="ep-overview">{{ o }}</p>{% when None %}{% endmatch %}
+                </a>
+                {% endfor %}
+            </div>
+        </div>
+        {% endfor %}
+    </div>
+</main>
+
+<style>
+.series-detail-page { max-width: 1200px; margin: 0 auto; padding: 1rem; }
+.breadcrumb { font-size: 0.85rem; color: #888; margin-bottom: 1.2rem; }
+.breadcrumb a { color: #11457E; text-decoration: none; }
+
+#header-search-box { position: relative; overflow: visible !important; }
+.search-dropdown { display: none; position: absolute; top: calc(100% + 4px); left: 0; right: 0; background: white; border: 1px solid #ddd; border-radius: 12px; box-shadow: 0 8px 24px rgba(0,0,0,0.18); z-index: 200; max-height: 420px; overflow-y: auto; }
+.search-dropdown.open { display: block; }
+.search-item { display: flex; align-items: center; gap: 0.7rem; padding: 0.5rem 0.8rem; text-decoration: none; color: inherit; border-bottom: 1px solid #f0f0f0; }
+.search-item:hover { background: #f5f5f5; }
+.search-item img { width: 40px; height: 60px; object-fit: cover; border-radius: 4px; }
+.search-item .si-placeholder { width: 40px; height: 60px; background: #eee; border-radius: 4px; }
+.search-item .si-info { flex: 1; min-width: 0; }
+.search-item .si-title { font-weight: 500; display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.search-item .si-meta { font-size: 0.8rem; color: #888; }
+
+.film-hero { display: flex; gap: 1.5rem; margin-bottom: 1.5rem; }
+@media (max-width: 600px) { .film-hero { flex-direction: column; align-items: center; } }
+.film-cover { flex-shrink: 0; width: 200px; }
+.film-cover img { width: 200px; border-radius: 8px; box-shadow: 0 2px 12px rgba(0,0,0,0.2); display: block; }
+.cover-zoom { cursor: zoom-in; display: inline-block; border-radius: 8px; overflow: hidden; }
+.no-cover { width: 200px; height: 300px; background: #222; border-radius: 8px; display: flex; align-items: center; justify-content: center; color: #888; padding: 1rem; text-align: center; }
+.film-meta h2 { margin: 0 0 0.4rem; font-size: 1.5rem; }
+.film-meta .year { color: #888; font-weight: 400; }
+.original-title { color: #888; font-style: italic; margin: 0 0 0.6rem; font-size: 0.9rem; }
+.meta-row { display: flex; gap: 0.4rem; margin-bottom: 0.8rem; }
+.meta-badge { padding: 0.2rem 0.5rem; border-radius: 4px; font-size: 0.82rem; font-weight: 600; }
+.meta-badge.imdb { background: #f5c518; color: #000; }
+.meta-badge.csfd { background: #ba0305; color: #fff; }
+.genre-tags { display: flex; gap: 0.4rem; flex-wrap: wrap; margin-bottom: 0.8rem; }
+.genre-tag { padding: 0.3rem 0.8rem; border-radius: 999px; background: #f1f5f9; color: #11457E; text-decoration: none; font-size: 0.85rem; font-weight: 600; transition: background 0.15s, color 0.15s; cursor: pointer; }
+.genre-tag:hover { background: #11457E; color: white; }
+.film-description { line-height: 1.6; color: #333; }
+
+/* Crew (actors + creators) */
+.crew-section { margin: 1.5rem 0; }
+.crew-section h3 { font-size: 1.1rem; margin: 0 0 0.8rem; color: #333; }
+.people-row { display: grid; grid-template-columns: repeat(auto-fill, minmax(120px, 1fr)); gap: 0.8rem; }
+.person-card { background: white; border-radius: 8px; overflow: hidden; box-shadow: 0 1px 4px rgba(0,0,0,0.1); display: flex; flex-direction: column; }
+.person-photo { width: 100%; aspect-ratio: 2/3; object-fit: cover; display: block; background: #222; }
+.person-photo.placeholder { display: flex; align-items: center; justify-content: center; color: #888; padding: 0.5rem; text-align: center; font-size: 0.75rem; }
+.person-name { display: block; padding: 0.4rem 0.5rem 0.1rem; font-size: 0.82rem; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.person-char { display: block; padding: 0 0.5rem 0.4rem; font-size: 0.75rem; color: #888; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* Seasons + episodes */
+.seasons-header { display: flex; justify-content: space-between; align-items: center; margin: 1rem 0 0.8rem; }
+.seasons-section h3 { font-size: 1.2rem; margin: 0; color: #333; }
+.films-toolbar { display: flex; gap: 0.4rem; }
+.view-btn { background: #f1f5f9; color: #555; border: none; padding: 0.4rem 0.7rem; border-radius: 6px; cursor: pointer; display: inline-flex; align-items: center; transition: background 0.15s; }
+.view-btn:hover { background: #e2e8f0; }
+.season-block { margin-bottom: 1.5rem; }
+.season-toggle { display: flex; align-items: center; gap: 0.5rem; width: 100%; background: #f1f5f9; border: none; padding: 0.6rem 0.9rem; border-radius: 8px; font-size: 1rem; font-weight: 600; color: #11457E; cursor: pointer; text-align: left; margin: 0.8rem 0 0.6rem; transition: background 0.15s; }
+.season-toggle:hover { background: #e2e8f0; }
+.season-toggle .chev { display: inline-block; transition: transform 0.15s; font-size: 0.8rem; }
+.season-block.collapsed .season-toggle .chev { transform: rotate(-90deg); }
+.season-block.collapsed .episode-grid { display: none; }
+.season-toggle .ep-count { color: #888; font-weight: 400; font-size: 0.85rem; margin-left: auto; }
+
+/* Grid view (default): compact cards without thumbnails */
+.episode-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 0.5rem; }
+.episode-card { display: block; background: white; border-radius: 8px; padding: 0.7rem 0.9rem; box-shadow: 0 1px 3px rgba(0,0,0,0.08); text-decoration: none; color: inherit; transition: transform 0.15s, box-shadow 0.15s; }
+.episode-card:hover { transform: translateY(-1px); box-shadow: 0 4px 10px rgba(0,0,0,0.12); }
+.ep-head { display: flex; align-items: baseline; gap: 0.5rem; margin-bottom: 0.25rem; }
+.ep-badge { flex-shrink: 0; background: #f1f5f9; color: #11457E; padding: 0.15rem 0.5rem; border-radius: 4px; font-size: 0.72rem; font-weight: 700; letter-spacing: 0.02em; transition: background 0.15s, color 0.15s; }
+.episode-card:hover .ep-badge { background: #11457E; color: white; }
+.ep-title { margin: 0; font-size: 0.9rem; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; min-width: 0; }
+.ep-meta { display: flex; gap: 0.6rem; font-size: 0.75rem; color: #888; flex-wrap: wrap; }
+.ep-overview { display: none; font-size: 0.82rem; color: #555; margin: 0.4rem 0 0; line-height: 1.4; }
+
+/* List view: show overview + allow title wrap */
+.episode-grid.list-view { grid-template-columns: 1fr; }
+.episode-grid.list-view .episode-card { padding: 0.8rem 1rem; }
+.episode-grid.list-view .ep-title { white-space: normal; }
+.episode-grid.list-view .ep-overview { display: block; }
+</style>
+
+<script>
+function toggleSeason(num) {
+    var block = document.querySelector('.season-block[data-season="' + num + '"]');
+    if (!block) return;
+    block.classList.toggle('collapsed');
+    // Persist state per series
+    var key = 'seasonsCollapsed:' + location.pathname;
+    var state = {};
+    try { state = JSON.parse(localStorage.getItem(key) || '{}'); } catch (e) {}
+    state[num] = block.classList.contains('collapsed');
+    localStorage.setItem(key, JSON.stringify(state));
+}
+(function() {
+    // Default: all seasons collapsed. Restore any user-expanded seasons
+    // from localStorage (stored with value `false` = expanded).
+    var key = 'seasonsCollapsed:' + location.pathname;
+    var state = {};
+    try { state = JSON.parse(localStorage.getItem(key) || '{}'); } catch (e) {}
+    Object.keys(state).forEach(function(num) {
+        var block = document.querySelector('.season-block[data-season="' + num + '"]');
+        if (!block) return;
+        if (state[num] === false) block.classList.remove('collapsed');
+    });
+})();
+
+function setEpView(mode) {
+    document.querySelectorAll('.episode-grid').forEach(function(g) {
+        g.classList.toggle('list-view', mode === 'list');
+    });
+    var iconGrid = document.querySelector('.view-icon-grid');
+    var iconList = document.querySelector('.view-icon-list');
+    if (iconGrid) iconGrid.style.display = (mode === 'list') ? 'none' : '';
+    if (iconList) iconList.style.display = (mode === 'list') ? '' : 'none';
+    localStorage.setItem('seriesEpView', mode);
+}
+function toggleEpView() {
+    var cur = localStorage.getItem('seriesEpView') || 'grid';
+    setEpView(cur === 'list' ? 'grid' : 'list');
+}
+(function() {
+    var saved = localStorage.getItem('seriesEpView');
+    if (saved === 'list') setEpView('list');
+})();
+
+/* Header search */
+function doSearch() {
+    var q = document.getElementById('series-search').value.trim();
+    if (q.length >= 2) window.location = '/serialy-online/?q=' + encodeURIComponent(q);
+}
+(function() {
+    var input = document.getElementById('series-search');
+    var dd = document.getElementById('search-results');
+    var timer = null;
+    if (!input || !dd) return;
+    input.addEventListener('input', function() {
+        clearTimeout(timer);
+        var q = this.value.trim();
+        if (q.length < 2) { dd.classList.remove('open'); return; }
+        timer = setTimeout(function() {
+            fetch('/api/series/search?q=' + encodeURIComponent(q))
+                .then(function(r) { return r.json(); })
+                .then(function(results) {
+                    if (!results.length) { dd.innerHTML = '<div style="padding:0.8rem;color:#888;text-align:center">Nic nenalezeno</div>'; }
+                    else {
+                        dd.innerHTML = results.map(function(r) {
+                            var cover = r.cover
+                                ? '<img src="/serialy-online/' + r.slug + '.webp" alt="' + r.title + '" title="' + r.title + '">'
+                                : '<div class="si-placeholder"></div>';
+                            var yr = r.year ? ' (' + r.year + ')' : '';
+                            var rat = r.imdb_rating ? ' — IMDB ' + r.imdb_rating : '';
+                            return '<a href="/serialy-online/' + r.slug + '/" class="search-item" alt="' + r.title + '" title="' + r.title + '">'
+                                + cover + '<div class="si-info"><span class="si-title">' + r.title + yr + '</span>'
+                                + '<span class="si-meta">' + rat + '</span></div></a>';
+                        }).join('');
+                    }
+                    dd.classList.add('open');
+                })
+                .catch(function() { dd.classList.remove('open'); });
+        }, 200);
+    });
+    document.addEventListener('click', function(e) { if (!e.target.closest('#header-search-box')) dd.classList.remove('open'); });
+    input.addEventListener('keydown', function(e) { if (e.key === 'Enter') { e.preventDefault(); doSearch(); } });
+})();
+
+/* Auto-redirect from old URL ?s=X&e=Y to new episode detail URL */
+(function() {
+    var params = new URLSearchParams(window.location.search);
+    var s = parseInt(params.get('s'), 10);
+    var e = parseInt(params.get('e'), 10);
+    if (s && e) {
+        window.location.replace(window.location.pathname + s + 'x' + e + '/');
+    }
+})();
+</script>
+{% endblock %}

--- a/cr-web/templates/series_list.html
+++ b/cr-web/templates/series_list.html
@@ -1,0 +1,373 @@
+{% extends "base.html" %}
+
+{% block title %}{% match current_genre %}{% when Some with (g) %}{{ g.name_cs }} seriály online{% when None %}Seriály online{% endmatch %}{% endblock %}
+
+{% block meta_description %}{% match current_genre %}{% when Some with (g) %}{{ g.name_cs }} seriály online zdarma — {{ total_count }} seriálů ke zhlédnutí.{% when None %}Seriály online zdarma — {{ total_count }} seriálů ke zhlédnutí na ceskarepublika.wiki.{% endmatch %}{% endblock %}
+
+{% block og_title %}{% match current_genre %}{% when Some with (g) %}{{ g.name_cs }} seriály online — ceskarepublika.wiki{% when None %}Seriály online — ceskarepublika.wiki{% endmatch %}{% endblock %}
+{% block og_description %}Seriály online zdarma — {{ total_count }} seriálů ke zhlédnutí.{% endblock %}
+{% block og_image %}https://ceskarepublika.wiki/static/img/og-filmy-a-serialy-v6.png{% endblock %}
+{% block og_type %}article{% endblock %}
+
+{% block leaflet %}{% endblock %}
+
+{% block head %}
+<link rel="icon" type="image/svg+xml" href="/static/img/logo-filmy-a-serialy.svg?v=6">
+<meta property="og:image:secure_url" content="https://ceskarepublika.wiki/static/img/og-filmy-a-serialy-v6.png">
+<meta property="og:image:type" content="image/png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:alt" content="Seriály online — ceskarepublika.wiki">
+<meta property="og:url" content="https://ceskarepublika.wiki/serialy-online/">
+{% endblock %}
+
+{% block header_left %}
+<div class="logo-group" style="display:flex;align-items:center;gap:0.5rem;">
+    <a href="/serialy-online/" style="display:flex;align-items:center;text-decoration:none;" alt="Seriály online" title="Seriály online">
+        <img src="/static/img/logo-filmy-a-serialy.svg?v=6" alt="Logo Seriály online" title="Seriály online" class="header-emblem">
+    </a>
+    <h1>{% match current_genre %}{% when Some with (g) %}{{ g.name_cs }}{% when None %}Seriály online{% endmatch %}</h1>
+</div>
+{% endblock %}
+
+{% block header_search %}
+<div class="search-container" id="header-search-box">
+    <input type="text" id="series-search" class="search-input" placeholder="Hledat seriál..." autocomplete="off" {% match search_query %}{% when Some with (q) %}value="{{ q }}"{% when None %}{% endmatch %}>
+    <button class="search-btn" onclick="doSearch()">Hledat</button>
+    <div id="search-results" class="search-dropdown"></div>
+</div>
+{% endblock %}
+
+{% block header_right %}<div class="context-emblem"></div>{% endblock %}
+
+{% block content %}
+<main class="series-page">
+<nav class="breadcrumb">
+    <a href="/" alt="Česká republika" title="Česká republika">Česká republika</a>
+    <span>›</span> <a href="/serialy-online/" alt="Seriály online" title="Seriály online">Seriály online</a>
+    {% match current_genre %}
+    {% when Some with (g) %}
+    <span>›</span> <span>{{ g.name_cs }}</span>
+    {% when None %}
+    {% endmatch %}
+</nav>
+
+<div class="films-header">
+    <h2>
+        {% match search_query %}
+        {% when Some with (q) %}Výsledky hledání pro „{{ q }}" <span class="count">({{ total_count }})</span>
+        {% when None %}
+            {% match current_genre %}
+            {% when Some with (g) %}{{ g.name_cs }} <span class="count">({{ total_count }})</span>
+            {% when None %}Nejnovější epizody z {{ total_count }} seriálů
+            {% endmatch %}
+        {% endmatch %}
+    </h2>
+    <div class="films-toolbar">
+        <label class="toolbar-group">
+            <span class="toolbar-label">Řazení:</span>
+            <select id="sort-select" onchange="applySortCombined(this.value)" aria-label="Řazení" class="sort-select-combined">
+                <option value="pridano:desc">Naposledy přidané</option>
+                <option value="rok:desc">Od nejnovějších</option>
+                <option value="imdb:desc">Nejlépe hodnocené IMDB</option>
+                <option value="nazev:asc">Podle názvu A–Z</option>
+            </select>
+        </label>
+        <button class="view-btn view-toggle" id="btn-view-toggle" onclick="toggleView()" aria-label="Přepnout zobrazení mřížka / seznam">
+            <svg class="view-icon-grid" width="18" height="18" viewBox="0 0 18 18"><rect x="1" y="2" width="16" height="3" rx="1" fill="currentColor"/><rect x="1" y="7.5" width="16" height="3" rx="1" fill="currentColor"/><rect x="1" y="13" width="16" height="3" rx="1" fill="currentColor"/></svg>
+            <svg class="view-icon-list" width="18" height="18" viewBox="0 0 18 18" style="display:none;"><rect x="1" y="1" width="7" height="7" rx="1" fill="currentColor"/><rect x="10" y="1" width="7" height="7" rx="1" fill="currentColor"/><rect x="1" y="10" width="7" height="7" rx="1" fill="currentColor"/><rect x="10" y="10" width="7" height="7" rx="1" fill="currentColor"/></svg>
+        </button>
+    </div>
+</div>
+
+<nav class="genre-nav">
+    {% if current_genre.is_none() %}
+    <span class="genre-tag current">Vše</span>
+    {% else %}
+    <a href="/serialy-online/" class="genre-tag" alt="Všechny seriály" title="Všechny seriály">Vše</a>
+    {% endif %}
+    {% for g in genres %}
+    {% match current_genre %}{% when Some with (cg) %}{% if cg.id == g.id %}
+    <span class="genre-tag current">{{ g.name_cs }}</span>
+    {% else %}
+    <a href="/serialy-online/{{ g.slug }}/" class="genre-tag" alt="{{ g.name_cs }} seriály" title="{{ g.name_cs }} seriály">{{ g.name_cs }}</a>
+    {% endif %}{% when None %}
+    <a href="/serialy-online/{{ g.slug }}/" class="genre-tag" alt="{{ g.name_cs }} seriály" title="{{ g.name_cs }} seriály">{{ g.name_cs }}</a>
+    {% endmatch %}
+    {% endfor %}
+</nav>
+
+{# Main grid: episodes (default) or series (search mode) #}
+{% if !episodes.is_empty() %}
+<div class="films-grid" id="films-container">
+    {% for ep in episodes %}
+    <a href="/serialy-online/{{ ep.series_slug }}/{{ ep.season }}x{{ ep.episode }}/" class="film-card" alt="{{ ep.series_title }} — S{{ ep.season }}E{{ ep.episode }}" title="{{ ep.series_title }} — S{{ ep.season }}E{{ ep.episode }}">
+        <div class="film-poster">
+            {% match ep.series_cover_filename %}
+            {% when Some with (c) %}
+            <img src="/serialy-online/{{ ep.series_slug }}.webp" alt="{{ ep.series_title }}" title="{{ ep.series_title }}" loading="lazy" width="200" height="300">
+            {% when None %}
+            <div class="no-poster">{{ ep.series_title }}</div>
+            {% endmatch %}
+            <div class="rating-badges">
+                {% match ep.series_imdb_rating %}
+                {% when Some with (r) %}<span class="rating-badge imdb" title="IMDB hodnocení">{{ r }}</span>{% when None %}{% endmatch %}
+                {% match ep.series_csfd_rating %}
+                {% when Some with (r) %}<span class="rating-badge csfd" title="ČSFD hodnocení">{{ r }}%</span>{% when None %}{% endmatch %}
+            </div>
+            {% if ep.has_subtitles.unwrap_or(false) %}
+            <span class="cc-badge" title="České titulky">CC</span>
+            {% endif %}
+        </div>
+        <div class="film-body">
+            <div class="film-info">
+                <span class="film-title">{{ ep.series_title }}</span>
+                {% match ep.series_original_title %}{% when Some with (ot) %}{% if ot.as_str() != ep.series_title.as_str() %}<span class="film-original">{{ ot }}</span>{% endif %}{% when None %}{% endmatch %}
+                <span class="film-episode-label">Epizoda S{{ ep.season }}×{{ ep.episode }}</span>
+            </div>
+            <div class="film-list-extra">
+                <div class="film-ratings">
+                    {% match ep.series_imdb_rating %}{% when Some with (r) %}<span class="badge imdb">IMDB {{ r }}</span>{% when None %}{% endmatch %}
+                    {% match ep.series_csfd_rating %}{% when Some with (r) %}<span class="badge csfd">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
+                    {% match ep.series_first_air_year %}{% when Some with (y) %}<span class="badge year">{{ y }}</span>{% when None %}{% endmatch %}
+                </div>
+                {% match ep.series_description %}{% when Some with (d) %}<p class="film-desc">{{ d }}</p>{% when None %}{% endmatch %}
+            </div>
+        </div>
+    </a>
+    {% endfor %}
+</div>
+{% else %}
+<div class="films-grid" id="films-container">
+    {% for s in series %}
+    <a href="/serialy-online/{{ s.slug }}/" class="film-card" alt="{{ s.title }}" title="{{ s.title }}">
+        <div class="film-poster">
+            {% match s.cover_filename %}
+            {% when Some with (cover) %}
+            <img src="/serialy-online/{{ s.slug }}.webp" alt="{{ s.title }}" title="{{ s.title }}" loading="lazy" width="200" height="300">
+            {% when None %}
+            <div class="no-poster">{{ s.title }}</div>
+            {% endmatch %}
+            <div class="rating-badges">
+                {% match s.imdb_rating %}{% when Some with (r) %}<span class="rating-badge imdb" title="IMDB hodnocení">{{ r }}</span>{% when None %}{% endmatch %}
+                {% match s.csfd_rating %}{% when Some with (r) %}<span class="rating-badge csfd" title="ČSFD hodnocení">{{ r }}%</span>{% when None %}{% endmatch %}
+            </div>
+        </div>
+        <div class="film-body">
+            <div class="film-info">
+                <span class="film-title">{{ s.title }}</span>
+                {% match s.original_title %}{% when Some with (ot) %}{% if ot.as_str() != s.title.as_str() %}<span class="film-original">{{ ot }}</span>{% endif %}{% when None %}{% endmatch %}
+                {% match s.first_air_year %}{% when Some with (y) %}<span class="film-year">{{ y }}</span>{% when None %}{% endmatch %}
+            </div>
+            <div class="film-list-extra">
+                <div class="film-ratings">
+                    {% match s.imdb_rating %}{% when Some with (r) %}<span class="badge imdb">IMDB {{ r }}</span>{% when None %}{% endmatch %}
+                    {% match s.csfd_rating %}{% when Some with (r) %}<span class="badge csfd">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
+                </div>
+                {% match s.description %}{% when Some with (d) %}<p class="film-desc">{{ d }}</p>{% when None %}{% endmatch %}
+            </div>
+        </div>
+    </a>
+    {% endfor %}
+</div>
+{% endif %}
+
+{% if total_pages > 1 %}
+<nav class="pagination">
+    {% if page > 1 %}
+    <a href="?strana={{ page - 1 }}{{ query_string }}" class="page-link" alt="Předchozí stránka" title="Předchozí stránka">&laquo;</a>
+    {% endif %}
+    {% for p in 1..=total_pages %}
+    {% if p == page %}
+    <span class="page-link current">{{ p }}</span>
+    {% else %}
+    {% if p <= 2 || p > total_pages - 2 || (p >= page - 2 && p <= page + 2) %}
+    <a href="?strana={{ p }}{{ query_string }}" class="page-link" alt="Strana {{ p }}" title="Strana {{ p }}">{{ p }}</a>
+    {% else %}
+    {% if p == 3 && page > 5 %}<span class="page-dots">…</span>{% endif %}
+    {% if p == total_pages - 2 && page < total_pages - 4 %}<span class="page-dots">…</span>{% endif %}
+    {% endif %}
+    {% endif %}
+    {% endfor %}
+    {% if page < total_pages %}
+    <a href="?strana={{ page + 1 }}{{ query_string }}" class="page-link" alt="Další stránka" title="Další stránka">&raquo;</a>
+    {% endif %}
+</nav>
+{% endif %}
+</main>
+
+<style>
+.series-page { max-width: 1200px; margin: 0 auto; padding: 1rem; }
+
+/* Search dropdown */
+#header-search-box { position: relative; overflow: visible !important; }
+.search-dropdown { display: none; position: absolute; top: calc(100% + 4px); left: 0; right: 0; background: white; border: 1px solid #ddd; border-radius: 12px; box-shadow: 0 8px 24px rgba(0,0,0,0.18); z-index: 200; max-height: 420px; overflow-y: auto; }
+.search-dropdown.open { display: block; }
+.search-item { display: flex; align-items: center; gap: 0.7rem; padding: 0.5rem 0.8rem; text-decoration: none; color: inherit; border-bottom: 1px solid #f0f0f0; transition: background 0.15s; }
+.search-item:last-child { border-bottom: none; }
+.search-item:hover { background: #f5f5f5; }
+.search-item img { width: 40px; height: 60px; object-fit: cover; border-radius: 4px; flex-shrink: 0; }
+.search-item .si-placeholder { width: 40px; height: 60px; background: #eee; border-radius: 4px; flex-shrink: 0; }
+.search-item .si-info { flex: 1; min-width: 0; }
+.search-item .si-title { font-weight: 500; display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.search-item .si-meta { font-size: 0.8rem; color: #888; }
+
+/* Header + toolbar */
+.breadcrumb { font-size: 0.85rem; color: #888; margin: 0.5rem 0 1rem; }
+.breadcrumb a { color: #11457E; text-decoration: none; }
+.films-header { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 0.8rem; }
+.films-header h2 { margin: 0; font-size: 1.3rem; }
+.films-header .count { color: #888; font-weight: 400; }
+.films-toolbar { display: flex; align-items: center; gap: 0.4rem; }
+.toolbar-group { display: inline-flex; align-items: center; gap: 0.4rem; }
+.toolbar-label { font-size: 0.82rem; color: #555; font-weight: 500; }
+.sort-select-combined { padding: 0.4rem 0.7rem; border: 1px solid #ddd; border-radius: 6px; font-size: 0.85rem; cursor: pointer; background: white; min-width: 200px; }
+.view-btn { background: #f0f0f0; border: none; padding: 0.4rem; border-radius: 6px; cursor: pointer; color: #666; display: flex; align-items: center; transition: background 0.15s; }
+.view-btn:hover { background: #e0e0e0; }
+.view-toggle { background: #f1f5f9; color: #555; border-radius: 6px; padding: 0.4rem 0.7rem; }
+
+/* Genre tags */
+.genre-nav { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-bottom: 1.2rem; }
+.genre-tag { display: inline-flex; align-items: center; padding: 0.4rem 0.9rem; border-radius: 999px; background: #f1f5f9; color: #11457E; text-decoration: none; font-size: 0.85rem; font-weight: 600; transition: background 0.15s, color 0.15s; cursor: pointer; }
+.genre-tag:hover { background: #11457E; color: white; }
+.genre-tag.current { background: #C5A059; color: white; cursor: default; }
+
+/* Films grid (cards) */
+.films-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 1rem; }
+.films-grid .film-card { text-decoration: none; color: inherit; display: block; border-radius: 8px; overflow: hidden; background: white; box-shadow: 0 1px 4px rgba(0,0,0,0.1); transition: transform 0.15s, box-shadow 0.15s; }
+.films-grid .film-card:hover { transform: translateY(-2px); box-shadow: 0 4px 12px rgba(0,0,0,0.15); }
+.film-poster { aspect-ratio: 2/3; background: #222; position: relative; }
+.film-poster img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.no-poster { width: 100%; height: 100%; display: flex; align-items: center; justify-content: center; color: #888; padding: 1rem; text-align: center; }
+.rating-badges { position: absolute; top: 0.4rem; left: 0.4rem; display: flex; gap: 0.25rem; }
+.rating-badge { padding: 0.15rem 0.4rem; border-radius: 4px; font-size: 0.7rem; font-weight: 700; box-shadow: 0 1px 3px rgba(0,0,0,0.3); }
+.rating-badge.imdb { background: #f5c518; color: #000; }
+.rating-badge.csfd { background: #b01020; color: #fff; }
+.cc-badge { position: absolute; bottom: 0.4rem; right: 0.4rem; background: #4ade80; color: #003c1c; padding: 0.1rem 0.4rem; border-radius: 4px; font-size: 0.7rem; font-weight: 700; letter-spacing: 0.03em; box-shadow: 0 1px 3px rgba(0,0,0,0.3); }
+.film-body { padding: 0.6rem; }
+.film-info { display: flex; flex-direction: column; }
+.film-title { font-weight: 600; font-size: 0.95rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.film-original { font-size: 0.8rem; color: #888; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.film-year { font-size: 0.8rem; color: #555; }
+.film-episode-label { display: inline-block; padding: 0.15rem 0.5rem; border-radius: 999px; background: #f1f5f9; color: #11457E; font-size: 0.78rem; font-weight: 600; margin-top: 0.15rem; align-self: flex-start; transition: background 0.15s, color 0.15s; }
+.film-card:hover .film-episode-label { background: #11457E; color: white; }
+.film-list-extra { display: none; }
+.film-ratings { display: flex; gap: 0.3rem; margin: 0.3rem 0; flex-wrap: wrap; }
+.badge { font-size: 0.72rem; padding: 0.1rem 0.4rem; border-radius: 4px; font-weight: 600; }
+.badge.imdb { background: #f5c518; color: #000; }
+.badge.csfd { background: #b01020; color: #fff; }
+.badge.year { background: #e2e8f0; color: #333; }
+.film-desc { font-size: 0.8rem; color: #555; margin: 0.3rem 0 0; display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
+
+/* List view — rows instead of grid */
+.films-grid.list-view { grid-template-columns: 1fr; }
+.films-grid.list-view .film-card { display: grid; grid-template-columns: 120px 1fr; }
+.films-grid.list-view .film-poster { aspect-ratio: 2/3; max-width: 120px; }
+.films-grid.list-view .film-body { padding: 0.8rem 1rem; }
+.films-grid.list-view .film-list-extra { display: block; }
+
+/* Pagination */
+.pagination { display: flex; justify-content: center; align-items: center; gap: 0.3rem; margin: 2rem 0; flex-wrap: wrap; }
+.page-link { display: inline-flex; align-items: center; justify-content: center; padding: 0.4rem 0.8rem; border-radius: 999px; background: #f1f5f9; color: #11457E; text-decoration: none; font-size: 0.85rem; font-weight: 600; min-width: 2.2rem; transition: background 0.15s, color 0.15s; }
+.page-link:hover { background: #11457E; color: white; }
+.page-link.current { background: #C5A059; color: white; cursor: default; }
+.page-dots { padding: 0.4rem 0.2rem; color: #888; }
+</style>
+
+<script>
+function doSearch() {
+    var q = document.getElementById('series-search').value.trim();
+    if (q.length >= 2) window.location = '/serialy-online/?q=' + encodeURIComponent(q);
+}
+
+/* View toggle (grid/list) */
+function setView(mode) {
+    var c = document.getElementById('films-container');
+    var iconGrid = document.querySelector('.view-icon-grid');
+    var iconList = document.querySelector('.view-icon-list');
+    if (mode === 'list') {
+        c.classList.add('list-view');
+        if (iconGrid) iconGrid.style.display = 'none';
+        if (iconList) iconList.style.display = '';
+    } else {
+        c.classList.remove('list-view');
+        if (iconGrid) iconGrid.style.display = '';
+        if (iconList) iconList.style.display = 'none';
+    }
+    localStorage.setItem('seriesView', mode);
+}
+function toggleView() {
+    var current = localStorage.getItem('seriesView') || 'grid';
+    setView(current === 'list' ? 'grid' : 'list');
+}
+(function(){ var s = localStorage.getItem('seriesView'); if (s === 'list') setView('list'); })();
+
+/* Sort */
+function applySortCombined(v) {
+    var field = v.split(':')[0];
+    var u = new URL(window.location);
+    if (field === 'pridano') u.searchParams.delete('razeni');
+    else u.searchParams.set('razeni', field);
+    u.searchParams.delete('strana');
+    window.location = u.toString();
+}
+(function() {
+    var urlParams = new URLSearchParams(window.location.search);
+    var razeni = urlParams.get('razeni') || 'pridano';
+    var sortSel = document.getElementById('sort-select');
+    if (sortSel) {
+        var target = razeni === 'nazev' ? 'nazev:asc' : razeni + ':desc';
+        for (var i = 0; i < sortSel.options.length; i++) {
+            if (sortSel.options[i].value === target) {
+                sortSel.selectedIndex = i;
+                break;
+            }
+        }
+    }
+})();
+
+/* Autocomplete */
+(function() {
+    var input = document.getElementById('series-search');
+    var dd = document.getElementById('search-results');
+    var timer = null;
+    if (!input || !dd) return;
+
+    input.addEventListener('input', function() {
+        clearTimeout(timer);
+        var q = this.value.trim();
+        if (q.length < 2) { dd.classList.remove('open'); return; }
+        timer = setTimeout(function() {
+            fetch('/api/series/search?q=' + encodeURIComponent(q))
+                .then(function(r) { return r.json(); })
+                .then(function(results) {
+                    if (!results.length) {
+                        dd.innerHTML = '<div style="padding:0.8rem;color:#888;text-align:center">Nic nenalezeno</div>';
+                    } else {
+                        dd.innerHTML = results.map(function(r) {
+                            var cover = r.cover
+                                ? '<img src="/serialy-online/' + r.slug + '.webp" alt="' + r.title + '" title="' + r.title + '">'
+                                : '<div class="si-placeholder"></div>';
+                            var yr = r.year ? ' (' + r.year + ')' : '';
+                            var rat = r.imdb_rating ? ' — IMDB ' + r.imdb_rating : '';
+                            return '<a href="/serialy-online/' + r.slug + '/" class="search-item" title="' + r.title + '">'
+                                + cover + '<div class="si-info"><span class="si-title">' + r.title + yr + '</span>'
+                                + '<span class="si-meta">' + rat + '</span></div></a>';
+                        }).join('');
+                    }
+                    dd.classList.add('open');
+                })
+                .catch(function() { dd.classList.remove('open'); });
+        }, 200);
+    });
+
+    document.addEventListener('click', function(e) {
+        if (!e.target.closest('#header-search-box')) dd.classList.remove('open');
+    });
+
+    input.addEventListener('keydown', function(e) {
+        if (e.key === 'Enter') { e.preventDefault(); doSearch(); }
+    });
+})();
+</script>
+{% endblock %}


### PR DESCRIPTION
<!-- claude-session: c0717c9a-16b7-4690-af5a-437a07586132 -->

## Summary
Restore the dedicated `/filmy-online/` and `/serialy-online/` portal links on the homepage that disappeared during the recent main-branch reset.

## Test plan
- [x] Live-deployed and curl-verified: homepage now contains all three links (/filmy-a-serialy/, /filmy-online/, /serialy-online/)