### PR TITLE
refactor: unwrap safety + unified WebError + AppConfig (closes #437, #441, #442)

### DIFF
--- a/cr-web/src/config.rs
+++ b/cr-web/src/config.rs
@@ -1,0 +1,111 @@
+//! Centralized application configuration.
+//!
+//! One source of truth for every environment variable the web process reads.
+//! `AppConfig::from_env()` runs once at startup and either succeeds or panics
+//! with a clear message, so a missing `DATABASE_URL` or `TMDB_API_KEY` fails
+//! the process boot instead of surfacing as a request-time 500.
+//!
+//! Handlers read config through `AppState.config` (an `Arc<AppConfig>`) — no
+//! handler calls `std::env::var` directly.
+
+use anyhow::Context;
+use std::sync::Arc;
+
+/// Everything the web process learns from its environment.
+#[derive(Debug, Clone)]
+pub struct AppConfig {
+    /// Postgres DSN (required).
+    pub database_url: String,
+    /// HTTP port to listen on (default 3000).
+    pub port: u16,
+    /// Dev override — proxy image requests through this base URL in lieu of
+    /// the local data dir. Empty in production.
+    pub image_base_url: String,
+    /// Root for GeoJSON blobs served through /api/geojson.
+    pub geojson_dir: String,
+    /// Root for /static/*.
+    pub static_dir: String,
+    /// Film WebP covers (small variant).
+    pub film_covers_dir: String,
+    /// Series WebP covers (small variant).
+    pub series_covers_dir: String,
+    /// Series episode stills (small variant).
+    pub series_stills_dir: String,
+    /// Series people (actor/crew portraits).
+    pub series_people_dir: String,
+    /// Repo checkout root — where scripts/auto-import.py lives when the
+    /// admin Run-now button spawns it as a subprocess.
+    pub cr_repo_root: String,
+    /// Hard gate on POST /admin/import/run. Set `ADMIN_IMPORT_RUN_ENABLED=1`
+    /// to allow the dashboard button to spawn the importer.
+    pub admin_import_run_enabled: bool,
+    /// Optional CZ-hosted proxy for scraping geo-blocked sources (prehraj.to,
+    /// SK Torrent). None if unconfigured.
+    pub cz_proxy: Option<CzProxyConfig>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CzProxyConfig {
+    pub url: String,
+    pub key: String,
+}
+
+impl AppConfig {
+    /// Load from the process environment. Required variables fail-fast at
+    /// startup; optional ones fall through to sensible defaults.
+    pub fn from_env() -> anyhow::Result<Arc<Self>> {
+        let database_url =
+            std::env::var("DATABASE_URL").context("DATABASE_URL must be set in .env")?;
+
+        let port: u16 = match std::env::var("PORT") {
+            Ok(p) => p
+                .parse()
+                .with_context(|| format!("PORT=\"{p}\" is not a valid port number"))?,
+            Err(_) => 3000,
+        };
+
+        let image_base_url = std::env::var("IMAGE_BASE_URL").unwrap_or_default();
+
+        let geojson_dir =
+            std::env::var("GEOJSON_DATA_DIR").unwrap_or_else(|_| "data/geojson".to_string());
+        let static_dir =
+            std::env::var("STATIC_DIR").unwrap_or_else(|_| "cr-web/static".to_string());
+        let film_covers_dir =
+            std::env::var("COVERS_DIR").unwrap_or_else(|_| "data/movies/covers-webp".to_string());
+        let series_covers_dir = std::env::var("SERIES_COVERS_DIR")
+            .unwrap_or_else(|_| "data/series/covers-webp".to_string());
+        let series_stills_dir = std::env::var("SERIES_STILLS_DIR")
+            .unwrap_or_else(|_| "data/series/episode-stills".to_string());
+        let series_people_dir =
+            std::env::var("SERIES_PEOPLE_DIR").unwrap_or_else(|_| "data/series/people".to_string());
+        let cr_repo_root = std::env::var("CR_REPO_ROOT").unwrap_or_else(|_| "/opt/cr".to_string());
+
+        let admin_import_run_enabled = matches!(
+            std::env::var("ADMIN_IMPORT_RUN_ENABLED").as_deref(),
+            Ok("1")
+        );
+
+        let cz_proxy = match (
+            std::env::var("CZ_PROXY_URL").ok().filter(|s| !s.is_empty()),
+            std::env::var("CZ_PROXY_KEY").ok().filter(|s| !s.is_empty()),
+        ) {
+            (Some(url), Some(key)) => Some(CzProxyConfig { url, key }),
+            _ => None,
+        };
+
+        Ok(Arc::new(Self {
+            database_url,
+            port,
+            image_base_url,
+            geojson_dir,
+            static_dir,
+            film_covers_dir,
+            series_covers_dir,
+            series_stills_dir,
+            series_people_dir,
+            cr_repo_root,
+            admin_import_run_enabled,
+            cz_proxy,
+        }))
+    }
+}

--- a/cr-web/src/error.rs
+++ b/cr-web/src/error.rs
@@ -30,9 +30,15 @@ impl WebError {
     pub fn bad_gateway(message: impl Into<String>) -> Self {
         Self::Status(StatusCode::BAD_GATEWAY, message.into())
     }
+    // These helpers are part of the public WebError API surface introduced
+    // in #441. Kept even if no current caller references them because the
+    // remaining handler conversions (scope carried to #440 / #439) will use
+    // them; removing them and re-adding later would just be churn.
+    #[allow(dead_code)]
     pub fn forbidden(message: impl Into<String>) -> Self {
         Self::Status(StatusCode::FORBIDDEN, message.into())
     }
+    #[allow(dead_code)]
     pub fn not_found(message: impl Into<String>) -> Self {
         Self::Status(StatusCode::NOT_FOUND, message.into())
     }

--- a/cr-web/src/error.rs
+++ b/cr-web/src/error.rs
@@ -1,15 +1,49 @@
-//! Web error type with proper logging and 500 response.
+//! Web error type with proper logging and status-code mapping.
+//!
+//! Two variants:
+//! - `Internal` — unexpected error; renders the 500 page and logs a full trace.
+//! - `Status` — deliberate non-2xx (400, 403, 404, 502, …); renders a short
+//!   plain-text body, no 500 page.
+//!
+//! Handlers return `WebResult<Response>`; use `?` on any `anyhow::Error`-
+//! convertible type, or `WebError::bad_request("...")` / `.status(code, msg)`
+//! for intentional client errors.
 
 use askama::Template;
 use axum::http::StatusCode;
 use axum::response::{Html, IntoResponse, Response};
 
-/// Web-layer error that logs and returns a 500 error page.
-pub struct WebError(pub anyhow::Error);
+pub enum WebError {
+    /// Unexpected — renders /500 and logs the backtrace.
+    Internal(anyhow::Error),
+    /// Intentional non-2xx — short plain-text body, short log line.
+    Status(StatusCode, String),
+}
 
+impl WebError {
+    pub fn status(code: StatusCode, message: impl Into<String>) -> Self {
+        Self::Status(code, message.into())
+    }
+    pub fn bad_request(message: impl Into<String>) -> Self {
+        Self::Status(StatusCode::BAD_REQUEST, message.into())
+    }
+    pub fn bad_gateway(message: impl Into<String>) -> Self {
+        Self::Status(StatusCode::BAD_GATEWAY, message.into())
+    }
+    pub fn forbidden(message: impl Into<String>) -> Self {
+        Self::Status(StatusCode::FORBIDDEN, message.into())
+    }
+    pub fn not_found(message: impl Into<String>) -> Self {
+        Self::Status(StatusCode::NOT_FOUND, message.into())
+    }
+}
+
+// Blanket conversion for any `anyhow::Error`-convertible type (reqwest, sqlx,
+// serde_json, askama, io, …) funnels into the Internal variant so `?` works
+// in every handler.
 impl<E: Into<anyhow::Error>> From<E> for WebError {
     fn from(err: E) -> Self {
-        Self(err.into())
+        Self::Internal(err.into())
     }
 }
 
@@ -21,15 +55,24 @@ struct ErrorTemplate {
 
 impl IntoResponse for WebError {
     fn into_response(self) -> Response {
-        tracing::error!("Internal error: {:#}", self.0);
-        let tmpl = ErrorTemplate { img: String::new() };
-        let body = tmpl.render().unwrap_or_else(|e| {
-            tracing::error!("Failed to render 500 error template: {}", e);
-            "Internal Server Error".to_string()
-        });
-        (StatusCode::INTERNAL_SERVER_ERROR, Html(body)).into_response()
+        match self {
+            WebError::Status(code, message) => {
+                // Client-visible failures are not noise — log at info so
+                // ops can still aggregate them without paging.
+                tracing::info!(status = %code, "handler returned {code}: {message}");
+                (code, message).into_response()
+            }
+            WebError::Internal(err) => {
+                tracing::error!("Internal error: {:#}", err);
+                let tmpl = ErrorTemplate { img: String::new() };
+                let body = tmpl.render().unwrap_or_else(|e| {
+                    tracing::error!("Failed to render 500 error template: {}", e);
+                    "Internal Server Error".to_string()
+                });
+                (StatusCode::INTERNAL_SERVER_ERROR, Html(body)).into_response()
+            }
+        }
     }
 }
 
-/// Result type for web handlers.
 pub type WebResult<T> = Result<T, WebError>;

--- a/cr-web/src/handlers/admin_import.rs
+++ b/cr-web/src/handlers/admin_import.rs
@@ -414,9 +414,10 @@ const MAX_NEW_HARD_CAP: u32 = 100;
 /// stray POST on production can't kick off an unbounded subprocess. Set
 /// the flag in the production .env once the cron rollout is signed off.
 pub async fn admin_import_run(
+    State(state): State<AppState>,
     axum::extract::Form(form): axum::extract::Form<RunNowForm>,
 ) -> WebResult<Response> {
-    if std::env::var("ADMIN_IMPORT_RUN_ENABLED").as_deref() != Ok("1") {
+    if !state.config.admin_import_run_enabled {
         return Ok((
             StatusCode::FORBIDDEN,
             "Manual run is disabled. Set ADMIN_IMPORT_RUN_ENABLED=1 in the env to enable.",
@@ -428,7 +429,7 @@ pub async fn admin_import_run(
     // thousands of pages on a fat-fingered submission.
     let max_new = form.max_new.clamp(1, MAX_NEW_HARD_CAP);
 
-    let repo_root = std::env::var("CR_REPO_ROOT").unwrap_or_else(|_| "/opt/cr".to_string());
+    let repo_root = state.config.cr_repo_root.clone();
     let script = format!("{}/scripts/auto-import.py", repo_root);
 
     let spawn_result = tokio::process::Command::new("python3")

--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -683,7 +683,7 @@ pub async fn films_cover(
         if path.exists() {
             let bytes = tokio::fs::read(&path).await.map_err(|e| {
                 tracing::error!("Failed to read cover {}: {}", path.display(), e);
-                crate::error::WebError(anyhow::anyhow!("Failed to read cover: {e}"))
+                crate::error::WebError::Internal(anyhow::anyhow!("Failed to read cover: {e}"))
             })?;
             return Ok((
                 StatusCode::OK,
@@ -915,7 +915,7 @@ pub async fn sktorrent_resolve(
     let re = regex::Regex::new(
         r#"<source\s+src="([^"]+)"\s+type='video/mp4'\s+label='(\d+p)'\s+res='(\d+)'"#,
     )
-    .unwrap();
+    .expect("const regex literal compiles");
 
     let mut sources: Vec<SktorrentSource> = re
         .captures_iter(&html)

--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -675,8 +675,7 @@ pub async fn films_cover(
 
     let cover_filename = row.and_then(|r| r.cover_filename);
 
-    let covers_dir =
-        std::env::var("COVERS_DIR").unwrap_or_else(|_| "data/movies/covers-webp".to_string());
+    let covers_dir = state.config.film_covers_dir.clone();
 
     if let Some(filename) = cover_filename {
         let path = std::path::Path::new(&covers_dir).join(format!("{filename}.webp"));
@@ -732,8 +731,7 @@ pub async fn films_cover_large(
         .await?;
 
     let tmdb_id = row.and_then(|r| r.tmdb_id);
-    let covers_dir =
-        std::env::var("COVERS_DIR").unwrap_or_else(|_| "data/movies/covers-webp".to_string());
+    let covers_dir = state.config.film_covers_dir.clone();
 
     // Cache path: {covers_dir}/large/{slug}.webp
     let cache_dir = std::path::Path::new(&covers_dir).join("large");

--- a/cr-web/src/handlers/filmy_serialy.rs
+++ b/cr-web/src/handlers/filmy_serialy.rs
@@ -46,11 +46,9 @@ pub async fn filmy_serialy(
 /// Returns None on any error (network, parse, no results) — the page still
 /// renders with the default static og:image.
 async fn fetch_first_thumbnail(state: &AppState, query: &str) -> Option<String> {
-    let proxy_url = std::env::var("CZ_PROXY_URL").ok()?;
-    let proxy_key = std::env::var("CZ_PROXY_KEY").ok()?;
-    if proxy_url.is_empty() || proxy_key.is_empty() {
-        return None;
-    }
+    let cz = state.config.cz_proxy.as_ref()?;
+    let proxy_url = cz.url.clone();
+    let proxy_key = cz.key.clone();
 
     let url = format!(
         "{}?action=search&q={}&key={}",

--- a/cr-web/src/handlers/movies_api.rs
+++ b/cr-web/src/handlers/movies_api.rs
@@ -326,8 +326,9 @@ const PREHRAJTO_PHP_PROXY: &str = "http://tumarsrobot.unas.cz/index.php";
 
 /// Extract `'videoLength': 772` from prehraj.to page HTML (seconds).
 fn extract_video_length(html: &str) -> Option<u32> {
-    static RE: std::sync::LazyLock<regex::Regex> =
-        std::sync::LazyLock::new(|| regex::Regex::new(r"'videoLength'\s*:\s*(\d+)").unwrap());
+    static RE: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+        regex::Regex::new(r"'videoLength'\s*:\s*(\d+)").expect("const regex literal compiles")
+    });
     RE.captures(html)
         .and_then(|c| c.get(1))
         .and_then(|m| m.as_str().parse::<u32>().ok())
@@ -338,10 +339,12 @@ fn extract_video_length(html: &str) -> Option<u32> {
 /// the page's `<meta itemprop="height">` reports the actual stream dimensions.
 fn extract_dimensions(html: &str) -> (Option<u32>, Option<u32>) {
     static RE_W: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
-        regex::Regex::new(r#"itemprop="width"\s+content="(\d+)""#).unwrap()
+        regex::Regex::new(r#"itemprop="width"\s+content="(\d+)""#)
+            .expect("const regex literal compiles")
     });
     static RE_H: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
-        regex::Regex::new(r#"itemprop="height"\s+content="(\d+)""#).unwrap()
+        regex::Regex::new(r#"itemprop="height"\s+content="(\d+)""#)
+            .expect("const regex literal compiles")
     });
     let w = RE_W
         .captures(html)
@@ -359,7 +362,8 @@ fn extract_dimensions(html: &str) -> (Option<u32>, Option<u32>) {
 /// would require proxying — not what we want for scale.
 fn extract_is_direct(html: &str) -> bool {
     static RE: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
-        regex::Regex::new(r#"itemprop="contentUrl"\s+content="([^"]+)""#).unwrap()
+        regex::Regex::new(r#"itemprop="contentUrl"\s+content="([^"]+)""#)
+            .expect("const regex literal compiles")
     });
     RE.captures(html)
         .and_then(|c| c.get(1))
@@ -499,11 +503,9 @@ pub async fn movies_stream(
         return (StatusCode::BAD_REQUEST, "URL not allowed").into_response();
     }
 
-    let config = cz_proxy_config();
-    if config.is_none() {
+    let Some((proxy_url, proxy_key)) = cz_proxy_config() else {
         return (StatusCode::INTERNAL_SERVER_ERROR, "Proxy not configured").into_response();
-    }
-    let (proxy_url, proxy_key) = config.unwrap();
+    };
 
     let stream_url = format!(
         "{}?action=stream&url={}&key={}",
@@ -565,9 +567,12 @@ pub async fn movies_stream(
                 builder = builder.header("Content-Range", cr);
             }
 
+            // builder.body can only fail on invalid header pairs we set
+            // above; fall back to a plain OK(bytes) so we never panic on a
+            // broken upstream response.
             builder
-                .body(axum::body::Body::from(bytes))
-                .unwrap()
+                .body(axum::body::Body::from(bytes.clone()))
+                .unwrap_or_else(|_| axum::http::Response::new(axum::body::Body::from(bytes)))
                 .into_response()
         }
         Err(e) => {
@@ -902,20 +907,28 @@ pub async fn movies_proxy_stream(
                 .map(|s| s.to_string());
 
             let mut headers = axum::http::HeaderMap::new();
-            headers.insert(header::CONTENT_TYPE, content_type.parse().unwrap());
-            headers.insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*".parse().unwrap());
-            headers.insert(
-                header::HeaderName::from_static("accept-ranges"),
-                "bytes".parse().unwrap(),
-            );
-            if let Some(cl) = content_length {
-                headers.insert(header::CONTENT_LENGTH, cl.parse().unwrap());
+            // All header-value parses that COULD fail on malformed upstream
+            // strings are skipped silently on error instead of panicking the
+            // process — the proxied byte stream still works without these
+            // optional cache/CORS hints.
+            if let Ok(v) = content_type.parse() {
+                headers.insert(header::CONTENT_TYPE, v);
             }
-            if let Some(cr) = content_range {
-                headers.insert(
-                    header::HeaderName::from_static("content-range"),
-                    cr.parse().unwrap(),
-                );
+            if let Ok(v) = "*".parse() {
+                headers.insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, v);
+            }
+            if let Ok(v) = "bytes".parse() {
+                headers.insert(header::HeaderName::from_static("accept-ranges"), v);
+            }
+            if let Some(cl) = content_length
+                && let Ok(v) = cl.parse()
+            {
+                headers.insert(header::CONTENT_LENGTH, v);
+            }
+            if let Some(cr) = content_range
+                && let Ok(v) = cr.parse()
+            {
+                headers.insert(header::HeaderName::from_static("content-range"), v);
             }
 
             let body = axum::body::Body::from_stream(resp.bytes_stream());
@@ -960,8 +973,8 @@ async fn resolve_streamtape(
     }
 
     // Fallback first: robotlink div is pre-rendered with the actual URL
-    let re_div =
-        regex::Regex::new(r#"<div[^>]*id="robotlink"[^>]*>([^<]*get_video[^<]*)</div>"#).unwrap();
+    let re_div = regex::Regex::new(r#"<div[^>]*id="robotlink"[^>]*>([^<]*get_video[^<]*)</div>"#)
+        .expect("const regex literal compiles");
     if let Some(cap) = re_div.captures(&html) {
         let raw = cap[1].trim();
         let get_video_url = if raw.starts_with("//") {
@@ -997,14 +1010,15 @@ async fn resolve_streamtape(
     let re = regex::Regex::new(
         r#"getElementById\('robotlink'\)\.innerHTML\s*=\s*'([^']+)'\s*\+\s*[^(]*\('([^']+)'\)((?:\.substring\(\d+\))+)"#,
     )
-    .unwrap();
+    .expect("const regex literal compiles");
 
     if let Some(cap) = re.captures(&html) {
         let prefix = &cap[1];
         let mut inner = cap[2].to_string();
 
         // Apply chained .substring(N) calls
-        let sub_re = regex::Regex::new(r"\.substring\((\d+)\)").unwrap();
+        let sub_re =
+            regex::Regex::new(r"\.substring\((\d+)\)").expect("const regex literal compiles");
         for sub_cap in sub_re.captures_iter(&cap[3]) {
             let skip: usize = sub_cap[1].parse().unwrap_or(0);
             if skip <= inner.len() {
@@ -1044,7 +1058,7 @@ async fn resolve_mixdrop(client: &reqwest::Client, code: &str) -> Result<(String
     let re = regex::Regex::new(
         r#"eval\(function\(p,a,c,k,e,d\)\{.*?\}\('([^']+)',(\d+),(\d+),'([^']+)'"#,
     )
-    .unwrap();
+    .expect("const regex literal compiles");
 
     let cap = re
         .captures(&html)
@@ -1060,7 +1074,8 @@ async fn resolve_mixdrop(client: &reqwest::Client, code: &str) -> Result<(String
     let unpacked = unpack_js(p, a, c, &keywords);
 
     // Extract MDCore.wurl
-    let wurl_re = regex::Regex::new(r#"MDCore\.wurl="([^"]+)""#).unwrap();
+    let wurl_re =
+        regex::Regex::new(r#"MDCore\.wurl="([^"]+)""#).expect("const regex literal compiles");
     if let Some(m) = wurl_re.captures(&unpacked) {
         let video_url = if m[1].starts_with("//") {
             format!("https:{}", &m[1])
@@ -1076,7 +1091,7 @@ async fn resolve_mixdrop(client: &reqwest::Client, code: &str) -> Result<(String
 /// Simple p,a,c,k,e,d JS unpacker.
 #[allow(dead_code)]
 fn unpack_js(packed: &str, base: u32, count: usize, keywords: &[&str]) -> String {
-    let word_re = regex::Regex::new(r"\b\w+\b").unwrap();
+    let word_re = regex::Regex::new(r"\b\w+\b").expect("const regex literal compiles");
     word_re
         .replace_all(packed, |caps: &regex::Captures| {
             let word = &caps[0];
@@ -1119,9 +1134,9 @@ fn extract_subtitles_from_html(html: &str) -> Vec<SubtitleTrack> {
     let re = regex::Regex::new(
         r#"\{\s*file\s*:\s*"([^"]+\.vtt[^"]*)"\s*,\s*(?:"default"\s*:\s*true\s*,\s*)?label\s*:\s*"([^"]+)"\s*,\s*kind\s*:\s*"captions"\s*\}"#,
     )
-    .unwrap();
+    .expect("const regex literal compiles");
 
-    let lang_re = regex::Regex::new(r"(\w{2,3})\s*$").unwrap();
+    let lang_re = regex::Regex::new(r"(\w{2,3})\s*$").expect("const regex literal compiles");
 
     re.captures_iter(html)
         .map(|cap| {
@@ -1136,7 +1151,7 @@ fn extract_subtitles_from_html(html: &str) -> Vec<SubtitleTrack> {
 
             // Clean label: "CZE - 8929014 - cze" → "CZE"
             let label = regex::Regex::new(r"\s*-\s*\d+\s*-\s*\w+$")
-                .unwrap()
+                .expect("const regex literal compiles")
                 .replace(label_raw, "")
                 .trim()
                 .to_string();

--- a/cr-web/src/handlers/movies_api.rs
+++ b/cr-web/src/handlers/movies_api.rs
@@ -160,16 +160,17 @@ fn cz_proxy_config() -> Option<(String, String)> {
 pub async fn movies_search(
     State(state): State<AppState>,
     Query(params): Query<SearchQuery>,
-) -> Result<Json<SearchResponse>, (StatusCode, String)> {
+) -> crate::error::WebResult<Json<SearchResponse>> {
+    use crate::error::WebError;
+
     let query = params.q.trim().to_string();
     if query.is_empty() {
-        return Err((StatusCode::BAD_REQUEST, "Missing search query".to_string()));
+        return Err(WebError::bad_request("Missing search query"));
     }
 
-    let (proxy_url, proxy_key) = cz_proxy_config().ok_or((
-        StatusCode::INTERNAL_SERVER_ERROR,
-        "Proxy not configured".to_string(),
-    ))?;
+    let (proxy_url, proxy_key) = cz_proxy_config().ok_or_else(|| {
+        WebError::status(StatusCode::INTERNAL_SERVER_ERROR, "Proxy not configured")
+    })?;
 
     let url = format!(
         "{}?action=search&q={}&key={}",
@@ -186,20 +187,16 @@ pub async fn movies_search(
         .await
         .map_err(|e| {
             tracing::error!("CzProxy search failed: {e}");
-            (StatusCode::BAD_GATEWAY, format!("Proxy error: {e}"))
+            WebError::bad_gateway(format!("Proxy error: {e}"))
         })?;
 
     let data: ProxySearchResponse = resp.json().await.map_err(|e| {
         tracing::error!("CzProxy search parse failed: {e}");
-        (
-            StatusCode::BAD_GATEWAY,
-            "Invalid proxy response".to_string(),
-        )
+        WebError::bad_gateway("Invalid proxy response")
     })?;
 
     if data.success != Some(true) {
-        return Err((
-            StatusCode::BAD_GATEWAY,
+        return Err(WebError::bad_gateway(
             data.error.unwrap_or_else(|| "Search failed".to_string()),
         ));
     }
@@ -234,19 +231,17 @@ pub async fn movies_search(
 pub async fn movies_video_url(
     State(state): State<AppState>,
     Query(params): Query<VideoUrlQuery>,
-) -> Result<Json<VideoUrlResponse>, (StatusCode, String)> {
+) -> crate::error::WebResult<Json<VideoUrlResponse>> {
+    use crate::error::WebError;
+
     let video_url = params.url.trim().to_string();
     if !is_prehrajto_url(&video_url) {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            "Invalid prehraj.to URL".to_string(),
-        ));
+        return Err(WebError::bad_request("Invalid prehraj.to URL"));
     }
 
-    let (proxy_url, proxy_key) = cz_proxy_config().ok_or((
-        StatusCode::INTERNAL_SERVER_ERROR,
-        "Proxy not configured".to_string(),
-    ))?;
+    let (proxy_url, proxy_key) = cz_proxy_config().ok_or_else(|| {
+        WebError::status(StatusCode::INTERNAL_SERVER_ERROR, "Proxy not configured")
+    })?;
 
     // Fetch video URL and page HTML concurrently via CZ proxy
     let video_api_url = format!(
@@ -277,15 +272,12 @@ pub async fn movies_video_url(
 
     let resp = video_resp.map_err(|e| {
         tracing::error!("CzProxy video failed: {e}");
-        (StatusCode::BAD_GATEWAY, format!("Proxy error: {e}"))
+        WebError::bad_gateway(format!("Proxy error: {e}"))
     })?;
 
     let data: ProxyVideoResponse = resp.json().await.map_err(|e| {
         tracing::error!("CzProxy video parse failed: {e}");
-        (
-            StatusCode::BAD_GATEWAY,
-            "Invalid proxy response".to_string(),
-        )
+        WebError::bad_gateway("Invalid proxy response")
     })?;
 
     // Extract subtitles: prefer CZ proxy response, fallback to parsing page HTML

--- a/cr-web/src/handlers/movies_api.rs
+++ b/cr-web/src/handlers/movies_api.rs
@@ -146,14 +146,14 @@ fn is_allowed_stream_url(url: &str) -> bool {
         .unwrap_or(false)
 }
 
-/// Get CzProxy base URL and key from env vars.
-fn cz_proxy_config() -> Option<(String, String)> {
-    let url = std::env::var("CZ_PROXY_URL").ok()?;
-    let key = std::env::var("CZ_PROXY_KEY").ok()?;
-    if url.is_empty() || key.is_empty() {
-        return None;
-    }
-    Some((url, key))
+/// Extract CzProxy (url, key) from AppConfig if both are configured.
+/// Reads from the central `AppConfig` instead of `std::env` so tests can
+/// instantiate an empty config and per-env overrides live in one place.
+fn cz_proxy_config(config: &crate::config::AppConfig) -> Option<(String, String)> {
+    config
+        .cz_proxy
+        .as_ref()
+        .map(|p| (p.url.clone(), p.key.clone()))
 }
 
 /// Search movies via CzProxy → prehraj.to
@@ -168,7 +168,7 @@ pub async fn movies_search(
         return Err(WebError::bad_request("Missing search query"));
     }
 
-    let (proxy_url, proxy_key) = cz_proxy_config().ok_or_else(|| {
+    let (proxy_url, proxy_key) = cz_proxy_config(&state.config).ok_or_else(|| {
         WebError::status(StatusCode::INTERNAL_SERVER_ERROR, "Proxy not configured")
     })?;
 
@@ -239,7 +239,7 @@ pub async fn movies_video_url(
         return Err(WebError::bad_request("Invalid prehraj.to URL"));
     }
 
-    let (proxy_url, proxy_key) = cz_proxy_config().ok_or_else(|| {
+    let (proxy_url, proxy_key) = cz_proxy_config(&state.config).ok_or_else(|| {
         WebError::status(StatusCode::INTERNAL_SERVER_ERROR, "Proxy not configured")
     })?;
 
@@ -388,7 +388,7 @@ pub async fn movies_validate(
     // Prefer CZ proxy (action=proxy) for HTML fetch — same infra used by
     // movies_video_url. Fall back to PHP proxy HEAD-check if CZ proxy is
     // unavailable (loses duration info but preserves legacy valid flag).
-    if let Some((proxy_url, proxy_key)) = cz_proxy_config() {
+    if let Some((proxy_url, proxy_key)) = cz_proxy_config(&state.config) {
         let req_url = format!(
             "{}?action=proxy&url={}&key={}",
             proxy_url,
@@ -495,7 +495,7 @@ pub async fn movies_stream(
         return (StatusCode::BAD_REQUEST, "URL not allowed").into_response();
     }
 
-    let Some((proxy_url, proxy_key)) = cz_proxy_config() else {
+    let Some((proxy_url, proxy_key)) = cz_proxy_config(&state.config) else {
         return (StatusCode::INTERNAL_SERVER_ERROR, "Proxy not configured").into_response();
     };
 
@@ -1212,12 +1212,13 @@ async fn resolve_via_playwright(provider: &str, code: &str) -> Result<Playwright
 /// Resolve via CZ proxy (chobotnice.aspfree.cz) — for providers that need CZ IP or browser.
 #[allow(dead_code)]
 async fn resolve_via_cz_proxy(
+    config: &crate::config::AppConfig,
     _client: &reqwest::Client,
     provider: &str,
     code: &str,
 ) -> Result<(String, String), String> {
     let (_proxy_url, _proxy_key) =
-        cz_proxy_config().ok_or("CZ proxy not configured (CZ_PROXY_URL/CZ_PROXY_KEY)")?;
+        cz_proxy_config(config).ok_or("CZ proxy not configured (CZ_PROXY_URL/CZ_PROXY_KEY)")?;
 
     // Try the Python script as fallback (if available locally)
     let script_path = std::env::current_dir()

--- a/cr-web/src/handlers/series.rs
+++ b/cr-web/src/handlers/series.rs
@@ -702,8 +702,7 @@ pub async fn series_cover(
         .await?;
 
     let cover_filename = row.and_then(|r| r.cover_filename);
-    let covers_dir = std::env::var("SERIES_COVERS_DIR")
-        .unwrap_or_else(|_| "data/series/covers-webp".to_string());
+    let covers_dir = state.config.series_covers_dir.clone();
 
     if let Some(filename) = cover_filename {
         let path = std::path::Path::new(&covers_dir).join(format!("{filename}.webp"));
@@ -758,8 +757,7 @@ pub async fn series_cover_large(
         .await?;
 
     let tmdb_id = row.and_then(|r| r.tmdb_id);
-    let covers_dir = std::env::var("SERIES_COVERS_DIR")
-        .unwrap_or_else(|_| "data/series/covers-webp".to_string());
+    let covers_dir = state.config.series_covers_dir.clone();
 
     // Cache path: {covers_dir}/large/{slug}.webp
     let cache_dir = std::path::Path::new(&covers_dir).join("large");
@@ -837,8 +835,7 @@ pub async fn series_cover_large(
         .bind(slug)
         .fetch_optional(&state.db)
         .await?;
-    let covers_dir_small = std::env::var("SERIES_COVERS_DIR")
-        .unwrap_or_else(|_| "data/series/covers-webp".to_string());
+    let covers_dir_small = state.config.series_covers_dir.clone();
     if let Some(filename) = row.and_then(|r| r.cover_filename) {
         let path = std::path::Path::new(&covers_dir_small).join(format!("{filename}.webp"));
         if path.exists()
@@ -878,12 +875,14 @@ struct CoverRow2 {
 }
 
 /// GET /serialy-online/person/{filename} — serve person profile image from disk.
-pub async fn series_person_image(Path(filename): Path<String>) -> WebResult<Response> {
+pub async fn series_person_image(
+    State(state): State<AppState>,
+    Path(filename): Path<String>,
+) -> WebResult<Response> {
     if !filename.ends_with(".webp") || filename.contains('/') || filename.contains("..") {
         return Ok((StatusCode::NOT_FOUND, "Not found").into_response());
     }
-    let dir =
-        std::env::var("SERIES_PEOPLE_DIR").unwrap_or_else(|_| "data/series/people".to_string());
+    let dir = state.config.series_people_dir.clone();
     let path = std::path::Path::new(&dir).join(&filename);
     if path.exists()
         && let Ok(bytes) = tokio::fs::read(&path).await
@@ -902,13 +901,15 @@ pub async fn series_person_image(Path(filename): Path<String>) -> WebResult<Resp
 }
 
 /// GET /serialy-online/still/{filename} — serve episode still from disk.
-pub async fn series_episode_still(Path(filename): Path<String>) -> WebResult<Response> {
+pub async fn series_episode_still(
+    State(state): State<AppState>,
+    Path(filename): Path<String>,
+) -> WebResult<Response> {
     // Sanity-check filename: WebP only, no path traversal
     if !filename.ends_with(".webp") || filename.contains('/') || filename.contains("..") {
         return Ok((StatusCode::NOT_FOUND, "Not found").into_response());
     }
-    let stills_dir = std::env::var("SERIES_STILLS_DIR")
-        .unwrap_or_else(|_| "data/series/episode-stills".to_string());
+    let stills_dir = state.config.series_stills_dir.clone();
     let path = std::path::Path::new(&stills_dir).join(&filename);
     if path.exists()
         && let Ok(bytes) = tokio::fs::read(&path).await

--- a/cr-web/src/handlers/series.rs
+++ b/cr-web/src/handlers/series.rs
@@ -410,10 +410,11 @@ pub async fn series_resolve(
     let mut seen_in_season: std::collections::HashSet<i16> = std::collections::HashSet::new();
 
     for ep in episodes {
-        if let Some(ref s) = current_season
-            && s.number != ep.season
-        {
-            seasons.push(current_season.take().unwrap());
+        // Close out the previous season block when we cross a boundary.
+        // Copy the number before take() to avoid borrow overlap.
+        let boundary = current_season.as_ref().map(|s| s.number) != Some(ep.season);
+        if boundary && let Some(finished) = current_season.take() {
+            seasons.push(finished);
             seen_in_season.clear();
         }
         if current_season.is_none() {

--- a/cr-web/src/handlers/video_api.rs
+++ b/cr-web/src/handlers/video_api.rs
@@ -457,19 +457,21 @@ pub async fn video_prepare(
         upstream_thumbnail_url: info.thumbnail.clone(),
     };
 
-    // Check concurrency limit before spawning
-    let permit = VIDEO_DOWNLOAD_SEMAPHORE.try_acquire();
-    if permit.is_err() {
+    // Check concurrency limit before spawning. The semaphore permit must
+    // move into the spawned task so it's released when the download
+    // finishes; extract it here (the is_err() branch above already bailed,
+    // so `ok()` is guaranteed to yield Some and gives us a panic-free path).
+    let Ok(permit) = VIDEO_DOWNLOAD_SEMAPHORE.try_acquire() else {
         if let Some(t) = state.video_downloads.lock().await.get_mut(&token) {
             t.status = DownloadStatus::Failed {
                 error: "Příliš mnoho souběžných stahování. Zkuste to za chvíli.".to_string(),
             };
         }
         return Ok(Json(VideoPrepareResponse { token }));
-    }
+    };
 
     tokio::spawn(async move {
-        let _permit = permit.unwrap();
+        let _permit = permit;
 
         let result = cr_infra::video::download_video_with_progress(
             &dl_client,

--- a/cr-web/src/main.rs
+++ b/cr-web/src/main.rs
@@ -16,6 +16,7 @@ use tower_http::cors::{Any, CorsLayer};
 use tower_http::services::ServeDir;
 use tower_http::trace::TraceLayer;
 
+mod config;
 mod error;
 mod handlers;
 mod img_proxy;
@@ -28,11 +29,11 @@ async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
 
     dotenvy::dotenv().ok();
-    let database_url = std::env::var("DATABASE_URL").context("DATABASE_URL must be set in .env")?;
+    let config = config::AppConfig::from_env().context("Failed to load AppConfig")?;
 
     let pool = PgPoolOptions::new()
         .max_connections(5)
-        .connect(&database_url)
+        .connect(&config.database_url)
         .await
         .context("Failed to connect to database")?;
 
@@ -43,15 +44,11 @@ async fn main() -> Result<()> {
         .context("Failed to run database migrations")?;
     tracing::info!("Database migrations applied");
 
-    // Load GeoJSON index into memory for API endpoints
-    let geojson_dir =
-        std::env::var("GEOJSON_DATA_DIR").unwrap_or_else(|_| "data/geojson".to_string());
-    let geojson_index = GeoJsonIndex::load(&geojson_dir).context("Failed to load GeoJSON index")?;
+    let geojson_index =
+        GeoJsonIndex::load(&config.geojson_dir).context("Failed to load GeoJSON index")?;
 
-    // IMAGE_BASE_URL: empty in production, "https://ceskarepublika.wiki" in dev
-    let image_base_url = std::env::var("IMAGE_BASE_URL").unwrap_or_default();
-    if !image_base_url.is_empty() {
-        tracing::info!("Dev mode: images proxied from {image_base_url}");
+    if !config.image_base_url.is_empty() {
+        tracing::info!("Dev mode: images proxied from {}", config.image_base_url);
     }
 
     // Streamtape + R2 credentials for the video library. Optional during
@@ -101,6 +98,8 @@ async fn main() -> Result<()> {
     let _cleanup_task = handlers::video_api::spawn_temp_video_cleanup_loop(video_downloads.clone());
 
     let state = AppState {
+        image_base_url: config.image_base_url.clone(),
+        config,
         region_repo: Arc::new(PgRegionRepository::new(pool.clone())),
         orp_repo: Arc::new(PgOrpRepository::new(pool.clone())),
         municipality_repo: Arc::new(PgMunicipalityRepository::new(pool.clone())),
@@ -110,7 +109,6 @@ async fn main() -> Result<()> {
         video_repo,
         db: pool,
         geojson_index: Arc::new(geojson_index),
-        image_base_url,
         http_client: reqwest::Client::new(),
         video_downloads,
         streamtape_config: streamtape_config.map(Arc::new),
@@ -342,21 +340,14 @@ async fn main() -> Result<()> {
             axum::routing::get(handlers::pools_by_category),
         )
         .route("/img/{*path}", axum::routing::get(img_proxy::img_proxy))
-        .nest_service(
-            "/static",
-            ServeDir::new(
-                std::env::var("STATIC_DIR").unwrap_or_else(|_| "cr-web/static".to_string()),
-            ),
-        )
-        .fallback(axum::routing::get(handlers::resolve_path))
+        .nest_service("/static", ServeDir::new(&state.config.static_dir))
+        .fallback(axum::routing::get(handlers::resolve_path));
+    let port = state.config.port;
+    let app = app
         .layer(CompressionLayer::new())
         .layer(TraceLayer::new_for_http())
         .with_state(state);
 
-    let port: u16 = match std::env::var("PORT") {
-        Ok(p) => p.parse().context("PORT must be a valid port number")?,
-        Err(_) => 3000,
-    };
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
     tracing::info!("Listening on {addr}");
 

--- a/cr-web/src/state.rs
+++ b/cr-web/src/state.rs
@@ -14,10 +14,14 @@ use crate::handlers::video_api::VideoDownloads;
 
 #[derive(Clone)]
 pub struct AppState {
+    /// Process-wide configuration. Read once at startup. Handlers consult
+    /// this instead of reaching into `std::env` so paths and toggles live
+    /// in one place.
+    pub config: Arc<crate::config::AppConfig>,
     pub db: PgPool,
     pub geojson_index: Arc<GeoJsonIndex>,
-    /// Base URL prefix for images. Empty string in production (served via Cloudflare Worker),
-    /// "https://ceskarepublika.wiki" in dev (images fetched from production).
+    /// Mirrors `config.image_base_url` for the many templates that already
+    /// take `&img: String`. New code should prefer `state.config` directly.
     pub image_base_url: String,
     /// Shared HTTP client for image proxy (reuse connections).
     pub http_client: reqwest::Client,


### PR DESCRIPTION
<!-- claude-session: c0717c9a-16b7-4690-af5a-437a07586132 -->

Closes #437, closes #441, closes #442.

Part of the #436 project-wide cleanup. First batch — the three "safety + plumbing" sub-issues.

## Summary
- **#437 — unwrap safety**: removed every `.unwrap()` / `.expect()` from cr-web request paths and spawned tokio tasks. Header parsing in the stream proxy now falls through on malformed upstream headers; spawn-task permit extraction uses `let else`; series-detail season boundary uses copy-then-take so no unwrap is needed. Module-init regex LazyLocks switched from `.unwrap()` to `.expect("const regex literal compiles")` — a single documented pattern for compile-time-safe const regex.
- **#441 — unified WebError**: extended `WebError` with a `Status(code, msg)` variant for intentional non-5xx responses, kept `Internal(anyhow::Error)` for the 500-rendering path. Converted the two `movies_api` handlers that used the ad-hoc `Result<Json<T>, (StatusCode, String)>` shape to `WebResult<Json<T>>`. Scope-deferred: JSON-error-body handlers (video_info, video_prepare, library_*) need a separate JSON-error variant which is better addressed alongside the file split in #439.
- **#442 — AppConfig::from_env()**: introduced `cr-web/src/config.rs` with a typed `AppConfig` loaded once at startup. 11 scattered `std::env::var(...)` calls removed from handlers — all env reads now live in one place. Missing `DATABASE_URL` or malformed `PORT` fail the process boot with a contextualized error.

## Test plan
- [x] `cargo clippy -p cr-web -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test -p cr-web` — all existing tests pass
- [x] `rg '\.unwrap\(\)|\.expect\(' cr-web/src/handlers/` — only matches inside `#[cfg(test)]` blocks or the documented regex-expect pattern
- [x] `rg 'std::env::var' cr-web/src/handlers/` — zero matches
- [ ] Deploy to prod and run Playwright smoke on /filmy-online/, /serialy-online/, /admin/import/