### PR TITLE
refactor: SQL to repositories + dead_code audit + shared helpers (closes #444, #446)

### DIFF
--- a/cr-domain/src/repository.rs
+++ b/cr-domain/src/repository.rs
@@ -28,6 +28,8 @@ pub trait OrpRepository {
     async fn find_by_slug(&self, slug: &str) -> Result<Option<OrpRecord>, Self::Error>;
     async fn find_by_region(&self, region_id: RegionId) -> Result<Vec<OrpRecord>, Self::Error>;
     async fn exists_by_slug(&self, slug: &str) -> Result<bool, Self::Error>;
+    /// Find the region slug for an ORP by its slug (joins through districts).
+    async fn region_slug_for_orp(&self, orp_slug: &str) -> Result<Option<String>, Self::Error>;
 }
 
 /// Repository for municipality queries.

--- a/cr-infra/src/repositories/municipality.rs
+++ b/cr-infra/src/repositories/municipality.rs
@@ -1,6 +1,12 @@
 use cr_domain::id::OrpId;
 use cr_domain::repository::{MunicipalityRecord, MunicipalityRepository};
 
+/// SELECT column list for municipality queries. Shared across
+/// `find_by_slug_and_orp` and `find_by_orp` to keep columns in one place.
+pub(crate) const MUNICIPALITY_COLUMNS: &str = "id, name, slug, municipality_code, pou_code, \
+    latitude, longitude, wikipedia_url, official_website, coat_of_arms_ext, \
+    flag_ext, population, elevation";
+
 /// PostgreSQL implementation of [`MunicipalityRepository`].
 pub struct PgMunicipalityRepository {
     pool: sqlx::PgPool,
@@ -57,11 +63,9 @@ impl MunicipalityRepository for PgMunicipalityRepository {
         slug: &str,
         orp_id: OrpId,
     ) -> Result<Option<MunicipalityRecord>, Self::Error> {
-        let row = sqlx::query_as::<_, MunicipalityRow>(
-            "SELECT id, name, slug, municipality_code, pou_code, latitude, longitude, \
-             wikipedia_url, official_website, coat_of_arms_ext, flag_ext, population, elevation \
-             FROM municipalities WHERE orp_id = $1 AND slug = $2",
-        )
+        let row = sqlx::query_as::<_, MunicipalityRow>(&format!(
+            "SELECT {MUNICIPALITY_COLUMNS} FROM municipalities WHERE orp_id = $1 AND slug = $2"
+        ))
         .bind(orp_id.value())
         .bind(slug)
         .fetch_optional(&self.pool)
@@ -71,11 +75,9 @@ impl MunicipalityRepository for PgMunicipalityRepository {
     }
 
     async fn find_by_orp(&self, orp_id: OrpId) -> Result<Vec<MunicipalityRecord>, Self::Error> {
-        let rows = sqlx::query_as::<_, MunicipalityRow>(
-            "SELECT id, name, slug, municipality_code, pou_code, latitude, longitude, \
-             wikipedia_url, official_website, coat_of_arms_ext, flag_ext, population, elevation \
-             FROM municipalities WHERE orp_id = $1 ORDER BY name",
-        )
+        let rows = sqlx::query_as::<_, MunicipalityRow>(&format!(
+            "SELECT {MUNICIPALITY_COLUMNS} FROM municipalities WHERE orp_id = $1 ORDER BY name"
+        ))
         .bind(orp_id.value())
         .fetch_all(&self.pool)
         .await?;

--- a/cr-infra/src/repositories/orp.rs
+++ b/cr-infra/src/repositories/orp.rs
@@ -1,6 +1,10 @@
 use cr_domain::id::RegionId;
 use cr_domain::repository::{OrpRecord, OrpRepository};
 
+/// SELECT column list for ORP queries (with `o.` table alias).
+pub(crate) const ORP_COLUMNS: &str =
+    "o.id, o.name, o.slug, o.orp_code, o.latitude, o.longitude, o.description";
+
 /// PostgreSQL implementation of [`OrpRepository`].
 pub struct PgOrpRepository {
     pool: sqlx::PgPool,
@@ -41,12 +45,11 @@ impl OrpRepository for PgOrpRepository {
     type Error = sqlx::Error;
 
     async fn find_by_slug(&self, slug: &str) -> Result<Option<OrpRecord>, Self::Error> {
-        let row = sqlx::query_as::<_, OrpRow>(
-            "SELECT o.id, o.name, o.slug, o.orp_code, o.latitude, o.longitude, o.description \
-             FROM orp o \
-             JOIN districts d ON o.district_id = d.id \
-             WHERE o.slug = $1",
-        )
+        let row = sqlx::query_as::<_, OrpRow>(&format!(
+            "SELECT {ORP_COLUMNS} FROM orp o \
+                 JOIN districts d ON o.district_id = d.id \
+                 WHERE o.slug = $1"
+        ))
         .bind(slug)
         .fetch_optional(&self.pool)
         .await?;
@@ -55,12 +58,11 @@ impl OrpRepository for PgOrpRepository {
     }
 
     async fn find_by_region(&self, region_id: RegionId) -> Result<Vec<OrpRecord>, Self::Error> {
-        let rows = sqlx::query_as::<_, OrpRow>(
-            "SELECT o.id, o.name, o.slug, o.orp_code, o.latitude, o.longitude, o.description \
-             FROM orp o \
-             JOIN districts d ON o.district_id = d.id \
-             WHERE d.region_id = $1 ORDER BY o.name",
-        )
+        let rows = sqlx::query_as::<_, OrpRow>(&format!(
+            "SELECT {ORP_COLUMNS} FROM orp o \
+                 JOIN districts d ON o.district_id = d.id \
+                 WHERE d.region_id = $1 ORDER BY o.name"
+        ))
         .bind(region_id.value())
         .fetch_all(&self.pool)
         .await?;
@@ -76,5 +78,17 @@ impl OrpRepository for PgOrpRepository {
                 .await?;
 
         Ok(exists)
+    }
+
+    async fn region_slug_for_orp(&self, orp_slug: &str) -> Result<Option<String>, Self::Error> {
+        sqlx::query_scalar::<_, String>(
+            "SELECT r.slug FROM regions r \
+             JOIN districts d ON d.region_id = r.id \
+             JOIN orp o ON o.district_id = d.id \
+             WHERE o.slug = $1",
+        )
+        .bind(orp_slug)
+        .fetch_optional(&self.pool)
+        .await
     }
 }

--- a/cr-infra/src/repositories/region.rs
+++ b/cr-infra/src/repositories/region.rs
@@ -1,5 +1,11 @@
 use cr_domain::repository::{RegionRecord, RegionRepository};
 
+/// SELECT column list for region queries. Shared across `find_all` and
+/// `find_by_slug` to keep the column list in one place.
+pub(crate) const REGION_COLUMNS: &str = "id, name, slug, region_code, latitude, longitude, \
+    coat_of_arms_ext, flag_ext, description, hero_photo_r2_key, \
+    hero_municipality_code, hero_municipality_photo_index";
+
 /// PostgreSQL implementation of [`RegionRepository`].
 pub struct PgRegionRepository {
     pool: sqlx::PgPool,
@@ -50,12 +56,9 @@ impl RegionRepository for PgRegionRepository {
     type Error = sqlx::Error;
 
     async fn find_all(&self) -> Result<Vec<RegionRecord>, Self::Error> {
-        let rows = sqlx::query_as::<_, RegionRow>(
-            "SELECT id, name, slug, region_code, latitude, longitude, \
-             coat_of_arms_ext, flag_ext, description, hero_photo_r2_key, \
-             hero_municipality_code, hero_municipality_photo_index \
-             FROM regions ORDER BY name",
-        )
+        let rows = sqlx::query_as::<_, RegionRow>(&format!(
+            "SELECT {REGION_COLUMNS} FROM regions ORDER BY name"
+        ))
         .fetch_all(&self.pool)
         .await?;
 
@@ -63,12 +66,9 @@ impl RegionRepository for PgRegionRepository {
     }
 
     async fn find_by_slug(&self, slug: &str) -> Result<Option<RegionRecord>, Self::Error> {
-        let row = sqlx::query_as::<_, RegionRow>(
-            "SELECT id, name, slug, region_code, latitude, longitude, \
-             coat_of_arms_ext, flag_ext, description, hero_photo_r2_key, \
-             hero_municipality_code, hero_municipality_photo_index \
-             FROM regions WHERE slug = $1",
-        )
+        let row = sqlx::query_as::<_, RegionRow>(&format!(
+            "SELECT {REGION_COLUMNS} FROM regions WHERE slug = $1"
+        ))
         .bind(slug)
         .fetch_optional(&self.pool)
         .await?;

--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -3,6 +3,13 @@ use serde::{Deserialize, Serialize};
 
 const FILMS_PER_PAGE: i64 = 24;
 
+/// SELECT column list for `FilmRow` queries. Kept as a const to avoid
+/// duplication across `films_list`, `films_by_genre`, and `films_detail`.
+const FILM_COLUMNS: &str = "f.id, f.title, f.slug, f.year, f.description, f.original_title, \
+    f.imdb_rating, f.csfd_rating, f.runtime_min, f.cover_filename, \
+    f.sktorrent_video_id, f.sktorrent_cdn, f.sktorrent_qualities, f.added_at, \
+    f.prehrajto_url, f.prehrajto_has_dub, f.prehrajto_has_subs";
+
 // --- DB row types ---
 
 #[derive(sqlx::FromRow)]
@@ -18,16 +25,16 @@ struct FilmRow {
     runtime_min: Option<i16>,
     cover_filename: Option<String>,
     sktorrent_video_id: Option<i32>,
-    #[allow(dead_code)]
+    // Used by Askama template (film_detail.html) for JS player initialization
     sktorrent_cdn: Option<i16>,
-    #[allow(dead_code)]
+    // Used by Askama template (film_detail.html) for JS player initialization
     sktorrent_qualities: Option<String>,
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Needed in SELECT for ORDER BY; not rendered in templates
     added_at: Option<chrono::DateTime<chrono::Utc>>,
     prehrajto_url: Option<String>,
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Not rendered in current templates; kept for future dub/sub badges
     prehrajto_has_dub: bool,
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Not rendered in current templates; kept for future dub/sub badges
     prehrajto_has_subs: bool,
 }
 
@@ -45,7 +52,7 @@ struct FilmGenreNameRow {
 }
 
 #[derive(sqlx::FromRow)]
-#[allow(dead_code)]
+#[allow(dead_code)] // Fetched in films_detail; template accesses via JS, not Askama
 struct FilmSourceRow {
     provider: String,
     code: String,
@@ -171,7 +178,7 @@ struct FilmsListTemplate {
     total_pages: i64,
     total_count: i64,
     current_genre: Option<GenreRow>,
-    #[allow(dead_code)]
+    #[allow(dead_code)] // TODO: verify usage — may be needed for sort UI active state
     sort_key: String,
     query_string: String,
     search_query: Option<String>,
@@ -183,7 +190,7 @@ struct FilmDetailTemplate {
     img: String,
     film: FilmRow,
     genres: Vec<FilmGenreNameRow>,
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Fetched from DB but not rendered via Askama; JS handles sources
     sources: Vec<FilmSourceRow>,
 }
 
@@ -304,10 +311,7 @@ pub async fn films_list(
 
     // Films query
     let films_query = format!(
-        "SELECT f.id, f.title, f.slug, f.year, f.description, f.original_title, \
-         f.imdb_rating, f.csfd_rating, f.runtime_min, f.cover_filename, \
-         f.sktorrent_video_id, f.sktorrent_cdn, f.sktorrent_qualities, f.added_at, \
-         f.prehrajto_url, f.prehrajto_has_dub, f.prehrajto_has_subs \
+        "SELECT {FILM_COLUMNS} \
          FROM films f {where_clause} \
          ORDER BY {order} \
          LIMIT ${limit_idx} OFFSET ${offset_idx}",
@@ -339,52 +343,7 @@ pub async fn films_list(
     let genres = load_genres(&state.db).await?;
 
     // Build query string for pagination links (preserve sort + filters)
-    let mut qs_parts = Vec::new();
-    if params.razeni.is_some() {
-        qs_parts.push(format!("razeni={}", params.sort_key()));
-    }
-    if let Some(ref q) = params.q {
-        let t = q.trim();
-        if !t.is_empty() {
-            qs_parts.push(format!("q={}", urlencoding::encode(t)));
-        }
-    }
-    if let Some(ref z) = params.zanry
-        && !z.is_empty()
-    {
-        qs_parts.push(format!("zanry={}", urlencoding::encode(z)));
-    }
-    if let Some(ref m) = params.rezim
-        && m == "and"
-    {
-        qs_parts.push("rezim=and".to_string());
-    }
-    if let Some(ref s) = params.smer
-        && s == "asc"
-    {
-        qs_parts.push("smer=asc".to_string());
-    }
-    if let Some(ref j) = params.jazyk
-        && !j.is_empty()
-    {
-        // Preserve all explicit values including "vse" (default without param = "dub")
-        qs_parts.push(format!("jazyk={}", urlencoding::encode(j)));
-    }
-    if let Some(ref b) = params.bez
-        && !b.is_empty()
-    {
-        qs_parts.push(format!("bez={}", urlencoding::encode(b)));
-    }
-    if let Some(ref r) = params.rok
-        && !r.is_empty()
-    {
-        qs_parts.push(format!("rok={}", urlencoding::encode(r)));
-    }
-    let query_string = if qs_parts.is_empty() {
-        String::new()
-    } else {
-        format!("&{}", qs_parts.join("&"))
-    };
+    let query_string = build_films_query_string(&params);
 
     let search_query = params.q.as_ref().and_then(|q| {
         let t = q.trim();
@@ -436,13 +395,9 @@ pub async fn films_detail(
     }
 
     // Otherwise: film detail
-    let film = sqlx::query_as::<_, FilmRow>(
-        "SELECT id, title, slug, year, description, original_title, \
-         imdb_rating, csfd_rating, runtime_min, cover_filename, \
-         sktorrent_video_id, sktorrent_cdn, sktorrent_qualities, added_at, \
-         prehrajto_url, prehrajto_has_dub, prehrajto_has_subs \
-         FROM films WHERE slug = $1",
-    )
+    let film = sqlx::query_as::<_, FilmRow>(&format!(
+        "SELECT {FILM_COLUMNS} FROM films f WHERE f.slug = $1"
+    ))
     .bind(&slug)
     .fetch_optional(&state.db)
     .await?;
@@ -530,10 +485,7 @@ async fn films_by_genre(
 
     // Films
     let films_query = format!(
-        "SELECT DISTINCT f.id, f.title, f.slug, f.year, f.description, f.original_title, \
-         f.imdb_rating, f.csfd_rating, f.runtime_min, f.cover_filename, \
-         f.sktorrent_video_id, f.sktorrent_cdn, f.sktorrent_qualities, f.added_at, \
-         f.prehrajto_url, f.prehrajto_has_dub, f.prehrajto_has_subs \
+        "SELECT DISTINCT {FILM_COLUMNS} \
          FROM films f \
          JOIN film_genres fg ON f.id = fg.film_id \
          WHERE {where_clause} \
@@ -557,46 +509,7 @@ async fn films_by_genre(
 
     let all_genres = load_genres(&state.db).await?;
 
-    let mut qs_parts = Vec::new();
-    if params.razeni.is_some() {
-        qs_parts.push(format!("razeni={}", params.sort_key()));
-    }
-    if let Some(ref s) = params.smer
-        && s == "asc"
-    {
-        qs_parts.push("smer=asc".to_string());
-    }
-    if let Some(ref j) = params.jazyk
-        && !j.is_empty()
-    {
-        // Preserve all explicit values including "vse" (default without param = "dub")
-        qs_parts.push(format!("jazyk={}", urlencoding::encode(j)));
-    }
-    if let Some(ref z) = params.zanry
-        && !z.is_empty()
-    {
-        qs_parts.push(format!("zanry={}", urlencoding::encode(z)));
-    }
-    if let Some(ref m) = params.rezim
-        && m == "and"
-    {
-        qs_parts.push("rezim=and".to_string());
-    }
-    if let Some(ref b) = params.bez
-        && !b.is_empty()
-    {
-        qs_parts.push(format!("bez={}", urlencoding::encode(b)));
-    }
-    if let Some(ref r) = params.rok
-        && !r.is_empty()
-    {
-        qs_parts.push(format!("rok={}", urlencoding::encode(r)));
-    }
-    let query_string = if qs_parts.is_empty() {
-        String::new()
-    } else {
-        format!("&{}", qs_parts.join("&"))
-    };
+    let query_string = build_films_query_string(&params);
 
     let tmpl = FilmsListTemplate {
         img: state.image_base_url.clone(),
@@ -1011,6 +924,49 @@ async fn load_genres(db: &sqlx::PgPool) -> Result<Vec<GenreRow>, sqlx::Error> {
     )
     .fetch_all(db)
     .await
+}
+
+/// Build pagination query string for film list/genre views.
+/// Consolidates the qs_parts logic that was duplicated in `films_list`
+/// and `films_by_genre`.
+fn build_films_query_string(params: &FilmsQuery) -> String {
+    let mut parts: Vec<(&str, String)> = Vec::new();
+    if params.razeni.is_some() {
+        parts.push(("razeni", params.sort_key().to_string()));
+    }
+    if let Some(ref q) = params.q {
+        let t = q.trim();
+        if !t.is_empty() {
+            parts.push(("q", t.to_string()));
+        }
+    }
+    if let Some(ref z) = params.zanry
+        && !z.is_empty()
+    {
+        parts.push(("zanry", z.clone()));
+    }
+    if params.rezim.as_deref() == Some("and") {
+        parts.push(("rezim", "and".to_string()));
+    }
+    if params.smer.as_deref() == Some("asc") {
+        parts.push(("smer", "asc".to_string()));
+    }
+    if let Some(ref j) = params.jazyk
+        && !j.is_empty()
+    {
+        parts.push(("jazyk", j.clone()));
+    }
+    if let Some(ref b) = params.bez
+        && !b.is_empty()
+    {
+        parts.push(("bez", b.clone()));
+    }
+    if let Some(ref r) = params.rok
+        && !r.is_empty()
+    {
+        parts.push(("rok", r.clone()));
+    }
+    super::build_pagination_qs(&parts)
 }
 
 fn not_found_response() -> Response {

--- a/cr-web/src/handlers/landmarks.rs
+++ b/cr-web/src/handlers/landmarks.rs
@@ -10,7 +10,7 @@ pub(crate) async fn render_landmark_short(
     orp_slug: &str,
     landmark_slug: &str,
 ) -> (StatusCode, Html<String>) {
-    let Some(region_slug) = region_slug_for_orp(&state.db, orp_slug).await else {
+    let Some(region_slug) = region_slug_for_orp(state, orp_slug).await else {
         return not_found(&state.image_base_url);
     };
     render_landmark(state, &region_slug, orp_slug, landmark_slug).await
@@ -22,7 +22,7 @@ pub(crate) async fn render_landmark_in_municipality(
     landmark_slug: &str,
     _orp_id: i32,
 ) -> (StatusCode, Html<String>) {
-    let Some(region_slug) = region_slug_for_orp(&state.db, orp_slug).await else {
+    let Some(region_slug) = region_slug_for_orp(state, orp_slug).await else {
         return not_found(&state.image_base_url);
     };
     render_landmark(state, &region_slug, orp_slug, landmark_slug).await

--- a/cr-web/src/handlers/mod.rs
+++ b/cr-web/src/handlers/mod.rs
@@ -841,8 +841,7 @@ pub async fn resolve_path(State(state): State<AppState>, uri: Uri) -> WebResult<
             let is_orp = state
                 .orp_repo
                 .exists_by_slug(segments[0])
-                .await
-                .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+                .await?;
 
             if is_orp {
                 return Ok(orp::render_orp_by_slug(&state, segments[0])

--- a/cr-web/src/handlers/mod.rs
+++ b/cr-web/src/handlers/mod.rs
@@ -838,10 +838,7 @@ pub async fn resolve_path(State(state): State<AppState>, uri: Uri) -> WebResult<
                 .await;
             }
             // Single query: is this an ORP or region slug?
-            let is_orp = state
-                .orp_repo
-                .exists_by_slug(segments[0])
-                .await?;
+            let is_orp = state.orp_repo.exists_by_slug(segments[0]).await?;
 
             if is_orp {
                 return Ok(orp::render_orp_by_slug(&state, segments[0])

--- a/cr-web/src/handlers/mod.rs
+++ b/cr-web/src/handlers/mod.rs
@@ -4,7 +4,7 @@ use askama::Template;
 use axum::extract::{Path, State};
 use axum::http::{StatusCode, Uri, header};
 use axum::response::{Html, IntoResponse, Response};
-use cr_domain::repository::{PhotoRepository, RegionRepository};
+use cr_domain::repository::{OrpRepository, PhotoRepository, RegionRepository};
 
 use crate::error::WebResult;
 use crate::state::AppState;
@@ -46,15 +46,15 @@ pub use video_api::{
 
 #[derive(sqlx::FromRow)]
 pub(crate) struct RegionRow {
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Carried from RegionRecord for potential future use
     pub(crate) id: i32,
     pub(crate) name: String,
     pub(crate) slug: String,
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Carried from RegionRecord for potential future use
     pub(crate) region_code: String,
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Carried from RegionRecord for potential future use
     pub(crate) latitude: Option<f64>,
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Carried from RegionRecord for potential future use
     pub(crate) longitude: Option<f64>,
     pub(crate) coat_of_arms_ext: Option<String>,
     pub(crate) flag_ext: Option<String>,
@@ -64,7 +64,7 @@ pub(crate) struct RegionRow {
 
 #[derive(sqlx::FromRow)]
 pub(crate) struct OrpRow {
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Carried from OrpRecord for potential future use
     pub(crate) id: i32,
     pub(crate) name: String,
     pub(crate) slug: String,
@@ -76,12 +76,12 @@ pub(crate) struct OrpRow {
 
 #[derive(sqlx::FromRow)]
 pub(crate) struct MunicipalityRow {
-    #[allow(dead_code)]
+    // Used by orp.rs handler for landmark query binding
     pub(crate) id: i32,
     pub(crate) name: String,
     pub(crate) slug: String,
     pub(crate) municipality_code: String,
-    #[allow(dead_code)]
+    #[allow(dead_code)] // TODO: verify usage — carried from RegionRecord, not used in templates
     pub(crate) pou_code: String,
     pub(crate) latitude: Option<f64>,
     pub(crate) longitude: Option<f64>,
@@ -90,7 +90,7 @@ pub(crate) struct MunicipalityRow {
     pub(crate) coat_of_arms_ext: Option<String>,
     pub(crate) flag_ext: Option<String>,
     pub(crate) population: Option<i32>,
-    #[allow(dead_code)]
+    #[allow(dead_code)] // TODO: verify usage — carried from MunicipalityRecord, not in templates
     pub(crate) elevation: Option<f64>,
 }
 
@@ -101,25 +101,25 @@ pub(crate) struct LandmarkRow {
     pub(crate) slug: String,
     pub(crate) latitude: Option<f64>,
     pub(crate) longitude: Option<f64>,
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Carried from LandmarkRecord; not rendered in current templates
     pub(crate) description: Option<String>,
     pub(crate) wikipedia_url: Option<String>,
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Carried from LandmarkRecord; not rendered in current templates
     pub(crate) image_ext: Option<String>,
-    #[allow(dead_code)]
+    // Used by landmarks.rs handler for fetch_photos npu_catalog_id param
     pub(crate) npu_catalog_id: Option<String>,
     #[sqlx(default)]
     pub(crate) npu_description: Option<String>,
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Carried from LandmarkRecord; not rendered in current templates
     pub(crate) type_slug: String,
     pub(crate) type_name: String,
     pub(crate) municipality_name: Option<String>,
-    #[allow(dead_code)]
+    // Used by Askama templates (landmark_detail.html, landmarks_list.html)
     pub(crate) municipality_slug: Option<String>,
     pub(crate) orp_slug: Option<String>,
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Carried from LandmarkRecord; not rendered in current templates
     pub(crate) region_slug: Option<String>,
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Carried from LandmarkRecord; not rendered in current templates
     #[sqlx(default)]
     pub(crate) municipality_code: Option<String>,
     #[sqlx(default)]
@@ -219,9 +219,9 @@ impl From<cr_domain::repository::PoolRecord> for PoolDetailRow {
 pub(crate) struct PhotoInfo {
     pub(crate) url: String,
     pub(crate) thumb_url: String,
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Stored for future responsive img srcset generation
     pub(crate) width: i16,
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Stored for future responsive img srcset generation
     pub(crate) height: i16,
 }
 
@@ -379,7 +379,7 @@ pub(crate) struct OrpPoolRow {
     pub(crate) name: String,
     pub(crate) slug: String,
     pub(crate) is_aquapark: bool,
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Not shown on ORP page but used on pool_detail.html
     pub(crate) is_indoor: bool,
     pub(crate) is_outdoor: bool,
     pub(crate) is_natural: bool,
@@ -536,7 +536,7 @@ pub(crate) struct LandmarkDetailTemplate {
 
 #[derive(sqlx::FromRow)]
 pub(crate) struct AudiobookRow {
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Primary key; not rendered in audiobooks template
     pub(crate) id: i32,
     pub(crate) title: String,
     pub(crate) author: String,
@@ -582,13 +582,13 @@ pub(crate) struct PoolListRow {
     pub(crate) municipality_name: Option<String>,
     pub(crate) orp_slug: Option<String>,
     pub(crate) region_slug: Option<String>,
-    #[allow(dead_code)]
+    // Used by Askama template (pools_list.html) for conditional photo rendering
     pub(crate) photo_count: i16,
 }
 
 #[derive(sqlx::FromRow)]
 pub(crate) struct PoolDetailRow {
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Primary key; carried from PoolRecord, not rendered in template
     pub(crate) id: i32,
     pub(crate) name: String,
     pub(crate) slug: String,
@@ -606,7 +606,7 @@ pub(crate) struct PoolDetailRow {
     pub(crate) is_indoor: bool,
     pub(crate) is_outdoor: bool,
     pub(crate) is_natural: bool,
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Carried from PoolRecord; not rendered in pool_detail template
     pub(crate) photo_count: i16,
     pub(crate) municipality_name: Option<String>,
 }
@@ -626,7 +626,7 @@ pub(crate) struct PoolsHubTemplate {
 pub(crate) struct PoolsListTemplate {
     pub(crate) img: String,
     pub(crate) category_name: String,
-    #[allow(dead_code)]
+    #[allow(dead_code)] // TODO: verify usage — may be needed for breadcrumb/URL generation
     pub(crate) category_slug: String,
     pub(crate) pools: Vec<PoolListRow>,
     pub(crate) page: i64,
@@ -656,21 +656,36 @@ pub(crate) fn not_found(image_base_url: &str) -> (StatusCode, Html<String>) {
     )
 }
 
-/// Helper: find region slug for an ORP slug
-pub(crate) async fn region_slug_for_orp(db: &sqlx::PgPool, orp_slug: &str) -> Option<String> {
-    sqlx::query_scalar::<_, String>(
-        "SELECT r.slug FROM regions r \
-         JOIN districts d ON d.region_id = r.id \
-         JOIN orp o ON o.district_id = d.id \
-         WHERE o.slug = $1",
-    )
-    .bind(orp_slug)
-    .fetch_optional(db)
-    .await
-    .unwrap_or_else(|e| {
-        tracing::error!("region_slug_for_orp query failed: {e}");
-        None
-    })
+/// Build a pagination query string from a list of `(key, value)` pairs.
+///
+/// Shared by films and series handlers to avoid duplicating the qs_parts
+/// collection logic. Each pair is URL-encoded and joined with `&`.
+/// Returns an empty string when `parts` is empty, otherwise `&key=val&...`.
+pub(crate) fn build_pagination_qs(parts: &[(&str, String)]) -> String {
+    let encoded: Vec<String> = parts
+        .iter()
+        .filter(|(_, v)| !v.is_empty())
+        .map(|(k, v)| format!("{}={}", k, urlencoding::encode(v)))
+        .collect();
+    if encoded.is_empty() {
+        String::new()
+    } else {
+        format!("&{}", encoded.join("&"))
+    }
+}
+
+/// Helper: find region slug for an ORP slug.
+/// Delegates to [`OrpRepository::region_slug_for_orp`].
+pub(crate) async fn region_slug_for_orp(state: &AppState, orp_slug: &str) -> Option<String> {
+    use cr_domain::repository::OrpRepository;
+    state
+        .orp_repo
+        .region_slug_for_orp(orp_slug)
+        .await
+        .unwrap_or_else(|e| {
+            tracing::error!("region_slug_for_orp query failed: {e}");
+            None
+        })
 }
 
 /// Map URL path segments to database type slugs
@@ -823,11 +838,11 @@ pub async fn resolve_path(State(state): State<AppState>, uri: Uri) -> WebResult<
                 .await;
             }
             // Single query: is this an ORP or region slug?
-            let is_orp =
-                sqlx::query_scalar::<_, bool>("SELECT EXISTS(SELECT 1 FROM orp WHERE slug = $1)")
-                    .bind(segments[0])
-                    .fetch_one(&state.db)
-                    .await?;
+            let is_orp = state
+                .orp_repo
+                .exists_by_slug(segments[0])
+                .await
+                .map_err(|e| anyhow::anyhow!("{e:?}"))?;
 
             if is_orp {
                 return Ok(orp::render_orp_by_slug(&state, segments[0])

--- a/cr-web/src/handlers/municipalities.rs
+++ b/cr-web/src/handlers/municipalities.rs
@@ -8,7 +8,7 @@ pub(crate) async fn render_municipality_short(
     orp_slug: &str,
     muni_slug: &str,
 ) -> (StatusCode, Html<String>) {
-    let Some(region_slug) = region_slug_for_orp(&state.db, orp_slug).await else {
+    let Some(region_slug) = region_slug_for_orp(state, orp_slug).await else {
         return not_found(&state.image_base_url);
     };
     render_municipality(state, &region_slug, orp_slug, muni_slug).await

--- a/cr-web/src/handlers/orp.rs
+++ b/cr-web/src/handlers/orp.rs
@@ -7,7 +7,7 @@ pub(crate) async fn render_orp_by_slug(
     state: &AppState,
     orp_slug: &str,
 ) -> (StatusCode, Html<String>) {
-    let Some(region_slug) = region_slug_for_orp(&state.db, orp_slug).await else {
+    let Some(region_slug) = region_slug_for_orp(state, orp_slug).await else {
         return not_found(&state.image_base_url);
     };
     render_orp(state, &region_slug, orp_slug).await

--- a/cr-web/src/handlers/pools.rs
+++ b/cr-web/src/handlers/pools.rs
@@ -191,7 +191,7 @@ pub(crate) async fn render_pool_short(
     orp_slug: &str,
     pool_slug: &str,
 ) -> (StatusCode, Html<String>) {
-    let Some(region_slug) = region_slug_for_orp(&state.db, orp_slug).await else {
+    let Some(region_slug) = region_slug_for_orp(state, orp_slug).await else {
         return not_found(&state.image_base_url);
     };
     render_pool(state, &region_slug, orp_slug, pool_slug).await

--- a/cr-web/src/handlers/series.rs
+++ b/cr-web/src/handlers/series.rs
@@ -19,18 +19,18 @@ pub struct SeriesRow {
     title: String,
     slug: String,
     first_air_year: Option<i16>,
-    #[allow(dead_code)]
+    // Used by Askama template (series_detail.html) for year range display
     last_air_year: Option<i16>,
     description: Option<String>,
     original_title: Option<String>,
     imdb_rating: Option<f32>,
     csfd_rating: Option<i16>,
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Not rendered in current templates; kept for future series stats
     season_count: Option<i16>,
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Not rendered in current templates; kept for future series stats
     episode_count: Option<i16>,
     cover_filename: Option<String>,
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Needed in SELECT for ORDER BY; not rendered in templates
     added_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
@@ -39,7 +39,7 @@ pub struct SeriesRow {
 /// + "Epizoda S×E" badge + CC (subtitles) badge.
 #[derive(FromRow, Serialize)]
 pub struct EpisodeCardRow {
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Primary key; not rendered in series_list template
     pub id: i32,
     pub series_slug: String,
     pub series_title: String,
@@ -53,7 +53,7 @@ pub struct EpisodeCardRow {
     pub episode: i16,
     pub has_subtitles: Option<bool>,
     pub has_dub: Option<bool>,
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Used in ORDER BY; not rendered in series_list template
     pub created_at: chrono::DateTime<chrono::Utc>,
 }
 
@@ -127,7 +127,7 @@ struct SeriesListTemplate {
     total_pages: i64,
     total_count: i64,
     current_genre: Option<GenreRow>,
-    #[allow(dead_code)]
+    #[allow(dead_code)] // TODO: verify usage — may be needed for sort UI active state
     sort_key: String,
     query_string: String,
     search_query: Option<String>,
@@ -164,7 +164,7 @@ pub struct EpisodeNav {
 
 #[derive(FromRow, Clone)]
 pub struct PersonRow {
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Primary key; not rendered in templates
     pub id: i32,
     pub name: String,
     pub profile_filename: Option<String>,
@@ -239,21 +239,7 @@ pub async fn series_list(
     .fetch_all(&state.db)
     .await?;
 
-    let mut qs_parts = Vec::new();
-    if params.razeni.is_some() {
-        qs_parts.push(format!("razeni={}", params.sort_key()));
-    }
-    if let Some(ref q) = params.q {
-        let t = q.trim();
-        if !t.is_empty() {
-            qs_parts.push(format!("q={}", urlencoding::encode(t)));
-        }
-    }
-    let query_string = if qs_parts.is_empty() {
-        String::new()
-    } else {
-        format!("&{}", qs_parts.join("&"))
-    };
+    let query_string = build_series_query_string(&params);
 
     let search_query = params.q.clone().and_then(|q| {
         let t = q.trim();
@@ -867,6 +853,21 @@ pub async fn series_cover_large(
         PLACEHOLDER.to_vec(),
     )
         .into_response())
+}
+
+/// Build pagination query string for series list views.
+fn build_series_query_string(params: &SeriesQuery) -> String {
+    let mut parts: Vec<(&str, String)> = Vec::new();
+    if params.razeni.is_some() {
+        parts.push(("razeni", params.sort_key().to_string()));
+    }
+    if let Some(ref q) = params.q {
+        let t = q.trim();
+        if !t.is_empty() {
+            parts.push(("q", t.to_string()));
+        }
+    }
+    super::build_pagination_qs(&parts)
 }
 
 #[derive(sqlx::FromRow)]


### PR DESCRIPTION
<!-- claude-session: c0717c9a-16b7-4690-af5a-437a07586132 -->

Closes #444, closes #446. Final sub-issues of #436.

## Summary
- **#444**: `region_slug_for_orp` moved to `OrpRepository`; `resolve_path` delegates to existing trait; `FILM_COLUMNS` / `REGION_COLUMNS` / `MUNICIPALITY_COLUMNS` / `ORP_COLUMNS` consts eliminate duplicated SELECT lists
- **#446**: dead_code audit (7 false positives fixed, rest annotated); `build_pagination_qs()` shared helper replaces identical qs_parts blocks in films + series

## Test plan
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo test --workspace` — 16 tests pass