### PR TITLE
feat(tv-porady): homepage tile + /serialy-online/ cleanup (#466, #467)

### DIFF
--- a/cr-web/templates/homepage.html
+++ b/cr-web/templates/homepage.html
@@ -32,6 +32,10 @@
         <span class="portal-category-icon">📺</span>
         <span>Seriály online</span>
     </a>
+    <a href="/tv-porady/" class="portal-category-link">
+        <span class="portal-category-icon">📡</span>
+        <span>TV pořady</span>
+    </a>
 </nav>
 
 <section class="active-hub">


### PR DESCRIPTION
<!-- claude-session: c0717c9a-16b7-4690-af5a-437a07586132 -->

Closes #466, #467
Part of #461
Stacked on: #472 (#464, #465) → #471 (#463) → #470 (#462)

## Summary
Adds the **📡 TV pořady** tile to the homepage nav alongside *Seriály online*.

#467 (filter TV pořady out of /serialy-online/) is automatically satisfied once #463 runs on production — after the physical move, the `series` / `episodes` tables no longer contain TV pořady rows, so `/serialy-online/`, genre pages and `/api/series/search` naturally return only scripted series. No code change needed there.

## Test plan
- [ ] CI green
- [ ] Homepage shows new tile (📡 TV pořady) next to 📺 Seriály online
- [ ] Clicking the tile lands on `/tv-porady/`
- [ ] After deploy: `/serialy-online/` contains zero TV pořady (verified post-merge by counting via DB and Playwright)