### PR TITLE
feat: manual Run-now trigger for auto-import (#422)

### DIFF
--- a/cr-web/src/handlers/admin_import.rs
+++ b/cr-web/src/handlers/admin_import.rs
@@ -384,3 +384,77 @@ fn serialize_run_detail<'a>(
             .collect(),
     }
 }
+
+// --- Manual trigger (#422) ---
+
+#[derive(serde::Deserialize)]
+pub struct RunNowForm {
+    /// Hard cap on processed videos. Default 5 keeps ad-hoc runs safe;
+    /// the daily cron passes a higher value. Server clamps to 1..=100 so a
+    /// stray submission can't trigger a marathon scan.
+    #[serde(default = "default_max_new")]
+    pub max_new: u32,
+}
+
+fn default_max_new() -> u32 {
+    5
+}
+
+const MAX_NEW_HARD_CAP: u32 = 100;
+
+/// POST /admin/import/run — fire-and-redirect manual scanner trigger.
+///
+/// Spawns `python3 scripts/auto-import.py --trigger manual --max-new N` as
+/// a detached subprocess and 303-redirects to the dashboard. The script
+/// INSERTs an `import_runs` row immediately so the new run appears in the
+/// list within a second or two.
+///
+/// Guarded by env `ADMIN_IMPORT_RUN_ENABLED=1` — without it we 403, so a
+/// stray POST on production can't kick off an unbounded subprocess. Set
+/// the flag in the production .env once the cron rollout is signed off.
+pub async fn admin_import_run(
+    axum::extract::Form(form): axum::extract::Form<RunNowForm>,
+) -> WebResult<Response> {
+    if std::env::var("ADMIN_IMPORT_RUN_ENABLED").as_deref() != Ok("1") {
+        return Ok((
+            StatusCode::FORBIDDEN,
+            "Manual run is disabled. Set ADMIN_IMPORT_RUN_ENABLED=1 in the env to enable.",
+        )
+            .into_response());
+    }
+
+    // Clamp user input to a sane range so we don't accidentally scan
+    // thousands of pages on a fat-fingered submission.
+    let max_new = form.max_new.clamp(1, MAX_NEW_HARD_CAP);
+
+    let repo_root = std::env::var("CR_REPO_ROOT").unwrap_or_else(|_| "/opt/cr".to_string());
+    let script = format!("{}/scripts/auto-import.py", repo_root);
+
+    let spawn_result = tokio::process::Command::new("python3")
+        .arg("-u")
+        .arg(&script)
+        .arg("--trigger")
+        .arg("manual")
+        .arg("--max-new")
+        .arg(max_new.to_string())
+        .current_dir(&repo_root)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn();
+
+    if let Err(e) = spawn_result {
+        tracing::error!("admin_import_run: spawn failed: {e}");
+        return Ok((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Cannot spawn scanner: {e}"),
+        )
+            .into_response());
+    }
+
+    Ok((
+        StatusCode::SEE_OTHER,
+        [(axum::http::header::LOCATION, "/admin/import/")],
+    )
+        .into_response())
+}

--- a/cr-web/src/main.rs
+++ b/cr-web/src/main.rs
@@ -239,6 +239,10 @@ async fn main() -> Result<()> {
             axum::routing::get(handlers::admin_import::admin_import_failures),
         )
         .route(
+            "/admin/import/run",
+            axum::routing::post(handlers::admin_import::admin_import_run),
+        )
+        .route(
             "/admin/import/{run_id}",
             axum::routing::get(handlers::admin_import::admin_import_detail),
         )

--- a/cr-web/templates/admin_import_list.html
+++ b/cr-web/templates/admin_import_list.html
@@ -25,6 +25,14 @@
 
     <h2>Posledních 30 běhů SK Torrent scanneru</h2>
 
+    <form method="post" action="/admin/import/run" class="run-now-form">
+        <label for="max_new" title="Bezpečný strop pro testování">Max nových:</label>
+        <input type="number" id="max_new" name="max_new" value="5" min="1" max="100"
+               title="Maximum nových videí ke zpracování (default 5, server clampuje 1–100)">
+        <button type="submit" title="Spustit scanner ručně teď" class="btn-run">▶ Spustit teď</button>
+        <span class="hint" title="Vyžaduje ADMIN_IMPORT_RUN_ENABLED=1 v env. Scanner běží asynchronně, výsledek se objeví v seznamu během několika sekund.">Vyžaduje ADMIN_IMPORT_RUN_ENABLED=1; běží asynchronně.</span>
+    </form>
+
     {% if runs.is_empty() %}
     <p class="empty-state">Zatím žádný běh — scanner nebyl spuštěn.</p>
     {% else %}
@@ -85,5 +93,11 @@
 .empty-state { color: #888; padding: 2rem; text-align: center; background: #fafafa; border-radius: 8px; }
 .breadcrumb { font-size: 0.85rem; color: #888; margin-bottom: 1.2rem; }
 .breadcrumb a { color: #11457E; text-decoration: none; }
+.run-now-form { background: #f0f9ff; border: 1px solid #bfdbfe; border-radius: 8px; padding: 0.8rem 1rem; margin-bottom: 1.2rem; display: flex; align-items: center; gap: 0.6rem; flex-wrap: wrap; }
+.run-now-form label { font-weight: 600; color: #1e40af; }
+.run-now-form input[type="number"] { width: 60px; padding: 0.3rem 0.5rem; border: 1px solid #cbd5e1; border-radius: 4px; font-size: 0.9rem; }
+.run-now-form .btn-run { background: #11457E; color: white; border: none; padding: 0.4rem 1rem; border-radius: 4px; font-size: 0.9rem; font-weight: 600; cursor: pointer; }
+.run-now-form .btn-run:hover { background: #0d3a6e; }
+.run-now-form .hint { color: #64748b; font-size: 0.82rem; }
 </style>
 {% endblock %}


### PR DESCRIPTION
<!-- claude-session: c0717c9a-16b7-4690-af5a-437a07586132 -->

Closes #422 (part of #413).

## Summary
- POST /admin/import/run?max_new=N spawns the scanner script as detached subprocess, redirects to dashboard
- Form on /admin/import/ with a numeric max_new input (default 5)

## Test plan
- [ ] Stack on top of #432 (admin dashboard) — merge #432 first
- [ ] After merge, click "▶ Spustit teď" on /admin/import/ with max_new=2 → new row appears in seconds, scanner processes 2 new SK Torrent videos
- [ ] CR_REPO_ROOT env var set in production docker-compose to /opt/cr (default)

## Notes
Builds on #421 dashboard (PR #432). The scanner script (`scripts/auto-import.py`) is part of the broader auto-import work landing across #414-#420.