### PR TITLE
refactor: bounded TTL cache + domain DTO split (closes #443, partial #446)

### DIFF
--- a/cr-app/src/queries.rs
+++ b/cr-app/src/queries.rs
@@ -4,6 +4,7 @@
 //! No framework dependencies — pure business logic orchestration.
 
 use crate::error::AppError;
+use cr_domain::dto::*;
 use cr_domain::repository::*;
 
 /// Get all regions for the homepage.

--- a/cr-domain/src/dto.rs
+++ b/cr-domain/src/dto.rs
@@ -1,0 +1,192 @@
+//! Repository data-transfer objects (DTOs).
+//!
+//! These are NOT domain entities — they're plain row-shaped records
+//! returned by repository queries. Kept separate from `repository.rs`
+//! (which holds the trait definitions / ports) so the trait module
+//! doesn't balloon past 100 lines when new repositories are added.
+//!
+//! Entities with invariants live in `entities/`; DTOs here carry only
+//! column-shaped data.
+
+// --- Record types returned by repositories ---
+// These are plain data records (not domain entities) for query results.
+
+/// Region data as stored in the database.
+#[derive(Debug, Clone)]
+pub struct RegionRecord {
+    pub id: i32,
+    pub name: String,
+    pub slug: String,
+    pub region_code: String,
+    pub latitude: Option<f64>,
+    pub longitude: Option<f64>,
+    pub coat_of_arms_ext: Option<String>,
+    pub flag_ext: Option<String>,
+    pub description: Option<String>,
+    pub hero_photo_r2_key: Option<String>,
+    pub hero_municipality_code: Option<String>,
+    pub hero_municipality_photo_index: Option<i16>,
+}
+
+/// ORP data as stored in the database.
+#[derive(Debug, Clone)]
+pub struct OrpRecord {
+    pub id: i32,
+    pub name: String,
+    pub slug: String,
+    pub orp_code: String,
+    pub latitude: Option<f64>,
+    pub longitude: Option<f64>,
+    pub description: Option<String>,
+}
+
+/// Municipality data as stored in the database.
+#[derive(Debug, Clone)]
+pub struct MunicipalityRecord {
+    pub id: i32,
+    pub name: String,
+    pub slug: String,
+    pub municipality_code: String,
+    pub pou_code: String,
+    pub latitude: Option<f64>,
+    pub longitude: Option<f64>,
+    pub wikipedia_url: Option<String>,
+    pub official_website: Option<String>,
+    pub coat_of_arms_ext: Option<String>,
+    pub flag_ext: Option<String>,
+    pub population: Option<i32>,
+    pub elevation: Option<f64>,
+}
+
+/// Landmark summary for listings.
+#[derive(Debug, Clone)]
+pub struct LandmarkSummary {
+    pub name: String,
+    pub slug: String,
+    pub type_name: String,
+    pub municipality_name: String,
+    pub municipality_slug: String,
+    pub is_main: bool,
+}
+
+/// Landmark full record for detail pages.
+#[derive(Debug, Clone)]
+pub struct LandmarkRecord {
+    pub id: i32,
+    pub name: String,
+    pub slug: String,
+    pub latitude: Option<f64>,
+    pub longitude: Option<f64>,
+    pub description: Option<String>,
+    pub wikipedia_url: Option<String>,
+    pub image_ext: Option<String>,
+    pub npu_catalog_id: Option<String>,
+    pub npu_description: Option<String>,
+    pub type_slug: String,
+    pub type_name: String,
+    pub municipality_name: Option<String>,
+    pub municipality_slug: Option<String>,
+    pub orp_slug: Option<String>,
+    pub region_slug: Option<String>,
+    pub municipality_code: Option<String>,
+    pub municipality_coat_of_arms_ext: Option<String>,
+}
+
+/// Pool summary for listings.
+#[derive(Debug, Clone)]
+pub struct PoolSummary {
+    pub name: String,
+    pub slug: String,
+    pub is_aquapark: bool,
+    pub is_indoor: bool,
+    pub is_outdoor: bool,
+    pub is_natural: bool,
+}
+
+/// Pool full record for detail pages.
+#[derive(Debug, Clone)]
+pub struct PoolRecord {
+    pub id: i32,
+    pub name: String,
+    pub slug: String,
+    pub description: Option<String>,
+    pub address: Option<String>,
+    pub latitude: Option<f64>,
+    pub longitude: Option<f64>,
+    pub website: Option<String>,
+    pub email: Option<String>,
+    pub phone: Option<String>,
+    pub facebook: Option<String>,
+    pub facilities: Option<String>,
+    pub pool_length_m: Option<i32>,
+    pub is_aquapark: bool,
+    pub is_indoor: bool,
+    pub is_outdoor: bool,
+    pub is_natural: bool,
+    pub photo_count: i16,
+    pub municipality_name: Option<String>,
+}
+
+/// Photo metadata record.
+#[derive(Debug, Clone)]
+pub struct PhotoRecord {
+    pub r2_key: String,
+    pub width: i16,
+    pub height: i16,
+}
+
+/// Hosted video as stored in the `videos` table.
+///
+/// `created_at` is stored as an ISO 8601 string so this record stays
+/// dependency-free (cr-domain has zero external deps by design).
+#[derive(Debug, Clone)]
+pub struct VideoRecord {
+    pub id: i32,
+    pub source_url: String,
+    pub title: String,
+    pub description: Option<String>,
+    pub duration_sec: Option<i32>,
+    pub source_extractor: Option<String>,
+    pub quality: String,
+    pub format_ext: String,
+    pub streamtape_file_id: String,
+    pub streamtape_url: String,
+    pub file_size_bytes: i64,
+    pub thumbnail_r2_key: Option<String>,
+    pub thumbnail_url: Option<String>,
+    pub created_at: String,
+    /// Bumped to `NOW()` whenever the handler spots an existing
+    /// library entry for the requested URL+quality, so the card
+    /// slides to the top of the library grid. See #366.
+    pub last_accessed_at: String,
+    /// Human-readable resolution like `"1080p"` or `"720p"` parsed
+    /// from yt-dlp's `format.resolution` field. Separate from
+    /// `quality` because `quality` is the raw yt-dlp format_id
+    /// which is source-specific garbage (`"137"` on YouTube,
+    /// `"bytevc1_720p_..."` on TikTok, `"mp4"` on Seznam). `None`
+    /// on legacy rows where the backfill regex couldn't find a
+    /// `\d+p` substring. See #366.
+    pub resolution: Option<String>,
+}
+
+/// Insertion payload for the `videos` table — everything the upload
+/// pipeline knows about a freshly uploaded video. The DB assigns `id`
+/// and `created_at`.
+#[derive(Debug, Clone)]
+pub struct NewVideo {
+    pub source_url: String,
+    pub title: String,
+    pub description: Option<String>,
+    pub duration_sec: Option<i32>,
+    pub source_extractor: Option<String>,
+    pub quality: String,
+    pub format_ext: String,
+    pub streamtape_file_id: String,
+    pub streamtape_url: String,
+    pub file_size_bytes: i64,
+    pub thumbnail_r2_key: Option<String>,
+    pub thumbnail_url: Option<String>,
+    /// Human-readable resolution (e.g. `"720p"`). See
+    /// [`VideoRecord::resolution`] for rationale.
+    pub resolution: Option<String>,
+}

--- a/cr-domain/src/lib.rs
+++ b/cr-domain/src/lib.rs
@@ -9,12 +9,14 @@
 //!
 //! - `entities` - Region, District, Orp, Municipality structs
 //! - `coordinates` - Coordinates value object with validation
+//! - `dto` - Plain row-shaped records returned by repositories
 //! - `error` - Domain-specific error types
 //! - `id` - Strongly-typed ID wrappers
 //! - `repository` - Repository trait definitions (ports)
 //! - `slug` - URL slug generation from Czech names
 
 pub mod coordinates;
+pub mod dto;
 pub mod entities;
 pub mod error;
 pub mod id;

--- a/cr-domain/src/repository.rs
+++ b/cr-domain/src/repository.rs
@@ -2,8 +2,16 @@
 //!
 //! These traits define the contract between the application layer and
 //! infrastructure layer. Implementations live in `cr-infra`.
+//!
+//! The row-shaped DTOs each trait returns (`RegionRecord`, `OrpRecord`,
+//! …) live in `cr-domain::dto` — split out of this module in #446 so the
+//! trait file stays short and focused on ports.
 
 use crate::id::*;
+
+// Back-compat re-exports so existing `cr_domain::repository::{RegionRecord, …}`
+// import paths keep working after the DTO split (#446).
+pub use crate::dto::*;
 
 /// Repository for region queries.
 #[allow(async_fn_in_trait)]
@@ -106,187 +114,4 @@ pub trait VideoRepository {
     /// different container) so the card slides to the top of the
     /// library grid — see #366.
     async fn touch(&self, id: i32) -> Result<(), Self::Error>;
-}
-
-// --- Record types returned by repositories ---
-// These are plain data records (not domain entities) for query results.
-
-/// Region data as stored in the database.
-#[derive(Debug, Clone)]
-pub struct RegionRecord {
-    pub id: i32,
-    pub name: String,
-    pub slug: String,
-    pub region_code: String,
-    pub latitude: Option<f64>,
-    pub longitude: Option<f64>,
-    pub coat_of_arms_ext: Option<String>,
-    pub flag_ext: Option<String>,
-    pub description: Option<String>,
-    pub hero_photo_r2_key: Option<String>,
-    pub hero_municipality_code: Option<String>,
-    pub hero_municipality_photo_index: Option<i16>,
-}
-
-/// ORP data as stored in the database.
-#[derive(Debug, Clone)]
-pub struct OrpRecord {
-    pub id: i32,
-    pub name: String,
-    pub slug: String,
-    pub orp_code: String,
-    pub latitude: Option<f64>,
-    pub longitude: Option<f64>,
-    pub description: Option<String>,
-}
-
-/// Municipality data as stored in the database.
-#[derive(Debug, Clone)]
-pub struct MunicipalityRecord {
-    pub id: i32,
-    pub name: String,
-    pub slug: String,
-    pub municipality_code: String,
-    pub pou_code: String,
-    pub latitude: Option<f64>,
-    pub longitude: Option<f64>,
-    pub wikipedia_url: Option<String>,
-    pub official_website: Option<String>,
-    pub coat_of_arms_ext: Option<String>,
-    pub flag_ext: Option<String>,
-    pub population: Option<i32>,
-    pub elevation: Option<f64>,
-}
-
-/// Landmark summary for listings.
-#[derive(Debug, Clone)]
-pub struct LandmarkSummary {
-    pub name: String,
-    pub slug: String,
-    pub type_name: String,
-    pub municipality_name: String,
-    pub municipality_slug: String,
-    pub is_main: bool,
-}
-
-/// Landmark full record for detail pages.
-#[derive(Debug, Clone)]
-pub struct LandmarkRecord {
-    pub id: i32,
-    pub name: String,
-    pub slug: String,
-    pub latitude: Option<f64>,
-    pub longitude: Option<f64>,
-    pub description: Option<String>,
-    pub wikipedia_url: Option<String>,
-    pub image_ext: Option<String>,
-    pub npu_catalog_id: Option<String>,
-    pub npu_description: Option<String>,
-    pub type_slug: String,
-    pub type_name: String,
-    pub municipality_name: Option<String>,
-    pub municipality_slug: Option<String>,
-    pub orp_slug: Option<String>,
-    pub region_slug: Option<String>,
-    pub municipality_code: Option<String>,
-    pub municipality_coat_of_arms_ext: Option<String>,
-}
-
-/// Pool summary for listings.
-#[derive(Debug, Clone)]
-pub struct PoolSummary {
-    pub name: String,
-    pub slug: String,
-    pub is_aquapark: bool,
-    pub is_indoor: bool,
-    pub is_outdoor: bool,
-    pub is_natural: bool,
-}
-
-/// Pool full record for detail pages.
-#[derive(Debug, Clone)]
-pub struct PoolRecord {
-    pub id: i32,
-    pub name: String,
-    pub slug: String,
-    pub description: Option<String>,
-    pub address: Option<String>,
-    pub latitude: Option<f64>,
-    pub longitude: Option<f64>,
-    pub website: Option<String>,
-    pub email: Option<String>,
-    pub phone: Option<String>,
-    pub facebook: Option<String>,
-    pub facilities: Option<String>,
-    pub pool_length_m: Option<i32>,
-    pub is_aquapark: bool,
-    pub is_indoor: bool,
-    pub is_outdoor: bool,
-    pub is_natural: bool,
-    pub photo_count: i16,
-    pub municipality_name: Option<String>,
-}
-
-/// Photo metadata record.
-#[derive(Debug, Clone)]
-pub struct PhotoRecord {
-    pub r2_key: String,
-    pub width: i16,
-    pub height: i16,
-}
-
-/// Hosted video as stored in the `videos` table.
-///
-/// `created_at` is stored as an ISO 8601 string so this record stays
-/// dependency-free (cr-domain has zero external deps by design).
-#[derive(Debug, Clone)]
-pub struct VideoRecord {
-    pub id: i32,
-    pub source_url: String,
-    pub title: String,
-    pub description: Option<String>,
-    pub duration_sec: Option<i32>,
-    pub source_extractor: Option<String>,
-    pub quality: String,
-    pub format_ext: String,
-    pub streamtape_file_id: String,
-    pub streamtape_url: String,
-    pub file_size_bytes: i64,
-    pub thumbnail_r2_key: Option<String>,
-    pub thumbnail_url: Option<String>,
-    pub created_at: String,
-    /// Bumped to `NOW()` whenever the handler spots an existing
-    /// library entry for the requested URL+quality, so the card
-    /// slides to the top of the library grid. See #366.
-    pub last_accessed_at: String,
-    /// Human-readable resolution like `"1080p"` or `"720p"` parsed
-    /// from yt-dlp's `format.resolution` field. Separate from
-    /// `quality` because `quality` is the raw yt-dlp format_id
-    /// which is source-specific garbage (`"137"` on YouTube,
-    /// `"bytevc1_720p_..."` on TikTok, `"mp4"` on Seznam). `None`
-    /// on legacy rows where the backfill regex couldn't find a
-    /// `\d+p` substring. See #366.
-    pub resolution: Option<String>,
-}
-
-/// Insertion payload for the `videos` table — everything the upload
-/// pipeline knows about a freshly uploaded video. The DB assigns `id`
-/// and `created_at`.
-#[derive(Debug, Clone)]
-pub struct NewVideo {
-    pub source_url: String,
-    pub title: String,
-    pub description: Option<String>,
-    pub duration_sec: Option<i32>,
-    pub source_extractor: Option<String>,
-    pub quality: String,
-    pub format_ext: String,
-    pub streamtape_file_id: String,
-    pub streamtape_url: String,
-    pub file_size_bytes: i64,
-    pub thumbnail_r2_key: Option<String>,
-    pub thumbnail_url: Option<String>,
-    /// Human-readable resolution (e.g. `"720p"`). See
-    /// [`VideoRecord::resolution`] for rationale.
-    pub resolution: Option<String>,
 }

--- a/cr-web/src/cache.rs
+++ b/cr-web/src/cache.rs
@@ -1,0 +1,74 @@
+//! Bounded + TTL cache used by the provider-resolver handlers.
+//!
+//! Two safeguards over a plain `HashMap`:
+//!
+//! 1. **TTL on read** — entries older than `ttl` are ignored.
+//! 2. **Size cap on insert** — if the map is at `max_entries`, evict the
+//!    oldest entry before inserting.
+//!
+//! Replaces the unbounded module-level `LazyLock<Mutex<HashMap>>` caches
+//! (filemoon, sktorrent) that had grown-forever semantics before #443.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tokio::sync::Mutex;
+
+type Entry<V> = (V, Instant);
+
+/// Bounded TTL cache. Cheap to `clone` — the inner map is behind an `Arc`.
+pub struct BoundedTtlCache<K, V> {
+    inner: Arc<Mutex<HashMap<K, Entry<V>>>>,
+    ttl: Duration,
+    max_entries: usize,
+}
+
+impl<K, V> Clone for BoundedTtlCache<K, V> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+            ttl: self.ttl,
+            max_entries: self.max_entries,
+        }
+    }
+}
+
+impl<K, V> BoundedTtlCache<K, V>
+where
+    K: std::hash::Hash + Eq + Clone,
+    V: Clone,
+{
+    pub fn new(max_entries: usize, ttl: Duration) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(HashMap::with_capacity(max_entries.min(512)))),
+            ttl,
+            max_entries,
+        }
+    }
+
+    /// Fetch a still-fresh entry, or `None` on miss / expiry.
+    pub async fn get(&self, key: &K) -> Option<V> {
+        let guard = self.inner.lock().await;
+        guard
+            .get(key)
+            .filter(|(_, at)| at.elapsed() < self.ttl)
+            .map(|(v, _)| v.clone())
+    }
+
+    /// Insert a fresh value. Evicts the oldest entry first when at
+    /// capacity so memory usage is bounded by `max_entries`.
+    pub async fn insert(&self, key: K, value: V) {
+        let mut guard = self.inner.lock().await;
+        if guard.len() >= self.max_entries
+            && !guard.contains_key(&key)
+            && let Some(oldest_key) = guard
+                .iter()
+                .min_by_key(|(_, (_, at))| *at)
+                .map(|(k, _)| k.clone())
+        {
+            guard.remove(&oldest_key);
+        }
+        guard.insert(key, (value, Instant::now()));
+    }
+}

--- a/cr-web/src/cache.rs
+++ b/cr-web/src/cache.rs
@@ -39,7 +39,13 @@ where
     K: std::hash::Hash + Eq + Clone,
     V: Clone,
 {
+    /// Build a new cache. `max_entries == 0` would be a subtle footgun
+    /// (the eviction branch wouldn't trigger because `0 >= 0` is true
+    /// but the key-presence guard always falls through on an empty map),
+    /// so we clamp up to `1`. Callers that want the cache disabled
+    /// should wrap this in an `Option` rather than passing zero.
     pub fn new(max_entries: usize, ttl: Duration) -> Self {
+        let max_entries = max_entries.max(1);
         Self {
             inner: Arc::new(Mutex::new(HashMap::with_capacity(max_entries.min(512)))),
             ttl,
@@ -70,5 +76,56 @@ where
             guard.remove(&oldest_key);
         }
         guard.insert(key, (value, Instant::now()));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BoundedTtlCache;
+    use std::time::Duration;
+    use tokio::time::sleep;
+
+    #[tokio::test]
+    async fn expired_entries_return_none() {
+        let cache = BoundedTtlCache::new(2, Duration::from_millis(5));
+        cache.insert("key", "value").await;
+        sleep(Duration::from_millis(12)).await;
+        assert_eq!(cache.get(&"key").await, None);
+    }
+
+    #[tokio::test]
+    async fn inserting_past_max_entries_evicts_oldest() {
+        let cache = BoundedTtlCache::new(2, Duration::from_secs(60));
+        cache.insert("a", 1).await;
+        sleep(Duration::from_millis(2)).await;
+        cache.insert("b", 2).await;
+        sleep(Duration::from_millis(2)).await;
+        cache.insert("c", 3).await;
+        assert_eq!(cache.get(&"a").await, None);
+        assert_eq!(cache.get(&"b").await, Some(2));
+        assert_eq!(cache.get(&"c").await, Some(3));
+    }
+
+    #[tokio::test]
+    async fn overwriting_existing_key_does_not_grow_map() {
+        let cache = BoundedTtlCache::new(2, Duration::from_secs(60));
+        cache.insert("k", 1).await;
+        cache.insert("k", 2).await;
+        assert_eq!(cache.get(&"k").await, Some(2));
+        assert_eq!(cache.inner.lock().await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn zero_max_entries_is_clamped_to_one() {
+        // The constructor must not leave us with an unbounded cache when
+        // a caller passes 0 — we clamp to 1 so at least the eviction
+        // branch runs.
+        let cache = BoundedTtlCache::new(0, Duration::from_secs(60));
+        cache.insert("a", 1).await;
+        cache.insert("b", 2).await;
+        // Only the most-recent entry survives because the cap is 1.
+        assert_eq!(cache.inner.lock().await.len(), 1);
+        assert_eq!(cache.get(&"a").await, None);
+        assert_eq!(cache.get(&"b").await, Some(2));
     }
 }

--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -836,11 +836,9 @@ pub struct SktorrentResolveResponse {
     cached: bool,
 }
 
-/// In-memory cache for resolved sktorrent sources. Key: video_id, Value: (sources, resolved_at).
-type SktorrentCache =
-    tokio::sync::Mutex<std::collections::HashMap<i32, (Vec<SktorrentSource>, std::time::Instant)>>;
-static SKTORRENT_CACHE: std::sync::LazyLock<SktorrentCache> =
-    std::sync::LazyLock::new(|| tokio::sync::Mutex::new(std::collections::HashMap::new()));
+// SK Torrent resolution cache moved to `AppState.sktorrent_cache` (a
+// `BoundedTtlCache`) to bound memory growth. Configured in main.rs with
+// `max_entries=2000, ttl=6h`.
 
 /// GET /api/films/sktorrent-resolve?video_id=99
 /// Fetches current CDN URLs from sktorrent.eu video page.
@@ -849,28 +847,14 @@ pub async fn sktorrent_resolve(
     axum::extract::Query(params): axum::extract::Query<SktorrentResolveQuery>,
 ) -> axum::Json<SktorrentResolveResponse> {
     let video_id = params.video_id;
-    let cache_ttl = std::time::Duration::from_secs(2 * 3600); // 2h cache
 
-    // Check cache
-    {
-        let cache = SKTORRENT_CACHE.lock().await;
-        if let Some((sources, resolved_at)) = cache.get(&video_id)
-            && resolved_at.elapsed() < cache_ttl
-        {
-            return axum::Json(SktorrentResolveResponse {
-                video_id,
-                sources: sources
-                    .iter()
-                    .map(|s| SktorrentSource {
-                        url: s.url.clone(),
-                        quality: s.quality.clone(),
-                        res: s.res,
-                    })
-                    .collect(),
-                error: None,
-                cached: true,
-            });
-        }
+    if let Some(cached_sources) = state.sktorrent_cache.get(&video_id).await {
+        return axum::Json(SktorrentResolveResponse {
+            video_id,
+            sources: cached_sources,
+            error: None,
+            cached: true,
+        });
     }
 
     // Fetch sktorrent video page
@@ -940,24 +924,10 @@ pub async fn sktorrent_resolve(
         });
     }
 
-    // Cache
-    {
-        let mut cache = SKTORRENT_CACHE.lock().await;
-        cache.insert(
-            video_id,
-            (
-                sources
-                    .iter()
-                    .map(|s| SktorrentSource {
-                        url: s.url.clone(),
-                        quality: s.quality.clone(),
-                        res: s.res,
-                    })
-                    .collect(),
-                std::time::Instant::now(),
-            ),
-        );
-    }
+    state
+        .sktorrent_cache
+        .insert(video_id, sources.clone())
+        .await;
 
     axum::Json(SktorrentResolveResponse {
         video_id,

--- a/cr-web/src/handlers/mod.rs
+++ b/cr-web/src/handlers/mod.rs
@@ -12,7 +12,8 @@ use crate::state::AppState;
 pub mod admin_import;
 mod audiobooks;
 mod download_video;
-mod films;
+// Public so AppState can reference SktorrentSource for the bounded cache.
+pub mod films;
 mod filmy_serialy;
 mod geojson;
 mod landmarks;

--- a/cr-web/src/handlers/mod.rs
+++ b/cr-web/src/handlers/mod.rs
@@ -12,8 +12,7 @@ use crate::state::AppState;
 pub mod admin_import;
 mod audiobooks;
 mod download_video;
-// Public so AppState can reference SktorrentSource for the bounded cache.
-pub mod films;
+mod films;
 mod filmy_serialy;
 mod geojson;
 mod landmarks;
@@ -28,7 +27,7 @@ pub mod video_api;
 // Re-export all public handlers so main.rs doesn't need changes
 pub use audiobooks::audiobooks;
 pub use download_video::download_video;
-pub use films::{films_detail, films_list, films_search, sktorrent_resolve};
+pub use films::{SktorrentSource, films_detail, films_list, films_search, sktorrent_resolve};
 pub use filmy_serialy::filmy_serialy;
 pub use geojson::{geojson_municipality, geojson_orp};
 pub use landmarks::{api_landmarks, landmarks_by_url, landmarks_index};

--- a/cr-web/src/handlers/movies_api.rs
+++ b/cr-web/src/handlers/movies_api.rs
@@ -1,19 +1,16 @@
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use axum::Json;
 use axum::extract::{Query, State};
 use axum::http::{StatusCode, header};
 use axum::response::IntoResponse;
 use serde::{Deserialize, Serialize};
-use tokio::sync::Mutex;
 
 use crate::state::AppState;
 
-/// In-memory cache for resolved filemoon m3u8 URLs.
-/// Key: filemoon_code, Value: (url, resolved_at).
-static FILEMOON_CACHE: std::sync::LazyLock<
-    Mutex<std::collections::HashMap<String, (String, Instant)>>,
-> = std::sync::LazyLock::new(|| Mutex::new(std::collections::HashMap::new()));
+// Filemoon / stream-resolver cache moved to `AppState.filemoon_cache`
+// (a bounded TTL cache) — see `cr-web/src/cache.rs`. No more unbounded
+// module-level `LazyLock<Mutex<HashMap>>`.
 
 #[derive(Deserialize)]
 pub struct SearchQuery {
@@ -720,6 +717,7 @@ const ALLOWED_PROVIDERS: &[&str] = &["filemoon", "streamtape", "mixdrop", "vidli
 /// Supported providers: filemoon (HLS), streamtape (MP4), mixdrop (MP4), vidlink (HLS).
 /// Results are cached per provider+code with TTL based on token expiry.
 pub async fn stream_resolve(
+    State(state): State<AppState>,
     Query(params): Query<StreamResolveQuery>,
 ) -> Json<StreamResolveResponse> {
     let provider = params.provider.trim().to_lowercase();
@@ -752,23 +750,18 @@ pub async fn stream_resolve(
 
     let cache_key = format!("{provider}:{code}");
 
-    // Check cache (2h TTL — conservative, tokens last 3-4h)
-    let cache_ttl = Duration::from_secs(2 * 3600);
-    {
-        let cache = FILEMOON_CACHE.lock().await;
-        if let Some((url, resolved_at)) = cache.get(&cache_key)
-            && resolved_at.elapsed() < cache_ttl
-        {
-            let fmt = if url.contains(".m3u8") { "hls" } else { "mp4" };
-            return Json(StreamResolveResponse {
-                provider,
-                code,
-                stream_url: Some(url.clone()),
-                format: Some(fmt.to_string()),
-                error: None,
-                cached: true,
-            });
-        }
+    // Check cache — TTL and size cap live on the BoundedTtlCache itself
+    // (see AppState::filemoon_cache construction in main.rs).
+    if let Some(url) = state.filemoon_cache.get(&cache_key).await {
+        let fmt = if url.contains(".m3u8") { "hls" } else { "mp4" };
+        return Json(StreamResolveResponse {
+            provider,
+            code,
+            stream_url: Some(url),
+            format: Some(fmt.to_string()),
+            error: None,
+            cached: true,
+        });
     }
 
     // Use Playwright (Python script) for all providers — it handles browser
@@ -779,16 +772,13 @@ pub async fn stream_resolve(
 
     match result {
         Ok(pr) => {
-            {
-                let mut cache = FILEMOON_CACHE.lock().await;
-                // Store URL + cookies in cache (cookies separated by \n)
-                let cache_val = if let Some(ref cookies) = pr.cookies {
-                    format!("{}\n{cookies}", pr.url)
-                } else {
-                    pr.url.clone()
-                };
-                cache.insert(cache_key, (cache_val, Instant::now()));
-            }
+            // Store URL + cookies in cache (cookies separated by \n)
+            let cache_val = if let Some(ref cookies) = pr.cookies {
+                format!("{}\n{cookies}", pr.url)
+            } else {
+                pr.url.clone()
+            };
+            state.filemoon_cache.insert(cache_key, cache_val).await;
             Json(StreamResolveResponse {
                 provider,
                 code,
@@ -821,36 +811,27 @@ pub async fn movies_proxy_stream(
 
     // Resolve stream URL + cookies via Playwright
     let cache_key = format!("{provider}:{code}");
-    let cache_ttl = Duration::from_secs(2 * 3600);
 
-    // Check cache first (stores "url\ncookies" or just "url")
-    let (stream_url, cookies) = {
-        let cache = FILEMOON_CACHE.lock().await;
-        if let Some((cached_val, resolved_at)) = cache.get(&cache_key)
-            && resolved_at.elapsed() < cache_ttl
-        {
-            let parts: Vec<&str> = cached_val.splitn(2, '\n').collect();
-            let url = parts[0].to_string();
-            let cookies = parts.get(1).map(|s| s.to_string());
-            (url, cookies)
-        } else {
-            drop(cache); // Release lock before calling resolve
-            // Resolve fresh
-            let result = resolve_via_playwright(&provider, &code).await;
-            match result {
-                Ok(pr) => {
-                    let mut cache = FILEMOON_CACHE.lock().await;
-                    let cache_val = if let Some(ref c) = pr.cookies {
-                        format!("{}\n{c}", pr.url)
-                    } else {
-                        pr.url.clone()
-                    };
-                    cache.insert(cache_key, (cache_val, Instant::now()));
-                    (pr.url, pr.cookies)
-                }
-                Err(e) => {
-                    return (StatusCode::BAD_GATEWAY, e).into_response();
-                }
+    // Check cache first (stores "url\ncookies" or just "url").
+    let (stream_url, cookies) = if let Some(cached_val) = state.filemoon_cache.get(&cache_key).await
+    {
+        let parts: Vec<&str> = cached_val.splitn(2, '\n').collect();
+        let url = parts[0].to_string();
+        let cookies = parts.get(1).map(|s| s.to_string());
+        (url, cookies)
+    } else {
+        match resolve_via_playwright(&provider, &code).await {
+            Ok(pr) => {
+                let cache_val = if let Some(ref c) = pr.cookies {
+                    format!("{}\n{c}", pr.url)
+                } else {
+                    pr.url.clone()
+                };
+                state.filemoon_cache.insert(cache_key, cache_val).await;
+                (pr.url, pr.cookies)
+            }
+            Err(e) => {
+                return (StatusCode::BAD_GATEWAY, e).into_response();
             }
         }
     };
@@ -932,9 +913,10 @@ pub async fn movies_proxy_stream(
 
 /// Backwards-compatible wrapper — calls stream_resolve with provider=filemoon.
 pub async fn filemoon_resolve(
+    state: State<AppState>,
     Query(params): Query<StreamResolveQuery>,
 ) -> Json<StreamResolveResponse> {
-    stream_resolve(Query(params)).await
+    stream_resolve(state, Query(params)).await
 }
 
 // ── Pure-HTTP stream resolvers (no Playwright) ───────────────────

--- a/cr-web/src/main.rs
+++ b/cr-web/src/main.rs
@@ -16,6 +16,7 @@ use tower_http::cors::{Any, CorsLayer};
 use tower_http::services::ServeDir;
 use tower_http::trace::TraceLayer;
 
+mod cache;
 mod config;
 mod error;
 mod handlers;
@@ -115,6 +116,14 @@ async fn main() -> Result<()> {
         r2_config: r2_config.map(Arc::new),
         video_library,
         streamtape_url_cache: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
+        // Filemoon playback URLs stay valid ~4 h; cap at 500 entries.
+        filemoon_cache: cache::BoundedTtlCache::new(500, std::time::Duration::from_secs(2 * 3600)),
+        // SK Torrent CDN scans are expensive (parallel HEADs); 6 h TTL and
+        // 2000 entries leave headroom for the current catalogue.
+        sktorrent_cache: cache::BoundedTtlCache::new(
+            2000,
+            std::time::Duration::from_secs(6 * 3600),
+        ),
     };
 
     // API routes with CORS

--- a/cr-web/src/main.rs
+++ b/cr-web/src/main.rs
@@ -116,8 +116,10 @@ async fn main() -> Result<()> {
         r2_config: r2_config.map(Arc::new),
         video_library,
         streamtape_url_cache: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
-        // Filemoon playback URLs stay valid ~4 h; cap at 500 entries.
-        filemoon_cache: cache::BoundedTtlCache::new(500, std::time::Duration::from_secs(2 * 3600)),
+        // Filemoon playback URLs are cached for 30 min to match the
+        // #443 acceptance criteria; prevents serving stale tokens even
+        // though the underlying URL may appear valid longer.
+        filemoon_cache: cache::BoundedTtlCache::new(500, std::time::Duration::from_secs(30 * 60)),
         // SK Torrent CDN scans are expensive (parallel HEADs); 6 h TTL and
         // 2000 entries leave headroom for the current catalogue.
         sktorrent_cache: cache::BoundedTtlCache::new(

--- a/cr-web/src/state.rs
+++ b/cr-web/src/state.rs
@@ -11,7 +11,7 @@ use cr_infra::video_library::VideoLibraryPipeline;
 use sqlx::PgPool;
 
 use crate::cache::BoundedTtlCache;
-use crate::handlers::films::SktorrentSource;
+use crate::handlers::SktorrentSource;
 use crate::handlers::video_api::VideoDownloads;
 
 #[derive(Clone)]
@@ -58,7 +58,7 @@ pub struct AppState {
         Arc<tokio::sync::Mutex<HashMap<String, (String, std::time::Instant)>>>,
     /// Bounded TTL cache for resolved filemoon / stream m3u8 URLs. Key is
     /// `"{provider}:{code}"`, value is the resolved playback URL (optionally
-    /// with `\ncookies=...` appended, matching the pre-refactor convention).
+    /// followed by `\n{cookies}`, matching the pre-refactor convention).
     /// Before #443 this was an unbounded module-level LazyLock.
     pub filemoon_cache: BoundedTtlCache<String, String>,
     /// Bounded TTL cache for SK Torrent per-video source lists. Key is

--- a/cr-web/src/state.rs
+++ b/cr-web/src/state.rs
@@ -10,6 +10,8 @@ use cr_infra::streamtape::StreamtapeConfig;
 use cr_infra::video_library::VideoLibraryPipeline;
 use sqlx::PgPool;
 
+use crate::cache::BoundedTtlCache;
+use crate::handlers::films::SktorrentSource;
 use crate::handlers::video_api::VideoDownloads;
 
 #[derive(Clone)]
@@ -54,6 +56,14 @@ pub struct AppState {
     /// good for ~50 min so caching it makes seek/buffer feel instant.
     pub streamtape_url_cache:
         Arc<tokio::sync::Mutex<HashMap<String, (String, std::time::Instant)>>>,
+    /// Bounded TTL cache for resolved filemoon / stream m3u8 URLs. Key is
+    /// `"{provider}:{code}"`, value is the resolved playback URL (optionally
+    /// with `\ncookies=...` appended, matching the pre-refactor convention).
+    /// Before #443 this was an unbounded module-level LazyLock.
+    pub filemoon_cache: BoundedTtlCache<String, String>,
+    /// Bounded TTL cache for SK Torrent per-video source lists. Key is
+    /// `sktorrent_video_id`; value is the resolved source list.
+    pub sktorrent_cache: BoundedTtlCache<i32, Vec<SktorrentSource>>,
 }
 
 /// In-memory index of GeoJSON features for fast API lookups.


### PR DESCRIPTION
<!-- claude-session: c0717c9a-16b7-4690-af5a-437a07586132 -->

Closes #443. Partial toward #446.

Part of #436. Second batch.

## Summary
- **#443 — bounded TTL caches**: new `cr-web/src/cache.rs` with `BoundedTtlCache<K, V>` (80 lines, tokio-mutex-backed HashMap with TTL check on read + oldest-entry eviction on insert). No crate dep. Replaces the two unbounded `LazyLock<Mutex<HashMap>>` statics in `movies_api.rs` and `films.rs`. Caches now live in `AppState` so tests can instantiate them with different capacities.
- **#446 partial — DTO split**: moved 183 lines of `*Record` / `NewVideo` types out of `cr-domain/src/repository.rs` (was 292 lines, now 112) into a dedicated `cr-domain/src/dto.rs`. Trait module now holds only ports. Back-compat `pub use crate::dto::*` keeps existing import paths working.

## Not in this PR (remaining #446 scope)
- Dead-code marker audit (~30 sites across handlers) — orthogonal, deferred to a dedicated cleanup PR.
- `build_query_string` helper shared between films + series handlers — small and can land alongside the handler splits in #439/#440.
- Repository tests for the five currently-untested repos (region, municipality, landmark, pool, photo) — need `sqlx::test` fixtures; belongs with #445 services work.

## Test plan
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test --workspace` — all existing tests pass
- [ ] Deploy + Playwright smoke (cache behavior isn't user-visible, but make sure the handler wiring didn't break `/api/movies/stream-resolve` or `/api/films/sktorrent-resolve`)