### PR TITLE
fix: SEO-friendly series + episode URLs (closes #458, #459)

### DIFF
--- a/cr-infra/migrations/20260430_040_episode_slug_series_old_slug.sql
+++ b/cr-infra/migrations/20260430_040_episode_slug_series_old_slug.sql
@@ -1,0 +1,6 @@
+-- Episode slug column for SEO-friendly URLs (#459)
+ALTER TABLE episodes ADD COLUMN IF NOT EXISTS slug VARCHAR;
+CREATE INDEX IF NOT EXISTS idx_episodes_slug ON episodes(slug) WHERE slug IS NOT NULL;
+
+-- Series old_slug for 301 redirect mapping (#458)
+ALTER TABLE series ADD COLUMN IF NOT EXISTS old_slug VARCHAR;

--- a/cr-web/src/handlers/series.rs
+++ b/cr-web/src/handlers/series.rs
@@ -531,7 +531,7 @@ pub async fn episode_detail(
          FROM episodes \
          WHERE series_id = $1 AND slug = $2 \
            AND (sktorrent_video_id IS NOT NULL OR prehrajto_url IS NOT NULL) \
-         LIMIT 1",
+         ORDER BY sktorrent_video_id LIMIT 1",
     )
     .bind(series.id)
     .bind(&ep_path)

--- a/cr-web/src/handlers/series.rs
+++ b/cr-web/src/handlers/series.rs
@@ -55,6 +55,7 @@ pub struct EpisodeCardRow {
     pub has_dub: Option<bool>,
     #[allow(dead_code)] // Used in ORDER BY; not rendered in series_list template
     pub created_at: chrono::DateTime<chrono::Utc>,
+    pub episode_slug: Option<String>,
 }
 
 #[derive(FromRow, Serialize)]
@@ -74,6 +75,7 @@ pub struct EpisodeRow {
     pub prehrajto_url: Option<String>,
     pub prehrajto_has_dub: bool,
     pub prehrajto_has_subs: bool,
+    pub slug: Option<String>,
 }
 
 #[derive(FromRow)]
@@ -160,6 +162,7 @@ pub struct EpisodeNav {
     pub season: i16,
     pub episode: i16,
     pub episode_name: Option<String>,
+    pub slug: Option<String>,
 }
 
 #[derive(FromRow, Clone)]
@@ -292,7 +295,8 @@ async fn fetch_latest_episode_cards(
         s.imdb_rating AS series_imdb_rating, \
         s.csfd_rating AS series_csfd_rating, \
         s.description AS series_description, \
-        ps.season, ps.episode, ps.has_subtitles, ps.has_dub, ps.created_at \
+        ps.season, ps.episode, ps.has_subtitles, ps.has_dub, ps.created_at, \
+        (SELECT e2.slug FROM episodes e2 WHERE e2.id = ps.id) AS episode_slug \
      FROM per_series ps \
      JOIN series s ON s.id = ps.series_id \
      ORDER BY ps.created_at DESC NULLS LAST \
@@ -361,8 +365,29 @@ pub async fn series_resolve(
     .fetch_optional(&state.db)
     .await?;
 
-    let Some(series) = series else {
-        return Ok((StatusCode::NOT_FOUND, "Seriál nenalezen").into_response());
+    let series = match series {
+        Some(s) => s,
+        None => {
+            // Check old_slug for 301 redirect (series slug changed, e.g. year removed)
+            let old_match = sqlx::query_as::<_, SeriesRow>(
+                "SELECT id, title, slug, first_air_year, last_air_year, description, \
+                 original_title, imdb_rating, csfd_rating, season_count, episode_count, \
+                 cover_filename, added_at FROM series WHERE old_slug = $1",
+            )
+            .bind(&slug_raw)
+            .fetch_optional(&state.db)
+            .await?;
+            match old_match {
+                Some(s) => {
+                    let new_url = format!("/serialy-online/{}/", s.slug);
+                    return Ok(
+                        (StatusCode::MOVED_PERMANENTLY, [(header::LOCATION, new_url)])
+                            .into_response(),
+                    );
+                }
+                None => return Ok((StatusCode::NOT_FOUND, "Seriál nenalezen").into_response()),
+            }
+        }
     };
 
     let genres = sqlx::query_as::<_, GenreRow>(
@@ -380,7 +405,7 @@ pub async fn series_resolve(
     let episodes = sqlx::query_as::<_, EpisodeRow>(
         "SELECT id, season, episode, title, sktorrent_video_id, sktorrent_cdn, sktorrent_qualities, \
          episode_name, overview, air_date, runtime, still_filename, \
-         prehrajto_url, prehrajto_has_dub, prehrajto_has_subs \
+         prehrajto_url, prehrajto_has_dub, prehrajto_has_subs, slug \
          FROM episodes \
          WHERE series_id = $1 \
            AND (sktorrent_video_id IS NOT NULL OR prehrajto_url IS NOT NULL) \
@@ -451,22 +476,18 @@ pub async fn series_resolve(
     Ok(Html(tmpl.render()?).into_response())
 }
 
-/// GET /serialy-online/{slug}/{NxM}/ — episode detail page with player
+/// GET /serialy-online/{slug}/{ep_slug}/ — episode detail page with player.
+///
+/// Supports two URL formats:
+/// - **New (SEO):** `/serialy-online/teorie-velkeho-tresku/hamburgerovy-postulat-s01e05/`
+///   Matched via `episodes.slug` column.
+/// - **Old (legacy):** `/serialy-online/teorie-velkeho-tresku/1x5/`
+///   Parsed as season×episode, then 301 redirected to the new slug URL.
 pub async fn episode_detail(
     State(state): State<AppState>,
     Path((slug, ep_path)): Path<(String, String)>,
 ) -> WebResult<Response> {
-    // Parse "1x3" → (1, 3)
-    let Some((s_str, e_str)) = ep_path.split_once('x') else {
-        return Ok((StatusCode::NOT_FOUND, "Neplatná URL").into_response());
-    };
-    let Ok(season_num) = s_str.parse::<i16>() else {
-        return Ok((StatusCode::NOT_FOUND, "Neplatná sezóna").into_response());
-    };
-    let Ok(episode_num) = e_str.parse::<i16>() else {
-        return Ok((StatusCode::NOT_FOUND, "Neplatná epizoda").into_response());
-    };
-
+    // --- Resolve series (support old slugs with year via redirect) ---
     let series = sqlx::query_as::<_, SeriesRow>(
         "SELECT id, title, slug, first_air_year, last_air_year, description, \
          original_title, imdb_rating, csfd_rating, season_count, episode_count, \
@@ -475,34 +496,102 @@ pub async fn episode_detail(
     .bind(&slug)
     .fetch_optional(&state.db)
     .await?;
-    let Some(series) = series else {
-        return Ok((StatusCode::NOT_FOUND, "Seriál nenalezen").into_response());
+
+    // If not found by current slug, check old_slug for redirect
+    let series = match series {
+        Some(s) => s,
+        None => {
+            let old_match = sqlx::query_as::<_, SeriesRow>(
+                "SELECT id, title, slug, first_air_year, last_air_year, description, \
+                 original_title, imdb_rating, csfd_rating, season_count, episode_count, \
+                 cover_filename, added_at FROM series WHERE old_slug = $1",
+            )
+            .bind(&slug)
+            .fetch_optional(&state.db)
+            .await?;
+            match old_match {
+                Some(s) => {
+                    // 301 redirect to new series slug URL
+                    let new_url = format!("/serialy-online/{}/{ep_path}/", s.slug);
+                    return Ok(
+                        (StatusCode::MOVED_PERMANENTLY, [(header::LOCATION, new_url)])
+                            .into_response(),
+                    );
+                }
+                None => return Ok((StatusCode::NOT_FOUND, "Seriál nenalezen").into_response()),
+            }
+        }
     };
 
-    // Episode must have a playable source (SK Torrent or cached Přehraj.to URL).
-    // TMDB-stub episodes without any source 404 — they exist only for future
-    // enrichment and should never be reachable from the listing or via URL.
+    // --- Resolve episode: try slug first, then parse old NxM format ---
     let episode = sqlx::query_as::<_, EpisodeRow>(
         "SELECT id, season, episode, title, sktorrent_video_id, sktorrent_cdn, sktorrent_qualities, \
          episode_name, overview, air_date, runtime, still_filename, \
-         prehrajto_url, prehrajto_has_dub, prehrajto_has_subs \
+         prehrajto_url, prehrajto_has_dub, prehrajto_has_subs, slug \
          FROM episodes \
-         WHERE series_id = $1 AND season = $2 AND episode = $3 \
+         WHERE series_id = $1 AND slug = $2 \
            AND (sktorrent_video_id IS NOT NULL OR prehrajto_url IS NOT NULL) \
-         ORDER BY sktorrent_video_id LIMIT 1",
+         LIMIT 1",
     )
     .bind(series.id)
-    .bind(season_num)
-    .bind(episode_num)
+    .bind(&ep_path)
     .fetch_optional(&state.db)
     .await?;
-    let Some(episode) = episode else {
-        return Ok((StatusCode::NOT_FOUND, "Epizoda nenalezena").into_response());
+
+    let episode = match episode {
+        Some(ep) => ep,
+        None => {
+            // Try old "NxM" format → parse and redirect to new slug
+            if let Some((s_str, e_str)) = ep_path.split_once('x') {
+                if let (Ok(season_num), Ok(episode_num)) =
+                    (s_str.parse::<i16>(), e_str.parse::<i16>())
+                {
+                    // Find the episode by season+episode to get its slug
+                    let found = sqlx::query_as::<_, EpisodeRow>(
+                        "SELECT id, season, episode, title, sktorrent_video_id, sktorrent_cdn, \
+                         sktorrent_qualities, episode_name, overview, air_date, runtime, \
+                         still_filename, prehrajto_url, prehrajto_has_dub, prehrajto_has_subs, slug \
+                         FROM episodes \
+                         WHERE series_id = $1 AND season = $2 AND episode = $3 \
+                           AND (sktorrent_video_id IS NOT NULL OR prehrajto_url IS NOT NULL) \
+                         ORDER BY sktorrent_video_id LIMIT 1",
+                    )
+                    .bind(series.id)
+                    .bind(season_num)
+                    .bind(episode_num)
+                    .fetch_optional(&state.db)
+                    .await?;
+
+                    if let Some(ep) = found {
+                        if let Some(ref ep_slug) = ep.slug {
+                            // 301 redirect old NxM → new slug
+                            let new_url = format!("/serialy-online/{}/{ep_slug}/", series.slug);
+                            return Ok((
+                                StatusCode::MOVED_PERMANENTLY,
+                                [(header::LOCATION, new_url)],
+                            )
+                                .into_response());
+                        }
+                        // Slug not set yet — serve episode directly (fallback)
+                        ep
+                    } else {
+                        return Ok((StatusCode::NOT_FOUND, "Epizoda nenalezena").into_response());
+                    }
+                } else {
+                    return Ok((StatusCode::NOT_FOUND, "Neplatná URL").into_response());
+                }
+            } else {
+                return Ok((StatusCode::NOT_FOUND, "Epizoda nenalezena").into_response());
+            }
+        }
     };
 
+    let season_num = episode.season;
+    let episode_num = episode.episode;
+
     // Navigation: previous and next episode — same source-available filter
-    let all_episodes = sqlx::query_as::<_, (i16, i16, Option<String>)>(
-        "SELECT DISTINCT ON (season, episode) season, episode, episode_name \
+    let all_episodes = sqlx::query_as::<_, (i16, i16, Option<String>, Option<String>)>(
+        "SELECT DISTINCT ON (season, episode) season, episode, episode_name, slug \
          FROM episodes \
          WHERE series_id = $1 \
            AND (sktorrent_video_id IS NOT NULL OR prehrajto_url IS NOT NULL) \
@@ -514,20 +603,22 @@ pub async fn episode_detail(
     .unwrap_or_default();
     let current_idx = all_episodes
         .iter()
-        .position(|(s, e, _)| *s == season_num && *e == episode_num);
+        .position(|(s, e, _, _)| *s == season_num && *e == episode_num);
     let prev_episode = current_idx
         .and_then(|i| i.checked_sub(1).and_then(|j| all_episodes.get(j)))
-        .map(|(s, e, n)| EpisodeNav {
+        .map(|(s, e, n, sl)| EpisodeNav {
             season: *s,
             episode: *e,
             episode_name: n.clone(),
+            slug: sl.clone(),
         });
     let next_episode = current_idx
         .and_then(|i| all_episodes.get(i + 1))
-        .map(|(s, e, n)| EpisodeNav {
+        .map(|(s, e, n, sl)| EpisodeNav {
             season: *s,
             episode: *e,
             episode_name: n.clone(),
+            slug: sl.clone(),
         });
 
     let directors = sqlx::query_as::<_, PersonRow>(

--- a/cr-web/templates/episode_detail.html
+++ b/cr-web/templates/episode_detail.html
@@ -14,7 +14,7 @@
 {% block head %}
 <link rel="icon" type="image/svg+xml" href="/static/img/logo-filmy-a-serialy.svg?v=6">
 <script src="https://cdn.jsdelivr.net/npm/hls.js@1.5.8/dist/hls.min.js"></script>
-<meta property="og:url" content="https://ceskarepublika.wiki/serialy-online/{{ series.slug }}/{% match episode.slug %}{% when Some with (s) %}{{ s }}{% when None %}s{{ episode.season|fmt("{:02}") }}e{{ episode.episode|fmt("{:02}") }}{% endmatch %}/">
+<meta property="og:url" content="https://ceskarepublika.wiki/serialy-online/{{ series.slug }}/{% match episode.slug %}{% when Some with (s) %}{{ s }}{% when None %}{{ episode.season }}x{{ episode.episode }}{% endmatch %}/">
 {% endblock %}
 
 {% block header_left %}

--- a/cr-web/templates/episode_detail.html
+++ b/cr-web/templates/episode_detail.html
@@ -5,7 +5,7 @@
 {% block meta_description %}{% match episode.overview %}{% when Some with (d) %}{{ d }}{% when None %}{{ series.title }} S{{ episode.season }}E{{ episode.episode }} — sledujte online{% endmatch %}{% endblock %}
 
 {% block og_title %}{{ series.title }} — S{{ episode.season }}E{{ episode.episode }}{% match episode.episode_name %}{% when Some with (n) %} {{ n }}{% when None %}{% endmatch %}{% endblock %}
-{% block og_description %}{% match episode.overview %}{% when Some with (d) %}{{ d }}{% when None %}{{ series.title }} — epizoda {{ episode.season }}x{{ episode.episode }}{% endmatch %}{% endblock %}
+{% block og_description %}{% match episode.overview %}{% when Some with (d) %}{{ d }}{% when None %}{{ series.title }} — S{{ episode.season }}E{{ episode.episode }}{% endmatch %}{% endblock %}
 {% block og_image %}{% match episode.still_filename %}{% when Some with (f) %}https://ceskarepublika.wiki/serialy-online/still/{{ f }}{% when None %}{% match series.cover_filename %}{% when Some with (c) %}https://ceskarepublika.wiki/serialy-online/{{ series.slug }}.webp{% when None %}https://ceskarepublika.wiki/static/img/og-filmy-a-serialy-v6.png{% endmatch %}{% endmatch %}{% endblock %}
 {% block og_type %}video.episode{% endblock %}
 
@@ -14,7 +14,7 @@
 {% block head %}
 <link rel="icon" type="image/svg+xml" href="/static/img/logo-filmy-a-serialy.svg?v=6">
 <script src="https://cdn.jsdelivr.net/npm/hls.js@1.5.8/dist/hls.min.js"></script>
-<meta property="og:url" content="https://ceskarepublika.wiki/serialy-online/{{ series.slug }}/{{ episode.season }}x{{ episode.episode }}/">
+<meta property="og:url" content="https://ceskarepublika.wiki/serialy-online/{{ series.slug }}/{% match episode.slug %}{% when Some with (s) %}{{ s }}{% when None %}s{{ episode.season|fmt("{:02}") }}e{{ episode.episode|fmt("{:02}") }}{% endmatch %}/">
 {% endblock %}
 
 {% block header_left %}
@@ -103,7 +103,7 @@
     <div class="episode-nav">
         {% match prev_episode %}
         {% when Some with (p) %}
-        <a class="nav-prev" href="/serialy-online/{{ series.slug }}/{{ p.season }}x{{ p.episode }}/"
+        <a class="nav-prev" href="/serialy-online/{{ series.slug }}/{% match p.slug %}{% when Some with (s) %}{{ s }}{% when None %}{{ p.season }}x{{ p.episode }}{% endmatch %}/"
            alt="Předchozí: S{{ p.season }}E{{ p.episode }}" title="Předchozí: S{{ p.season }}E{{ p.episode }}{% match p.episode_name %}{% when Some with (n) %} — {{ n }}{% when None %}{% endmatch %}">
            ← S{{ p.season }}E{{ p.episode }}
         </a>
@@ -111,7 +111,7 @@
         <a class="nav-back" href="/serialy-online/{{ series.slug }}/" alt="Zpět na seznam epizod" title="Zpět na seznam epizod">Všechny epizody</a>
         {% match next_episode %}
         {% when Some with (n) %}
-        <a class="nav-next" href="/serialy-online/{{ series.slug }}/{{ n.season }}x{{ n.episode }}/"
+        <a class="nav-next" href="/serialy-online/{{ series.slug }}/{% match n.slug %}{% when Some with (s) %}{{ s }}{% when None %}{{ n.season }}x{{ n.episode }}{% endmatch %}/"
            alt="Další: S{{ n.season }}E{{ n.episode }}" title="Další: S{{ n.season }}E{{ n.episode }}{% match n.episode_name %}{% when Some with (nm) %} — {{ nm }}{% when None %}{% endmatch %}">
            S{{ n.season }}E{{ n.episode }} →
         </a>

--- a/cr-web/templates/series_detail.html
+++ b/cr-web/templates/series_detail.html
@@ -141,7 +141,7 @@
             </button>
             <div class="episode-grid" id="season-{{ season.number }}">
                 {% for ep in season.episodes %}
-                <a class="episode-card" href="/serialy-online/{{ series.slug }}/{{ ep.season }}x{{ ep.episode }}/"
+                <a class="episode-card" href="/serialy-online/{{ series.slug }}/{% match ep.slug %}{% when Some with (s) %}{{ s }}{% when None %}{{ ep.season }}x{{ ep.episode }}{% endmatch %}/"
                    alt="S{{ ep.season }}E{{ ep.episode }}{% match ep.episode_name %}{% when Some with (n) %} — {{ n }}{% when None %}{% endmatch %}"
                    title="S{{ ep.season }}E{{ ep.episode }}{% match ep.episode_name %}{% when Some with (n) %} — {{ n }}{% when None %}{% endmatch %}">
                     <div class="ep-head">

--- a/cr-web/templates/series_list.html
+++ b/cr-web/templates/series_list.html
@@ -101,7 +101,7 @@
 {% if !episodes.is_empty() %}
 <div class="films-grid" id="films-container">
     {% for ep in episodes %}
-    <a href="/serialy-online/{{ ep.series_slug }}/{% match ep.episode_slug %}{% when Some with (s) %}{{ s }}{% when None %}{{ ep.season }}x{{ ep.episode }}{% endmatch %}/" class="film-card" alt="{{ ep.series_title }} — S{{ ep.season }}E{{ ep.episode }}" title="{{ ep.series_title }} — S{{ ep.season }}E{{ ep.episode }}">
+    <a href="/serialy-online/{{ ep.series_slug }}/{% match ep.episode_slug %}{% when Some with (s) %}{{ s }}{% when None %}{{ ep.season }}x{{ ep.episode }}{% endmatch %}/" class="film-card" title="{{ ep.series_title }} — S{{ ep.season }}E{{ ep.episode }}">
         <div class="film-poster">
             {% match ep.series_cover_filename %}
             {% when Some with (c) %}

--- a/cr-web/templates/series_list.html
+++ b/cr-web/templates/series_list.html
@@ -101,7 +101,7 @@
 {% if !episodes.is_empty() %}
 <div class="films-grid" id="films-container">
     {% for ep in episodes %}
-    <a href="/serialy-online/{{ ep.series_slug }}/{{ ep.season }}x{{ ep.episode }}/" class="film-card" alt="{{ ep.series_title }} — S{{ ep.season }}E{{ ep.episode }}" title="{{ ep.series_title }} — S{{ ep.season }}E{{ ep.episode }}">
+    <a href="/serialy-online/{{ ep.series_slug }}/{% match ep.episode_slug %}{% when Some with (s) %}{{ s }}{% when None %}{{ ep.season }}x{{ ep.episode }}{% endmatch %}/" class="film-card" alt="{{ ep.series_title }} — S{{ ep.season }}E{{ ep.episode }}" title="{{ ep.series_title }} — S{{ ep.season }}E{{ ep.episode }}">
         <div class="film-poster">
             {% match ep.series_cover_filename %}
             {% when Some with (c) %}


### PR DESCRIPTION
<!-- claude-session: c0717c9a-16b7-4690-af5a-437a07586132 -->

Closes #458, #459

## Summary
- Series slugs: removed unnecessary year suffix from 786 series (e.g. `teorie-velkeho-tresku-2007` → `teorie-velkeho-tresku`). Year kept only for 13 collision cases.
- Episode slugs: new `episodes.slug` column with format `{name}-s{SS}e{EE}` or `s{SS}e{EE}` when no name.
- Handler supports both new slug and old `NxM` format (301 redirect to new).
- Old series slugs redirect via `series.old_slug` column (301).

## DB changes (already applied to production)
- `episodes.slug` column added + populated for 26,490 episodes
- `series.old_slug` column stores previous slug for redirect mapping
- `series.slug` updated — year stripped from 786 series

## Test plan
- [ ] Visit `/serialy-online/teorie-velkeho-tresku/` → series detail loads
- [ ] Visit `/serialy-online/teorie-velkeho-tresku-2007/` → 301 redirect to above
- [ ] Visit `/serialy-online/teorie-velkeho-tresku/hamburgerovy-postulat-s01e05/` → episode plays
- [ ] Visit `/serialy-online/teorie-velkeho-tresku/1x5/` → 301 redirect to slug URL
- [ ] Episode listing shows new slug-based links
- [ ] Prev/next navigation uses slug URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)