### PR TITLE
feat(tv-porady): auto-import to tv_shows + 301 redirects from /serialy-online/ (#468, #469)

### DIFF
--- a/cr-infra/migrations/20260501_041_create_tv_shows_episodes.sql
+++ b/cr-infra/migrations/20260501_041_create_tv_shows_episodes.sql
@@ -1,0 +1,122 @@
+-- TV pořady (reality, talk shows, cooking, soaps, etc.) as a separate
+-- catalog from scripted series. TV pořady must NEVER appear in the
+-- /serialy-online/ listing — they live at /tv-porady/ with their own
+-- URL space, their own homepage tile, their own import pipeline.
+--
+-- Tables mirror the current schema of series/episodes so that existing
+-- handlers and image pipelines (covers, stills) can be adapted 1:1.
+-- When migrations 029..040 are applied, `series` has the superset of
+-- columns included below; `tv_shows` is kept in lockstep so moving
+-- data between them (scripts/move-tv-porady-to-new-tables.py, #463)
+-- is a straight column-for-column copy.
+
+CREATE TABLE tv_shows (
+    id                    SERIAL PRIMARY KEY,
+    title                 VARCHAR(255) NOT NULL,
+    original_title        VARCHAR(255),
+    slug                  VARCHAR(255) NOT NULL,
+    first_air_year        SMALLINT,
+    last_air_year         SMALLINT,
+    description           TEXT,
+    generated_description TEXT,
+    tmdb_overview_en      TEXT,
+    imdb_id               VARCHAR(20),
+    tmdb_id               INTEGER,
+    csfd_id               INTEGER,
+    imdb_rating           REAL,
+    csfd_rating           SMALLINT,
+    season_count          SMALLINT,
+    episode_count         SMALLINT,
+    cover_filename        VARCHAR(255),
+    has_dub               BOOLEAN DEFAULT FALSE,
+    has_subtitles         BOOLEAN DEFAULT FALSE,
+    old_slug              VARCHAR,
+    added_at              TIMESTAMP WITH TIME ZONE,
+    created_at            TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    CONSTRAINT tv_shows_slug_key UNIQUE (slug)
+);
+
+CREATE INDEX idx_tv_shows_imdb_id     ON tv_shows (imdb_id)     WHERE imdb_id IS NOT NULL;
+CREATE INDEX idx_tv_shows_tmdb_id     ON tv_shows (tmdb_id)     WHERE tmdb_id IS NOT NULL;
+CREATE INDEX idx_tv_shows_added_at    ON tv_shows (added_at DESC NULLS LAST);
+CREATE INDEX idx_tv_shows_imdb_rating ON tv_shows (imdb_rating DESC NULLS LAST);
+
+CREATE TABLE tv_episodes (
+    id                    SERIAL PRIMARY KEY,
+    tv_show_id            INTEGER NOT NULL REFERENCES tv_shows(id) ON DELETE CASCADE,
+    season                SMALLINT NOT NULL,
+    episode               SMALLINT NOT NULL,
+    title                 VARCHAR(500),
+    slug                  VARCHAR,
+    episode_name          TEXT,
+    overview              TEXT,
+    overview_en           TEXT,
+    generated_description TEXT,
+    air_date              DATE,
+    runtime               SMALLINT,
+    still_filename        VARCHAR(255),
+    vote_average          REAL,
+    sktorrent_video_id    INTEGER,
+    sktorrent_cdn         SMALLINT,
+    sktorrent_qualities   VARCHAR(50),
+    sktorrent_added_at    TIMESTAMP WITH TIME ZONE,
+    prehrajto_url         VARCHAR(500),
+    prehrajto_has_dub     BOOLEAN NOT NULL DEFAULT FALSE,
+    prehrajto_has_subs    BOOLEAN NOT NULL DEFAULT FALSE,
+    has_dub               BOOLEAN DEFAULT FALSE,
+    has_subtitles         BOOLEAN DEFAULT FALSE,
+    created_at            TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    CONSTRAINT tv_episodes_unique UNIQUE (tv_show_id, season, episode, sktorrent_video_id),
+    CONSTRAINT tv_episodes_slug_unique UNIQUE (tv_show_id, slug)
+);
+
+CREATE INDEX idx_tv_episodes_show          ON tv_episodes (tv_show_id, season, episode);
+CREATE INDEX idx_tv_episodes_sktorrent     ON tv_episodes (sktorrent_video_id) WHERE sktorrent_video_id IS NOT NULL;
+CREATE INDEX idx_tv_episodes_prehrajto_url ON tv_episodes (prehrajto_url)      WHERE prehrajto_url      IS NOT NULL;
+CREATE INDEX idx_tv_episodes_slug          ON tv_episodes (slug)                WHERE slug               IS NOT NULL;
+
+-- Genres junction (same shape as series_genres / film_genres).
+CREATE TABLE tv_show_genres (
+    tv_show_id INTEGER NOT NULL REFERENCES tv_shows(id) ON DELETE CASCADE,
+    genre_id   INTEGER NOT NULL REFERENCES genres(id)   ON DELETE CASCADE,
+    PRIMARY KEY (tv_show_id, genre_id)
+);
+
+-- Cross-slug uniqueness: a tv_shows slug must not collide with films,
+-- series or genres (and vice versa). Films and genres already have
+-- triggers checking each other plus series; extend the series trigger
+-- to also reject tv_shows collisions, and add a symmetric trigger on
+-- tv_shows.
+CREATE OR REPLACE FUNCTION check_series_slug_not_film_or_genre() RETURNS TRIGGER AS $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM films     WHERE slug = NEW.slug) THEN
+        RAISE EXCEPTION 'slug "%" already used by a film', NEW.slug;
+    END IF;
+    IF EXISTS (SELECT 1 FROM genres    WHERE slug = NEW.slug) THEN
+        RAISE EXCEPTION 'slug "%" already used by a genre', NEW.slug;
+    END IF;
+    IF EXISTS (SELECT 1 FROM tv_shows  WHERE slug = NEW.slug) THEN
+        RAISE EXCEPTION 'slug "%" already used by a tv_show', NEW.slug;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION check_tv_show_slug_not_film_series_or_genre() RETURNS TRIGGER AS $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM films  WHERE slug = NEW.slug) THEN
+        RAISE EXCEPTION 'slug "%" already used by a film', NEW.slug;
+    END IF;
+    IF EXISTS (SELECT 1 FROM genres WHERE slug = NEW.slug) THEN
+        RAISE EXCEPTION 'slug "%" already used by a genre', NEW.slug;
+    END IF;
+    IF EXISTS (SELECT 1 FROM series WHERE slug = NEW.slug) THEN
+        RAISE EXCEPTION 'slug "%" already used by a series', NEW.slug;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_tv_show_slug_not_film_series_or_genre
+    BEFORE INSERT OR UPDATE ON tv_shows
+    FOR EACH ROW EXECUTE FUNCTION check_tv_show_slug_not_film_series_or_genre();

--- a/cr-web/src/handlers/mod.rs
+++ b/cr-web/src/handlers/mod.rs
@@ -22,6 +22,7 @@ mod orp;
 mod pools;
 mod regions;
 mod series;
+mod tv_porady;
 pub mod video_api;
 
 // Re-export all public handlers so main.rs doesn't need changes
@@ -36,6 +37,7 @@ pub use series::{
     episode_detail, series_episode_still, series_list, series_person_image, series_resolve,
     series_search,
 };
+pub use tv_porady::{tv_epizoda_detail, tv_porad_detail, tv_porady_list};
 pub use video_api::{
     library_delete, library_file, library_list, library_play, library_stream, video_cleanup,
     video_file, video_file_part, video_info, video_prepare, video_recent, video_status,

--- a/cr-web/src/handlers/series.rs
+++ b/cr-web/src/handlers/series.rs
@@ -379,16 +379,26 @@ pub async fn series_resolve(
             .bind(&slug_raw)
             .fetch_optional(&state.db)
             .await?;
-            match old_match {
-                Some(s) => {
-                    let new_url = format!("/serialy-online/{}/", s.slug);
-                    return Ok(
-                        (StatusCode::MOVED_PERMANENTLY, [(header::LOCATION, new_url)])
-                            .into_response(),
-                    );
-                }
-                None => return Ok((StatusCode::NOT_FOUND, "Seriál nenalezen").into_response()),
+            if let Some(s) = old_match {
+                let new_url = format!("/serialy-online/{}/", s.slug);
+                return Ok(
+                    (StatusCode::MOVED_PERMANENTLY, [(header::LOCATION, new_url)]).into_response(),
+                );
             }
+            // Moved to tv_shows? Redirect to /tv-porady/
+            let tv_slug = sqlx::query_scalar::<_, String>(
+                "SELECT slug FROM tv_shows WHERE slug = $1 OR old_slug = $1 LIMIT 1",
+            )
+            .bind(&slug_raw)
+            .fetch_optional(&state.db)
+            .await?;
+            if let Some(s) = tv_slug {
+                let new_url = format!("/tv-porady/{s}/");
+                return Ok(
+                    (StatusCode::MOVED_PERMANENTLY, [(header::LOCATION, new_url)]).into_response(),
+                );
+            }
+            return Ok((StatusCode::NOT_FOUND, "Seriál nenalezen").into_response());
         }
     };
 
@@ -511,17 +521,27 @@ pub async fn episode_detail(
             .bind(&slug)
             .fetch_optional(&state.db)
             .await?;
-            match old_match {
-                Some(s) => {
-                    // 301 redirect to new series slug URL
-                    let new_url = format!("/serialy-online/{}/{ep_path}/", s.slug);
-                    return Ok(
-                        (StatusCode::MOVED_PERMANENTLY, [(header::LOCATION, new_url)])
-                            .into_response(),
-                    );
-                }
-                None => return Ok((StatusCode::NOT_FOUND, "Seriál nenalezen").into_response()),
+            if let Some(s) = old_match {
+                // 301 redirect to new series slug URL
+                let new_url = format!("/serialy-online/{}/{ep_path}/", s.slug);
+                return Ok(
+                    (StatusCode::MOVED_PERMANENTLY, [(header::LOCATION, new_url)]).into_response(),
+                );
             }
+            // Moved to tv_shows? Redirect episode URL to /tv-porady/
+            let tv_slug = sqlx::query_scalar::<_, String>(
+                "SELECT slug FROM tv_shows WHERE slug = $1 OR old_slug = $1 LIMIT 1",
+            )
+            .bind(&slug)
+            .fetch_optional(&state.db)
+            .await?;
+            if let Some(s) = tv_slug {
+                let new_url = format!("/tv-porady/{s}/{ep_path}/");
+                return Ok(
+                    (StatusCode::MOVED_PERMANENTLY, [(header::LOCATION, new_url)]).into_response(),
+                );
+            }
+            return Ok((StatusCode::NOT_FOUND, "Seriál nenalezen").into_response());
         }
     };
 

--- a/cr-web/src/handlers/tv_porady.rs
+++ b/cr-web/src/handlers/tv_porady.rs
@@ -1,0 +1,729 @@
+//! TV pořady listing and detail pages at `/tv-porady/`.
+//!
+//! Separate catalog from scripted series — reality shows, talk shows,
+//! cooking, telenovelas, etc. The data lives in `tv_shows` + `tv_episodes`
+//! (migration 041). URL shape mirrors `/serialy-online/` but no genre
+//! routes and no cast/crew sections for now — TV pořady typically don't
+//! have rich TMDB credits.
+
+use askama::Template;
+use axum::extract::{Path, State};
+use axum::http::{StatusCode, header};
+use axum::response::{Html, IntoResponse, Response};
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+
+use crate::error::WebResult;
+use crate::state::AppState;
+
+const TV_SHOWS_PER_PAGE: i64 = 24;
+
+#[derive(FromRow, Serialize)]
+pub struct TvShowRow {
+    id: i32,
+    title: String,
+    slug: String,
+    first_air_year: Option<i16>,
+    last_air_year: Option<i16>,
+    description: Option<String>,
+    original_title: Option<String>,
+    imdb_rating: Option<f32>,
+    csfd_rating: Option<i16>,
+    #[allow(dead_code)]
+    season_count: Option<i16>,
+    #[allow(dead_code)]
+    episode_count: Option<i16>,
+    cover_filename: Option<String>,
+    #[allow(dead_code)]
+    added_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// Episode card shown on list page — one latest episode per TV pořad.
+#[derive(FromRow, Serialize)]
+pub struct TvEpisodeCardRow {
+    #[allow(dead_code)]
+    pub id: i32,
+    pub tv_show_slug: String,
+    pub tv_show_title: String,
+    pub tv_show_original_title: Option<String>,
+    pub tv_show_cover_filename: Option<String>,
+    pub tv_show_first_air_year: Option<i16>,
+    pub tv_show_imdb_rating: Option<f32>,
+    pub tv_show_csfd_rating: Option<i16>,
+    pub tv_show_description: Option<String>,
+    pub season: i16,
+    pub episode: i16,
+    pub has_subtitles: Option<bool>,
+    pub has_dub: Option<bool>,
+    #[allow(dead_code)]
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub episode_slug: Option<String>,
+    pub episode_name: Option<String>,
+}
+
+#[derive(FromRow, Serialize)]
+pub struct TvEpisodeRow {
+    pub id: i32,
+    pub season: i16,
+    pub episode: i16,
+    pub title: Option<String>,
+    pub sktorrent_video_id: Option<i32>,
+    pub sktorrent_cdn: Option<i16>,
+    pub sktorrent_qualities: Option<String>,
+    pub episode_name: Option<String>,
+    pub overview: Option<String>,
+    pub air_date: Option<chrono::NaiveDate>,
+    pub runtime: Option<i16>,
+    pub still_filename: Option<String>,
+    pub prehrajto_url: Option<String>,
+    pub prehrajto_has_dub: bool,
+    pub prehrajto_has_subs: bool,
+    pub slug: Option<String>,
+}
+
+#[derive(FromRow)]
+struct CountRow {
+    count: Option<i64>,
+}
+
+#[derive(Deserialize)]
+pub struct TvShowQuery {
+    strana: Option<i64>,
+    razeni: Option<String>,
+    q: Option<String>,
+}
+
+impl TvShowQuery {
+    fn page(&self) -> i64 {
+        self.strana.unwrap_or(1).max(1)
+    }
+
+    fn order_clause(&self) -> &'static str {
+        match self.razeni.as_deref() {
+            Some("rok") => "s.first_air_year DESC NULLS LAST, s.title",
+            Some("imdb") => "s.imdb_rating DESC NULLS LAST, s.title",
+            Some("nazev") => "s.title ASC",
+            _ => "s.added_at DESC NULLS LAST, s.title",
+        }
+    }
+
+    fn sort_key(&self) -> &str {
+        self.razeni.as_deref().unwrap_or("pridano")
+    }
+}
+
+#[derive(Template)]
+#[template(path = "tv_porady_list.html")]
+struct TvPoradyListTemplate {
+    img: String,
+    episodes: Vec<TvEpisodeCardRow>,
+    shows: Vec<TvShowRow>,
+    page: i64,
+    total_pages: i64,
+    total_count: i64,
+    #[allow(dead_code)]
+    sort_key: String,
+    query_string: String,
+    search_query: Option<String>,
+}
+
+#[derive(Template)]
+#[template(path = "tv_porad_detail.html")]
+struct TvPoradDetailTemplate {
+    img: String,
+    show: TvShowRow,
+    seasons: Vec<Season>,
+}
+
+#[derive(Template)]
+#[template(path = "tv_epizoda_detail.html")]
+struct TvEpizodaDetailTemplate {
+    img: String,
+    show: TvShowRow,
+    episode: TvEpisodeRow,
+    prev_episode: Option<EpisodeNav>,
+    next_episode: Option<EpisodeNav>,
+}
+
+pub struct EpisodeNav {
+    pub season: i16,
+    pub episode: i16,
+    pub episode_name: Option<String>,
+    pub slug: Option<String>,
+}
+
+pub struct Season {
+    pub number: i16,
+    pub episodes: Vec<TvEpisodeRow>,
+}
+
+pub async fn tv_porady_list(
+    State(state): State<AppState>,
+    axum::extract::Query(params): axum::extract::Query<TvShowQuery>,
+) -> WebResult<Response> {
+    let page = params.page();
+    let offset = (page - 1) * TV_SHOWS_PER_PAGE;
+    let order = params.order_clause();
+
+    let search_q = params.q.as_ref().and_then(|q| {
+        let t = q.trim();
+        if t.len() >= 2 {
+            Some(format!("%{t}%"))
+        } else {
+            None
+        }
+    });
+
+    let (total_count, shows, episodes) = if let Some(ref pattern) = search_q {
+        let count_row = sqlx::query_as::<_, CountRow>(
+            "SELECT count(*) as count FROM tv_shows \
+             WHERE title ILIKE $1 OR original_title ILIKE $1",
+        )
+        .bind(pattern)
+        .fetch_one(&state.db)
+        .await?;
+
+        let query = format!(
+            "SELECT s.id, s.title, s.slug, s.first_air_year, s.last_air_year, \
+             s.description, s.original_title, s.imdb_rating, s.csfd_rating, \
+             s.season_count, s.episode_count, s.cover_filename, s.added_at \
+             FROM tv_shows s \
+             WHERE s.title ILIKE $1 OR s.original_title ILIKE $1 \
+             ORDER BY {order} LIMIT $2 OFFSET $3"
+        );
+        let rows = sqlx::query_as::<_, TvShowRow>(&query)
+            .bind(pattern)
+            .bind(TV_SHOWS_PER_PAGE)
+            .bind(offset)
+            .fetch_all(&state.db)
+            .await?;
+        (count_row.count.unwrap_or(0), rows, Vec::new())
+    } else {
+        let count_row = sqlx::query_as::<_, CountRow>(
+            "SELECT count(DISTINCT e.tv_show_id) as count FROM tv_episodes e",
+        )
+        .fetch_one(&state.db)
+        .await?;
+
+        let episodes = fetch_latest_episode_cards(&state, TV_SHOWS_PER_PAGE, offset).await?;
+        (count_row.count.unwrap_or(0), Vec::new(), episodes)
+    };
+
+    let total_pages = (total_count as f64 / TV_SHOWS_PER_PAGE as f64).ceil() as i64;
+
+    let query_string = build_query_string(&params);
+
+    let search_query = params.q.clone().and_then(|q| {
+        let t = q.trim();
+        if t.is_empty() {
+            None
+        } else {
+            Some(t.to_string())
+        }
+    });
+
+    let tmpl = TvPoradyListTemplate {
+        img: state.image_base_url.clone(),
+        episodes,
+        shows,
+        page,
+        total_pages,
+        total_count,
+        sort_key: params.sort_key().to_string(),
+        query_string,
+        search_query,
+    };
+    Ok(Html(tmpl.render()?).into_response())
+}
+
+async fn fetch_latest_episode_cards(
+    state: &AppState,
+    limit: i64,
+    offset: i64,
+) -> WebResult<Vec<TvEpisodeCardRow>> {
+    let sql = "WITH per_show AS ( \
+        SELECT DISTINCT ON (e.tv_show_id) \
+            e.id, e.tv_show_id, e.season, e.episode, e.has_subtitles, e.has_dub, e.created_at \
+        FROM tv_episodes e \
+        ORDER BY e.tv_show_id, e.created_at DESC \
+     ) \
+     SELECT ps.id, \
+        s.slug AS tv_show_slug, \
+        s.title AS tv_show_title, \
+        s.original_title AS tv_show_original_title, \
+        s.cover_filename AS tv_show_cover_filename, \
+        s.first_air_year AS tv_show_first_air_year, \
+        s.imdb_rating AS tv_show_imdb_rating, \
+        s.csfd_rating AS tv_show_csfd_rating, \
+        s.description AS tv_show_description, \
+        ps.season, ps.episode, ps.has_subtitles, ps.has_dub, ps.created_at, \
+        (SELECT e2.slug FROM tv_episodes e2 WHERE e2.id = ps.id) AS episode_slug, \
+        (SELECT e2.episode_name FROM tv_episodes e2 WHERE e2.id = ps.id) AS episode_name \
+     FROM per_show ps \
+     JOIN tv_shows s ON s.id = ps.tv_show_id \
+     ORDER BY ps.created_at DESC NULLS LAST \
+     LIMIT $1 OFFSET $2";
+
+    let rows = sqlx::query_as::<_, TvEpisodeCardRow>(sql)
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(&state.db)
+        .await?;
+    Ok(rows)
+}
+
+/// GET /tv-porady/{slug}/ — TV pořad detail with episode list.
+pub async fn tv_porad_detail(
+    State(state): State<AppState>,
+    Path(slug_raw): Path<String>,
+) -> WebResult<Response> {
+    // WebP cover variants routed here too (no genre routes on /tv-porady/)
+    if slug_raw.ends_with(".webp") {
+        return tv_porad_cover(State(state), Path(slug_raw)).await;
+    }
+
+    let show = sqlx::query_as::<_, TvShowRow>(
+        "SELECT id, title, slug, first_air_year, last_air_year, description, \
+         original_title, imdb_rating, csfd_rating, season_count, episode_count, \
+         cover_filename, added_at FROM tv_shows WHERE slug = $1",
+    )
+    .bind(&slug_raw)
+    .fetch_optional(&state.db)
+    .await?;
+
+    let show = match show {
+        Some(s) => s,
+        None => {
+            let old_match = sqlx::query_as::<_, TvShowRow>(
+                "SELECT id, title, slug, first_air_year, last_air_year, description, \
+                 original_title, imdb_rating, csfd_rating, season_count, episode_count, \
+                 cover_filename, added_at FROM tv_shows WHERE old_slug = $1",
+            )
+            .bind(&slug_raw)
+            .fetch_optional(&state.db)
+            .await?;
+            match old_match {
+                Some(s) => {
+                    let new_url = format!("/tv-porady/{}/", s.slug);
+                    return Ok(
+                        (StatusCode::MOVED_PERMANENTLY, [(header::LOCATION, new_url)])
+                            .into_response(),
+                    );
+                }
+                None => return Ok((StatusCode::NOT_FOUND, "TV pořad nenalezen").into_response()),
+            }
+        }
+    };
+
+    let episodes = sqlx::query_as::<_, TvEpisodeRow>(
+        "SELECT id, season, episode, title, sktorrent_video_id, sktorrent_cdn, \
+         sktorrent_qualities, episode_name, overview, air_date, runtime, still_filename, \
+         prehrajto_url, prehrajto_has_dub, prehrajto_has_subs, slug \
+         FROM tv_episodes \
+         WHERE tv_show_id = $1 \
+           AND (sktorrent_video_id IS NOT NULL OR prehrajto_url IS NOT NULL) \
+         ORDER BY season, episode, sktorrent_video_id",
+    )
+    .bind(show.id)
+    .fetch_all(&state.db)
+    .await?;
+
+    let mut seasons: Vec<Season> = Vec::new();
+    let mut current_season: Option<Season> = None;
+    let mut seen_in_season: std::collections::HashSet<i16> = std::collections::HashSet::new();
+
+    for ep in episodes {
+        let boundary = current_season.as_ref().map(|s| s.number) != Some(ep.season);
+        if boundary && let Some(finished) = current_season.take() {
+            seasons.push(finished);
+            seen_in_season.clear();
+        }
+        if current_season.is_none() {
+            current_season = Some(Season {
+                number: ep.season,
+                episodes: Vec::new(),
+            });
+        }
+        if seen_in_season.insert(ep.episode)
+            && let Some(ref mut s) = current_season
+        {
+            s.episodes.push(ep);
+        }
+    }
+    if let Some(s) = current_season {
+        seasons.push(s);
+    }
+
+    let tmpl = TvPoradDetailTemplate {
+        img: state.image_base_url.clone(),
+        show,
+        seasons,
+    };
+    Ok(Html(tmpl.render()?).into_response())
+}
+
+/// GET /tv-porady/{slug}/{ep_slug}/ — episode detail page with player.
+pub async fn tv_epizoda_detail(
+    State(state): State<AppState>,
+    Path((slug, ep_path)): Path<(String, String)>,
+) -> WebResult<Response> {
+    let show = sqlx::query_as::<_, TvShowRow>(
+        "SELECT id, title, slug, first_air_year, last_air_year, description, \
+         original_title, imdb_rating, csfd_rating, season_count, episode_count, \
+         cover_filename, added_at FROM tv_shows WHERE slug = $1",
+    )
+    .bind(&slug)
+    .fetch_optional(&state.db)
+    .await?;
+
+    let show = match show {
+        Some(s) => s,
+        None => {
+            let old_match = sqlx::query_as::<_, TvShowRow>(
+                "SELECT id, title, slug, first_air_year, last_air_year, description, \
+                 original_title, imdb_rating, csfd_rating, season_count, episode_count, \
+                 cover_filename, added_at FROM tv_shows WHERE old_slug = $1",
+            )
+            .bind(&slug)
+            .fetch_optional(&state.db)
+            .await?;
+            match old_match {
+                Some(s) => {
+                    let new_url = format!("/tv-porady/{}/{ep_path}/", s.slug);
+                    return Ok(
+                        (StatusCode::MOVED_PERMANENTLY, [(header::LOCATION, new_url)])
+                            .into_response(),
+                    );
+                }
+                None => return Ok((StatusCode::NOT_FOUND, "TV pořad nenalezen").into_response()),
+            }
+        }
+    };
+
+    let episode = sqlx::query_as::<_, TvEpisodeRow>(
+        "SELECT id, season, episode, title, sktorrent_video_id, sktorrent_cdn, \
+         sktorrent_qualities, episode_name, overview, air_date, runtime, still_filename, \
+         prehrajto_url, prehrajto_has_dub, prehrajto_has_subs, slug \
+         FROM tv_episodes \
+         WHERE tv_show_id = $1 AND slug = $2 \
+           AND (sktorrent_video_id IS NOT NULL OR prehrajto_url IS NOT NULL) \
+         ORDER BY sktorrent_video_id LIMIT 1",
+    )
+    .bind(show.id)
+    .bind(&ep_path)
+    .fetch_optional(&state.db)
+    .await?;
+
+    let episode = match episode {
+        Some(ep) => ep,
+        None => {
+            if let Some((s_str, e_str)) = ep_path.split_once('x') {
+                if let (Ok(season_num), Ok(episode_num)) =
+                    (s_str.parse::<i16>(), e_str.parse::<i16>())
+                {
+                    let found = sqlx::query_as::<_, TvEpisodeRow>(
+                        "SELECT id, season, episode, title, sktorrent_video_id, sktorrent_cdn, \
+                         sktorrent_qualities, episode_name, overview, air_date, runtime, \
+                         still_filename, prehrajto_url, prehrajto_has_dub, prehrajto_has_subs, slug \
+                         FROM tv_episodes \
+                         WHERE tv_show_id = $1 AND season = $2 AND episode = $3 \
+                           AND (sktorrent_video_id IS NOT NULL OR prehrajto_url IS NOT NULL) \
+                         ORDER BY sktorrent_video_id LIMIT 1",
+                    )
+                    .bind(show.id)
+                    .bind(season_num)
+                    .bind(episode_num)
+                    .fetch_optional(&state.db)
+                    .await?;
+
+                    if let Some(ep) = found {
+                        if let Some(ref ep_slug) = ep.slug {
+                            let new_url = format!("/tv-porady/{}/{ep_slug}/", show.slug);
+                            return Ok((
+                                StatusCode::MOVED_PERMANENTLY,
+                                [(header::LOCATION, new_url)],
+                            )
+                                .into_response());
+                        }
+                        ep
+                    } else {
+                        return Ok((StatusCode::NOT_FOUND, "Epizoda nenalezena").into_response());
+                    }
+                } else {
+                    return Ok((StatusCode::NOT_FOUND, "Neplatná URL").into_response());
+                }
+            } else {
+                return Ok((StatusCode::NOT_FOUND, "Epizoda nenalezena").into_response());
+            }
+        }
+    };
+
+    let season_num = episode.season;
+    let episode_num = episode.episode;
+
+    let all_episodes = sqlx::query_as::<_, (i16, i16, Option<String>, Option<String>)>(
+        "SELECT DISTINCT ON (season, episode) season, episode, episode_name, slug \
+         FROM tv_episodes \
+         WHERE tv_show_id = $1 \
+           AND (sktorrent_video_id IS NOT NULL OR prehrajto_url IS NOT NULL) \
+         ORDER BY season, episode",
+    )
+    .bind(show.id)
+    .fetch_all(&state.db)
+    .await
+    .unwrap_or_default();
+    let current_idx = all_episodes
+        .iter()
+        .position(|(s, e, _, _)| *s == season_num && *e == episode_num);
+    let prev_episode = current_idx
+        .and_then(|i| i.checked_sub(1).and_then(|j| all_episodes.get(j)))
+        .map(|(s, e, n, sl)| EpisodeNav {
+            season: *s,
+            episode: *e,
+            episode_name: n.clone(),
+            slug: sl.clone(),
+        });
+    let next_episode = current_idx
+        .and_then(|i| all_episodes.get(i + 1))
+        .map(|(s, e, n, sl)| EpisodeNav {
+            season: *s,
+            episode: *e,
+            episode_name: n.clone(),
+            slug: sl.clone(),
+        });
+
+    let tmpl = TvEpizodaDetailTemplate {
+        img: state.image_base_url.clone(),
+        show,
+        episode,
+        prev_episode,
+        next_episode,
+    };
+    Ok(Html(tmpl.render()?).into_response())
+}
+
+/// GET /tv-porady/{slug}.webp — cover (small) with TMDB fallback.
+pub async fn tv_porad_cover(
+    State(state): State<AppState>,
+    Path(slug_webp): Path<String>,
+) -> WebResult<Response> {
+    if slug_webp.ends_with("-large.webp") {
+        return tv_porad_cover_large(State(state), Path(slug_webp)).await;
+    }
+    let slug = slug_webp.strip_suffix(".webp").unwrap_or(&slug_webp);
+
+    #[derive(sqlx::FromRow)]
+    struct CoverRow {
+        cover_filename: Option<String>,
+        tmdb_id: Option<i32>,
+    }
+
+    let row = sqlx::query_as::<_, CoverRow>(
+        "SELECT cover_filename, tmdb_id FROM tv_shows WHERE slug = $1",
+    )
+    .bind(slug)
+    .fetch_optional(&state.db)
+    .await?;
+
+    let (cover_filename, tmdb_id) = match row {
+        Some(r) => (r.cover_filename, r.tmdb_id),
+        None => (None, None),
+    };
+    // Reuse series_covers_dir for now (migration reuses files written for
+    // these same slugs before they were moved).
+    let covers_dir = state.config.series_covers_dir.clone();
+
+    if let Some(ref filename) = cover_filename {
+        let path = std::path::Path::new(&covers_dir).join(format!("{filename}.webp"));
+        if path.exists()
+            && let Ok(bytes) = tokio::fs::read(&path).await
+        {
+            return Ok((
+                StatusCode::OK,
+                [
+                    (header::CONTENT_TYPE, "image/webp"),
+                    (header::CACHE_CONTROL, "public, max-age=31536000"),
+                ],
+                bytes,
+            )
+                .into_response());
+        }
+    }
+
+    if let Some(tid) = tmdb_id {
+        let tmdb_key = std::env::var("TMDB_API_KEY").unwrap_or_default();
+        if !tmdb_key.is_empty() {
+            let detail_url =
+                format!("https://api.themoviedb.org/3/tv/{tid}?api_key={tmdb_key}&language=cs-CZ");
+            if let Ok(resp) = state
+                .http_client
+                .get(&detail_url)
+                .timeout(std::time::Duration::from_secs(10))
+                .send()
+                .await
+                && let Ok(data) = resp.json::<serde_json::Value>().await
+                && let Some(poster_path) = data.get("poster_path").and_then(|v| v.as_str())
+            {
+                let img_url = format!("https://image.tmdb.org/t/p/w200{poster_path}");
+                if let Ok(img_resp) = state
+                    .http_client
+                    .get(&img_url)
+                    .timeout(std::time::Duration::from_secs(15))
+                    .send()
+                    .await
+                    && let Ok(img_bytes) = img_resp.bytes().await
+                {
+                    let cache_path = std::path::Path::new(&covers_dir).join(format!("{slug}.webp"));
+                    let _ = tokio::fs::create_dir_all(&covers_dir).await;
+                    let _ = tokio::fs::write(&cache_path, &img_bytes).await;
+
+                    return Ok((
+                        StatusCode::OK,
+                        [
+                            (header::CONTENT_TYPE, "image/webp"),
+                            (header::CACHE_CONTROL, "public, max-age=31536000, immutable"),
+                        ],
+                        img_bytes.to_vec(),
+                    )
+                        .into_response());
+                }
+            }
+        }
+    }
+
+    static PLACEHOLDER: &[u8] = &[
+        0x52, 0x49, 0x46, 0x46, 0x1a, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50, 0x56, 0x50, 0x38,
+        0x4c, 0x0d, 0x00, 0x00, 0x00, 0x2f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00,
+    ];
+    Ok((
+        StatusCode::OK,
+        [
+            (header::CONTENT_TYPE, "image/webp"),
+            (header::CACHE_CONTROL, "public, max-age=3600"),
+        ],
+        PLACEHOLDER.to_vec(),
+    )
+        .into_response())
+}
+
+/// GET /tv-porady/{slug}-large.webp — w780 poster from TMDB, cached.
+pub async fn tv_porad_cover_large(
+    State(state): State<AppState>,
+    Path(slug_webp): Path<String>,
+) -> WebResult<Response> {
+    let slug = slug_webp.strip_suffix("-large.webp").unwrap_or(&slug_webp);
+
+    #[derive(sqlx::FromRow)]
+    struct CoverRow {
+        tmdb_id: Option<i32>,
+    }
+
+    let row = sqlx::query_as::<_, CoverRow>("SELECT tmdb_id FROM tv_shows WHERE slug = $1")
+        .bind(slug)
+        .fetch_optional(&state.db)
+        .await?;
+
+    let tmdb_id = row.and_then(|r| r.tmdb_id);
+    let covers_dir = state.config.series_covers_dir.clone();
+
+    let cache_dir = std::path::Path::new(&covers_dir).join("large");
+    let cache_path = cache_dir.join(format!("{slug}.webp"));
+
+    if cache_path.exists()
+        && let Ok(bytes) = tokio::fs::read(&cache_path).await
+    {
+        return Ok((
+            StatusCode::OK,
+            [
+                (header::CONTENT_TYPE, "image/webp"),
+                (header::CACHE_CONTROL, "public, max-age=31536000, immutable"),
+            ],
+            bytes,
+        )
+            .into_response());
+    }
+
+    if let Some(tid) = tmdb_id {
+        let tmdb_key = std::env::var("TMDB_API_KEY").unwrap_or_default();
+        if !tmdb_key.is_empty() {
+            let detail_url =
+                format!("https://api.themoviedb.org/3/tv/{tid}?api_key={tmdb_key}&language=cs-CZ");
+
+            if let Ok(resp) = state
+                .http_client
+                .get(&detail_url)
+                .timeout(std::time::Duration::from_secs(10))
+                .send()
+                .await
+                && let Ok(data) = resp.json::<serde_json::Value>().await
+                && let Some(poster_path) = data.get("poster_path").and_then(|v| v.as_str())
+            {
+                let poster_url = format!("https://image.tmdb.org/t/p/w780{poster_path}");
+                if let Ok(img_resp) = state
+                    .http_client
+                    .get(&poster_url)
+                    .timeout(std::time::Duration::from_secs(15))
+                    .send()
+                    .await
+                    && img_resp.status().is_success()
+                    && let Ok(bytes) = img_resp.bytes().await
+                {
+                    let output_bytes = if let Ok(img) = image::load_from_memory(&bytes) {
+                        let mut buf = Vec::new();
+                        let mut cursor = std::io::Cursor::new(&mut buf);
+                        if img.write_to(&mut cursor, image::ImageFormat::WebP).is_ok() {
+                            buf
+                        } else {
+                            bytes.to_vec()
+                        }
+                    } else {
+                        bytes.to_vec()
+                    };
+
+                    let _ = tokio::fs::create_dir_all(&cache_dir).await;
+                    let _ = tokio::fs::write(&cache_path, &output_bytes).await;
+
+                    return Ok((
+                        StatusCode::OK,
+                        [
+                            (header::CONTENT_TYPE, "image/webp"),
+                            (header::CACHE_CONTROL, "public, max-age=31536000, immutable"),
+                        ],
+                        output_bytes,
+                    )
+                        .into_response());
+                }
+            }
+        }
+    }
+
+    static PLACEHOLDER: &[u8] = &[
+        0x52, 0x49, 0x46, 0x46, 0x1a, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50, 0x56, 0x50, 0x38,
+        0x4c, 0x0d, 0x00, 0x00, 0x00, 0x2f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00,
+    ];
+    Ok((
+        StatusCode::OK,
+        [
+            (header::CONTENT_TYPE, "image/webp"),
+            (header::CACHE_CONTROL, "public, max-age=3600"),
+        ],
+        PLACEHOLDER.to_vec(),
+    )
+        .into_response())
+}
+
+fn build_query_string(params: &TvShowQuery) -> String {
+    let mut parts: Vec<(&str, String)> = Vec::new();
+    if params.razeni.is_some() {
+        parts.push(("razeni", params.sort_key().to_string()));
+    }
+    if let Some(ref q) = params.q {
+        let t = q.trim();
+        if !t.is_empty() {
+            parts.push(("q", t.to_string()));
+        }
+    }
+    super::build_pagination_qs(&parts)
+}

--- a/cr-web/src/main.rs
+++ b/cr-web/src/main.rs
@@ -314,6 +314,24 @@ async fn main() -> Result<()> {
             "/serialy-online/{slug}/",
             axum::routing::get(handlers::series_resolve),
         )
+        .route("/tv-porady", axum::routing::get(handlers::tv_porady_list))
+        .route("/tv-porady/", axum::routing::get(handlers::tv_porady_list))
+        .route(
+            "/tv-porady/{slug}/{ep}",
+            axum::routing::get(handlers::tv_epizoda_detail),
+        )
+        .route(
+            "/tv-porady/{slug}/{ep}/",
+            axum::routing::get(handlers::tv_epizoda_detail),
+        )
+        .route(
+            "/tv-porady/{slug}",
+            axum::routing::get(handlers::tv_porad_detail),
+        )
+        .route(
+            "/tv-porady/{slug}/",
+            axum::routing::get(handlers::tv_porad_detail),
+        )
         .route(
             "/filmy-a-serialy",
             axum::routing::get(handlers::filmy_serialy),

--- a/cr-web/templates/homepage.html
+++ b/cr-web/templates/homepage.html
@@ -32,6 +32,10 @@
         <span class="portal-category-icon">📺</span>
         <span>Seriály online</span>
     </a>
+    <a href="/tv-porady/" class="portal-category-link">
+        <span class="portal-category-icon">📡</span>
+        <span>TV pořady</span>
+    </a>
 </nav>
 
 <section class="active-hub">

--- a/cr-web/templates/tv_epizoda_detail.html
+++ b/cr-web/templates/tv_epizoda_detail.html
@@ -1,0 +1,668 @@
+{% extends "base.html" %}
+
+{% block title %}{{ show.title }} — {% match episode.episode_name %}{% when Some with (n) %}{% if !n.is_empty() && !n.starts_with(char::is_numeric) %}{{ n }} {% endif %}{% when None %}{% endmatch %}S{{ "{:02}"|format(episode.season) }}E{{ "{:02}"|format(episode.episode) }} — TV pořad online{% endblock %}
+
+{% block meta_description %}{% match episode.overview %}{% when Some with (d) %}{{ d }}{% when None %}{{ show.title }} S{{ "{:02}"|format(episode.season) }}E{{ "{:02}"|format(episode.episode) }} — sledujte online{% endmatch %}{% endblock %}
+
+{% block og_title %}{{ show.title }} — {% match episode.episode_name %}{% when Some with (n) %}{% if !n.is_empty() && !n.starts_with(char::is_numeric) %}{{ n }} {% endif %}{% when None %}{% endmatch %}S{{ "{:02}"|format(episode.season) }}E{{ "{:02}"|format(episode.episode) }}{% endblock %}
+{% block og_description %}{% match episode.overview %}{% when Some with (d) %}{{ d }}{% when None %}{{ show.title }} — S{{ "{:02}"|format(episode.season) }}E{{ "{:02}"|format(episode.episode) }}{% endmatch %}{% endblock %}
+{% block og_image %}{% match episode.still_filename %}{% when Some with (f) %}https://ceskarepublika.wiki/tv-porady/still/{{ f }}{% when None %}{% match show.cover_filename %}{% when Some with (c) %}https://ceskarepublika.wiki/tv-porady/{{ show.slug }}.webp{% when None %}https://ceskarepublika.wiki/static/img/og-filmy-a-serialy-v6.png{% endmatch %}{% endmatch %}{% endblock %}
+{% block og_type %}video.episode{% endblock %}
+
+{% block leaflet %}{% endblock %}
+
+{% block head %}
+<link rel="icon" type="image/svg+xml" href="/static/img/logo-filmy-a-serialy.svg?v=6">
+<script src="https://cdn.jsdelivr.net/npm/hls.js@1.5.8/dist/hls.min.js"></script>
+<meta property="og:url" content="https://ceskarepublika.wiki/tv-porady/{{ show.slug }}/{% match episode.slug %}{% when Some with (s) %}{{ s }}{% when None %}{{ episode.season }}x{{ episode.episode }}{% endmatch %}/">
+{% endblock %}
+
+{% block header_left %}
+<div class="logo-group" style="display:flex;align-items:center;gap:0.5rem;">
+    <a href="/tv-porady/" style="display:flex;align-items:center;text-decoration:none;" alt="TV pořady" title="TV pořady">
+        <img src="/static/img/logo-filmy-a-serialy.svg?v=6" alt="Logo TV pořady" title="TV pořady" class="header-emblem">
+    </a>
+    <h1>{{ show.title }}</h1>
+</div>
+{% endblock %}
+
+{% block header_search %}
+<div class="search-container" id="header-search-box">
+    <input type="text" id="tv-search" class="search-input" placeholder="Hledat TV pořad..." autocomplete="off">
+    <button class="search-btn" onclick="doSearch()" alt="Hledat" title="Hledat">Hledat</button>
+    <div id="search-results" class="search-dropdown"></div>
+</div>
+{% endblock %}
+
+{% block header_right %}<div class="context-emblem"></div>{% endblock %}
+
+{% block content %}
+<main class="episode-detail-page">
+    <nav class="breadcrumb">
+        <a href="/" alt="Česká republika" title="Česká republika">Česká republika</a>
+        <span>›</span> <a href="/tv-porady/" alt="TV pořady" title="TV pořady">TV pořady</a>
+        <span>›</span> <a href="/tv-porady/{{ show.slug }}/" alt="{{ show.title }}" title="{{ show.title }}">{{ show.title }}</a>
+        <span>›</span> <span>S{{ episode.season }}E{{ episode.episode }}</span>
+    </nav>
+
+    <div class="player-section">
+        <div class="source-tabs" id="source-tabs">
+            <button class="source-tab active" id="tab-source-1" onclick="switchToSource1()">Zdroj 1</button>
+        </div>
+        <div class="player-panel">
+            <video id="tv-player" controls preload="metadata" width="100%"
+                   {% match episode.still_filename %}{% when Some with (f) %}poster="/tv-porady/still/{{ f }}"{% when None %}{% match show.cover_filename %}{% when Some with (c) %}poster="/tv-porady/{{ show.slug }}-large.webp"{% when None %}{% endmatch %}{% endmatch %}></video>
+            <div class="player-controls">
+                <div class="player-quality" id="source-quality"></div>
+                <div id="subtitle-controls" class="subtitle-controls" style="display:none;">
+                    <span class="sub-label">Velikost titulků</span>
+                    <select id="sub-size-select" class="sub-select" onchange="setSubSize(this.value)" title="Velikost titulků">
+                        <option value="14">14 px</option>
+                        <option value="16">16 px</option>
+                        <option value="18">18 px</option>
+                        <option value="20" selected>20 px</option>
+                        <option value="24">24 px</option>
+                        <option value="28">28 px</option>
+                        <option value="32">32 px</option>
+                        <option value="36">36 px</option>
+                        <option value="40">40 px</option>
+                    </select>
+                </div>
+                <div id="source-status" class="source-status"></div>
+            </div>
+        </div>
+        <div class="prehrajto-section" id="prehrajto-section" style="display:none;">
+            <h3>Další zdroje</h3>
+            <div id="prehrajto-results" class="prehrajto-results"></div>
+            <button type="button" id="prehrajto-more" class="prehrajto-more" style="display:none;" alt="Zobrazit další zdroje" title="Zobrazit další zdroje">Zobrazit další zdroje</button>
+        </div>
+    </div>
+
+    <div class="episode-info">
+        <h2>S{{ episode.season }}E{{ episode.episode }}{% match episode.episode_name %}{% when Some with (n) %} — {{ n }}{% when None %}{% endmatch %}</h2>
+        <div class="episode-meta">
+            {% match episode.air_date %}{% when Some with (d) %}<span class="meta-pill">📅 {{ d }}</span>{% when None %}{% endmatch %}
+            {% match episode.runtime %}{% when Some with (r) %}<span class="meta-pill">⏱ {{ r }} min</span>{% when None %}{% endmatch %}
+        </div>
+        {% match episode.overview %}{% when Some with (o) %}<p class="episode-overview">{{ o }}</p>{% when None %}{% endmatch %}
+    </div>
+
+    <div class="episode-nav">
+        {% match prev_episode %}
+        {% when Some with (p) %}
+        <a class="nav-prev" href="/tv-porady/{{ show.slug }}/{% match p.slug %}{% when Some with (s) %}{{ s }}{% when None %}{{ p.season }}x{{ p.episode }}{% endmatch %}/"
+           alt="Předchozí: S{{ p.season }}E{{ p.episode }}" title="Předchozí: S{{ p.season }}E{{ p.episode }}{% match p.episode_name %}{% when Some with (n) %} — {{ n }}{% when None %}{% endmatch %}">
+           ← S{{ p.season }}E{{ p.episode }}
+        </a>
+        {% when None %}<span></span>{% endmatch %}
+        <a class="nav-back" href="/tv-porady/{{ show.slug }}/" alt="Zpět na seznam epizod" title="Zpět na seznam epizod">Všechny epizody</a>
+        {% match next_episode %}
+        {% when Some with (n) %}
+        <a class="nav-next" href="/tv-porady/{{ show.slug }}/{% match n.slug %}{% when Some with (s) %}{{ s }}{% when None %}{{ n.season }}x{{ n.episode }}{% endmatch %}/"
+           alt="Další: S{{ n.season }}E{{ n.episode }}" title="Další: S{{ n.season }}E{{ n.episode }}{% match n.episode_name %}{% when Some with (nm) %} — {{ nm }}{% when None %}{% endmatch %}">
+           S{{ n.season }}E{{ n.episode }} →
+        </a>
+        {% when None %}<span></span>{% endmatch %}
+    </div>
+</main>
+
+<style>
+.episode-detail-page { max-width: 960px; margin: 0 auto; padding: 1rem; }
+.breadcrumb { font-size: 0.85rem; color: #888; margin-bottom: 1.2rem; }
+.breadcrumb a { color: #11457E; text-decoration: none; }
+
+/* Search dropdown */
+#header-search-box { position: relative; overflow: visible !important; }
+.search-dropdown { display: none; position: absolute; top: calc(100% + 4px); left: 0; right: 0; background: white; border: 1px solid #ddd; border-radius: 12px; box-shadow: 0 8px 24px rgba(0,0,0,0.18); z-index: 200; max-height: 420px; overflow-y: auto; }
+.search-dropdown.open { display: block; }
+.search-item { display: flex; align-items: center; gap: 0.7rem; padding: 0.5rem 0.8rem; text-decoration: none; color: inherit; border-bottom: 1px solid #f0f0f0; }
+.search-item:hover { background: #f5f5f5; }
+.search-item img { width: 40px; height: 60px; object-fit: cover; border-radius: 4px; }
+.search-item .si-placeholder { width: 40px; height: 60px; background: #eee; border-radius: 4px; }
+.search-item .si-info { flex: 1; min-width: 0; }
+.search-item .si-title { font-weight: 500; display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.search-item .si-meta { font-size: 0.8rem; color: #888; }
+
+/* Player */
+.player-section { margin-bottom: 1.5rem; }
+.source-tabs { display: flex; gap: 0.3rem; background: #1a1a1a; padding: 0.4rem 0.6rem; border-radius: 10px 10px 0 0; }
+.source-tab { background: #333; color: #ccc; border: none; padding: 0.35rem 0.8rem; border-radius: 4px; font-size: 0.8rem; cursor: pointer; transition: background 0.15s; }
+.source-tab:hover { background: #444; }
+.source-tab.active { background: #D7141A; color: white; }
+.player-panel { background: #000; border-radius: 0 0 10px 10px; overflow: hidden; }
+.player-panel video { display: block; width: 100%; max-height: 540px; background: #000; }
+.player-controls { display: flex; align-items: center; flex-wrap: wrap; gap: 0.5rem; padding: 0.4rem 0.6rem; background: #111; }
+.player-quality { display: flex; gap: 0.3rem; }
+.quality-btn { background: #333; color: #ccc; border: none; padding: 0.25rem 0.8rem; border-radius: 4px; cursor: pointer; font-size: 0.8rem; }
+.quality-btn.active { background: #D7141A; color: white; }
+.subtitle-controls { display: flex; align-items: center; gap: 0.4rem; margin-left: 0.3rem; }
+.sub-label { color: #bbb; font-size: 0.78rem; }
+.sub-select { background: #333; color: #eee; border: 1px solid #444; border-radius: 4px; padding: 0.2rem 0.3rem; font-size: 0.78rem; cursor: pointer; }
+.source-status { font-size: 0.78rem; color: #888; margin-left: auto; }
+video::cue { background: rgba(0,0,0,0.7); color: white; font-family: sans-serif; }
+
+/* Additional sources list */
+.prehrajto-section { margin-top: 1rem; padding: 0.8rem; background: #f8f8f8; border-radius: 8px; }
+.prehrajto-section h3 { font-size: 1rem; margin: 0 0 0.6rem; color: #555; }
+.prehrajto-results { display: flex; flex-direction: column; gap: 0.4rem; }
+.prehrajto-item { display: flex; align-items: center; gap: 0.6rem; padding: 0.5rem; background: white; border: 1px solid #eee; border-radius: 6px; cursor: pointer; transition: background 0.15s, border-color 0.15s; position: relative; width: 100%; text-align: left; font: inherit; color: inherit; }
+.prehrajto-item:hover { background: #f0f0f0; }
+.prehrajto-item.loading { opacity: 0.5; cursor: wait; }
+.prehrajto-item.active { background: #C5A059; border-color: #C5A059; color: white; }
+.prehrajto-item.active .pt-title { color: white; }
+.prehrajto-item .play-indicator { display: none; flex-shrink: 0; width: 22px; height: 22px; align-items: center; justify-content: center; background: rgba(255,255,255,0.2); border-radius: 50%; color: white; font-size: 0.7rem; }
+.prehrajto-item.active .play-indicator { display: inline-flex; }
+.prehrajto-item img { width: 60px; height: 40px; object-fit: cover; border-radius: 3px; }
+.prehrajto-more { margin-top: 0.5rem; width: 100%; padding: 0.5rem 0.8rem; background: #f1f5f9; border: 1px solid #ddd; border-radius: 6px; color: #11457E; font-size: 0.85rem; font-weight: 600; cursor: pointer; transition: background 0.15s; }
+.prehrajto-more:hover { background: #e2e8f0; }
+.pt-info { flex: 1; min-width: 0; }
+.pt-title { font-size: 0.85rem; font-weight: 500; display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: inherit; }
+.pt-loading { color: #888; font-size: 0.85rem; padding: 0.5rem; text-align: center; }
+.cc-badge-sm { display: inline-block; padding: 0.1rem 0.4rem; margin-left: 0.3rem; background: #4ade80; color: #003c1c; border-radius: 3px; font-size: 0.7rem; font-weight: 700; letter-spacing: 0.03em; }
+.prehrajto-item.active .cc-badge-sm { background: rgba(255,255,255,0.25); color: white; }
+.pt-badge { display: inline-block; padding: 0.1rem 0.4rem; border-radius: 3px; font-size: 0.7rem; font-weight: 700; margin-left: 0.3rem; }
+.pt-badge.direct { background: #27ae60; color: white; }
+.pt-badge.proxy { background: #f39c12; color: white; }
+.pt-badge.quality-hd { background: #1e40af; color: white; }
+.pt-badge.quality-sd { background: #92400e; color: white; }
+.pt-badge.quality-low { background: #6b7280; color: white; }
+.pt-badge-dur { display: inline-block; padding: 0.1rem 0.4rem; margin-left: 0.3rem; font-size: 0.7rem; color: #888; }
+.prehrajto-item.active .pt-badge { background: rgba(255,255,255,0.25); color: white; }
+.prehrajto-item.active .pt-badge-dur { color: rgba(255,255,255,0.85); }
+
+/* Episode info */
+.episode-info { margin: 1.5rem 0; }
+.episode-info h2 { margin: 0 0 0.5rem; font-size: 1.3rem; }
+.episode-meta { display: flex; gap: 0.5rem; margin-bottom: 0.8rem; flex-wrap: wrap; }
+.meta-pill { padding: 0.2rem 0.6rem; background: #f1f5f9; border-radius: 999px; font-size: 0.82rem; color: #555; }
+.episode-overview { line-height: 1.6; color: #333; margin-bottom: 1rem; }
+.crew-row { margin-bottom: 0.4rem; font-size: 0.9rem; }
+.crew-label { font-weight: 600; color: #555; margin-right: 0.3rem; }
+.crew-name { display: inline-block; padding: 0.15rem 0.6rem; background: #f1f5f9; color: #11457E; border-radius: 999px; font-size: 0.82rem; margin: 0 0.2rem 0.2rem 0; }
+
+/* Navigation */
+.episode-nav { display: grid; grid-template-columns: 1fr auto 1fr; gap: 0.5rem; align-items: center; margin: 1.5rem 0; }
+.episode-nav a { padding: 0.5rem 0.9rem; border-radius: 6px; background: #f1f5f9; color: #11457E; text-decoration: none; font-size: 0.85rem; font-weight: 600; transition: background 0.15s, color 0.15s; }
+.episode-nav a:hover { background: #11457E; color: white; }
+.episode-nav .nav-prev { text-align: left; justify-self: start; }
+.episode-nav .nav-next { text-align: right; justify-self: end; }
+</style>
+
+<script>
+var showTitle = "{{ show.title }}";
+var initialSeason = {{ episode.season }};
+var initialEpisode = {{ episode.episode }};
+var initialVideoId = {{ episode.sktorrent_video_id.unwrap_or(0) }};
+var initialCdn = {{ episode.sktorrent_cdn.unwrap_or(0) }};
+var initialQualities = "{% match episode.sktorrent_qualities %}{% when Some with (q) %}{{ q }}{% when None %}480p{% endmatch %}".split(",").filter(function(q) { return q.match(/^\d+p$/); });
+// Cached Přehraj.to URL for this episode (stable across searches).
+// Used as primary Zdroj 1 when SK Torrent is not available.
+var prehrajtoUrl = {% match episode.prehrajto_url %}{% when Some with (u) %}"{{ u }}"{% when None %}null{% endmatch %};
+var prehrajtoHasDub  = {{ episode.prehrajto_has_dub }};
+var prehrajtoHasSubs = {{ episode.prehrajto_has_subs }};
+
+// State — same shape as series_detail.html player
+var state = { source1: null, source2: null, activeSource: 1, activeEpisodeBtn: null };
+var resolvedSources = {};
+var currentPrehrajto = { all: [], visibleCount: 3 };
+var _subPoll = null;
+
+function initPlayer() {
+    if (initialVideoId) {
+        // Primary: SK Torrent (has quality options)
+        var qualities = initialQualities.length ? initialQualities : ['480p'];
+        var sources = qualities.map(function(q) {
+            return {
+                url: 'https://online' + initialCdn + '.sktorrent.eu/media/videos//h264/' + initialVideoId + '_' + q + '.mp4',
+                quality: q,
+                res: parseInt(q, 10),
+            };
+        });
+        sources.sort(function(a, b) { return b.res - a.res; });
+        state.source1 = {
+            episode: { season: initialSeason, episode: initialEpisode },
+            sources: sources,
+            currentIndex: 0,
+            videoId: initialVideoId,
+        };
+        switchToSource1();
+    } else if (prehrajtoUrl) {
+        // Fallback: cached Přehraj.to URL. Resolve on the fly, then play.
+        document.getElementById('source-status').textContent = 'Načítání Přehraj.to...';
+        fetch('/api/movies/video-url?url=' + encodeURIComponent(prehrajtoUrl))
+            .then(function(r) { return r.json(); })
+            .then(function(data) {
+                if (!data.success || !data.video_url) {
+                    document.getElementById('source-status').textContent = 'Zdroj nedostupný';
+                    return;
+                }
+                var url = data.video_url.replace(/&amp;/g, '&');
+                var isHls = url.indexOf('.m3u8') !== -1;
+                state.source1 = {
+                    episode: { season: initialSeason, episode: initialEpisode },
+                    prehrajto: true,
+                    url: url,
+                    isHls: isHls,
+                    subtitles: data.subtitles || [],
+                };
+                switchToSource1Prehrajto();
+            })
+            .catch(function() {
+                document.getElementById('source-status').textContent = 'Zdroj nedostupný';
+            });
+    } else {
+        document.getElementById('source-status').textContent = 'Zdroj nedostupný';
+    }
+    loadPrehrajtoForEpisode(initialSeason, initialEpisode);
+}
+
+/* Variant of switchToSource1 for cached Přehraj.to primary source */
+function switchToSource1Prehrajto() {
+    if (!state.source1 || !state.source1.prehrajto) return;
+    state.activeSource = 1;
+    setActiveTab(1);
+    var qualDiv = document.getElementById('source-quality');
+    qualDiv.innerHTML = '';
+    qualDiv.style.display = 'none';
+    playUrl(state.source1.url, state.source1.isHls ? 'hls' : 'mp4');
+    document.getElementById('source-status').textContent = 'S' + state.source1.episode.season + 'E' + state.source1.episode.episode;
+    applySubtitles(state.source1.subtitles || []);
+    document.querySelectorAll('.prehrajto-item.active').forEach(function(el) { el.classList.remove('active'); });
+}
+
+function switchToSource1() {
+    if (!state.source1) return;
+    if (state.source1.prehrajto) {
+        switchToSource1Prehrajto();
+        return;
+    }
+    state.activeSource = 1;
+    setActiveTab(1);
+    var subCtrl = document.getElementById('subtitle-controls');
+    if (subCtrl) subCtrl.style.display = 'none';
+    var player = document.getElementById('tv-player');
+    player.querySelectorAll('track').forEach(function(t) { t.remove(); });
+    document.querySelectorAll('.prehrajto-item.active').forEach(function(el) { el.classList.remove('active'); });
+    renderQualityButtons1();
+    playQuality1(state.source1.currentIndex, true);
+}
+
+function renderQualityButtons1() {
+    var qualDiv = document.getElementById('source-quality');
+    qualDiv.innerHTML = '';
+    state.source1.sources.forEach(function(s, i) {
+        var qBtn = document.createElement('button');
+        qBtn.className = 'quality-btn' + (i === state.source1.currentIndex ? ' active' : '');
+        qBtn.textContent = s.quality;
+        qBtn.onclick = function() { playQuality1(i, true); };
+        qualDiv.appendChild(qBtn);
+    });
+    qualDiv.style.display = '';
+}
+
+function playQuality1(index, doPlay) {
+    if (!state.source1) return;
+    var src = state.source1.sources[index];
+    state.source1.currentIndex = index;
+    var player = document.getElementById('tv-player');
+    if (window._hls) { window._hls.destroy(); window._hls = null; }
+    player.src = src.url;
+    player.dataset.fallbackVideoId = state.source1.videoId;
+    document.querySelectorAll('#source-quality .quality-btn').forEach(function(b, i) {
+        b.classList.toggle('active', i === index);
+    });
+    document.getElementById('source-status').textContent = 'S' + state.source1.episode.season + 'E' + state.source1.episode.episode;
+    if (doPlay) {
+        player.play().catch(function() {
+            // Browser blocked autoplay with sound on fresh page load — fall back
+            // to muted autoplay, then unmute on the very next user interaction
+            // (click anywhere, keypress, etc.) so the viewer gets sound as soon
+            // as they touch the page instead of hunting for the volume icon.
+            player.muted = true;
+            player.play().catch(function() {});
+            unmuteOnFirstInteraction(player);
+        });
+    }
+}
+
+function unmuteOnFirstInteraction(player) {
+    if (player._unmuteArmed) return;
+    player._unmuteArmed = true;
+    var handler = function() {
+        if (player.muted) {
+            player.muted = false;
+            if (player.volume === 0) player.volume = 1;
+        }
+        document.removeEventListener('click', handler, true);
+        document.removeEventListener('keydown', handler, true);
+        document.removeEventListener('touchstart', handler, true);
+        player._unmuteArmed = false;
+    };
+    document.addEventListener('click', handler, true);
+    document.addEventListener('keydown', handler, true);
+    document.addEventListener('touchstart', handler, true);
+}
+
+function switchToSource2() {
+    if (!state.source2) return;
+    state.activeSource = 2;
+    setActiveTab(2);
+    var qualDiv = document.getElementById('source-quality');
+    qualDiv.innerHTML = '';
+    qualDiv.style.display = 'none';
+    playUrl(state.source2.url, state.source2.isHls ? 'hls' : 'mp4');
+    document.getElementById('source-status').textContent = state.source2.label || 'Externí zdroj';
+    applySubtitles(state.source2.subtitles || []);
+    document.querySelectorAll('.prehrajto-item.active').forEach(function(el) { el.classList.remove('active'); });
+    if (state.source2.activeItem) state.source2.activeItem.classList.add('active');
+}
+
+function setActiveTab(n) {
+    var t1 = document.getElementById('tab-source-1');
+    var t2 = document.getElementById('tab-source-2');
+    if (t1) t1.classList.toggle('active', n === 1);
+    if (t2) t2.classList.toggle('active', n === 2);
+}
+
+function ensureSource2Tab() {
+    if (document.getElementById('tab-source-2')) return;
+    var tabs = document.getElementById('source-tabs');
+    var btn = document.createElement('button');
+    btn.className = 'source-tab';
+    btn.id = 'tab-source-2';
+    btn.textContent = 'Zdroj 2';
+    btn.onclick = switchToSource2;
+    tabs.appendChild(btn);
+}
+
+function loadPrehrajtoForEpisode(season, episode) {
+    var section = document.getElementById('prehrajto-section');
+    var container = document.getElementById('prehrajto-results');
+    if (!section || !container) return;
+    section.style.display = '';
+    container.innerHTML = '<div class="pt-loading">Hledám další zdroje...</div>';
+    var sStr = season < 10 ? '0' + season : '' + season;
+    var eStr = episode < 10 ? '0' + episode : '' + episode;
+    var query = showTitle + ' S' + sStr + 'E' + eStr;
+
+    fetch('/api/movies/search?q=' + encodeURIComponent(query))
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+            container.innerHTML = '';
+            var moreBtn = document.getElementById('prehrajto-more');
+            if (moreBtn) moreBtn.style.display = 'none';
+            if (!data.success || !data.movies || !data.movies.length) {
+                container.innerHTML = '<div class="pt-loading">Nic nenalezeno</div>';
+                return;
+            }
+            currentPrehrajto.all = data.movies.slice(0, 15);
+            currentPrehrajto.visibleCount = 3;
+            renderPrehrajto();
+            if (currentPrehrajto.all.length > currentPrehrajto.visibleCount && moreBtn) {
+                moreBtn.style.display = '';
+                moreBtn.textContent = 'Zobrazit další zdroje (' + (currentPrehrajto.all.length - currentPrehrajto.visibleCount) + ')';
+                moreBtn.onclick = function() {
+                    currentPrehrajto.visibleCount = currentPrehrajto.all.length;
+                    renderPrehrajto();
+                    moreBtn.style.display = 'none';
+                    validatePrehrajto(currentPrehrajto.all);
+                };
+            }
+            validatePrehrajto(currentPrehrajto.all.slice(0, currentPrehrajto.visibleCount));
+        })
+        .catch(function() { container.innerHTML = '<div class="pt-loading">Chyba při hledání</div>'; });
+}
+
+function buildPrehrajtoItem(movie) {
+    var item = document.createElement('button');
+    item.type = 'button';
+    item.className = 'prehrajto-item';
+    item.dataset.movieUrl = movie.url;
+    var cached = resolvedSources[movie.url];
+    item.dataset.height = cached && cached.height ? cached.height : 0;
+    var year = movie.year ? ' (' + movie.year + ')' : '';
+    var tooltip = (movie.title || 'Další zdroj') + year;
+    item.title = tooltip;
+    item.setAttribute('alt', tooltip);
+    item.onclick = function() { playPrehrajtoEpisode(movie, item); };
+    var thumb = movie.thumbnail
+        ? '<img src="/api/movies/thumb?url=' + encodeURIComponent(movie.thumbnail) + '" alt="' + (movie.title || 'Náhled') + '" title="' + (movie.title || '') + '">'
+        : '';
+    var badges = '';
+    if (cached) {
+        badges += cached.isDirect
+            ? '<span class="pt-badge direct" title="Přímý zdroj">Přímý</span>'
+            : '<span class="pt-badge proxy" title="Přes proxy">Proxy</span>';
+        // Real video resolution from prehraj.to microdata (not the filename —
+        // "1080p" in a candidate title is often a lie). Same logic as film_detail.
+        if (cached.height) {
+            var qCls = cached.height >= 1080 ? 'quality-hd' : (cached.height >= 720 ? 'quality-sd' : 'quality-low');
+            badges += '<span class="pt-badge ' + qCls + '" title="Skutečné rozlišení streamu">' + cached.height + 'p</span>';
+        }
+        if (cached.subtitles && cached.subtitles.length) badges += '<span class="cc-badge-sm" title="České titulky dostupné">CC</span>';
+        if (cached.duration_sec) {
+            var mm = Math.round(cached.duration_sec / 60);
+            badges += '<span class="pt-badge-dur" title="Délka videa">' + mm + ' min</span>';
+        }
+    }
+    item.innerHTML = thumb
+        + '<div class="pt-info"><span class="pt-title">' + (movie.title || '') + year + badges + '</span></div>'
+        + '<span class="play-indicator">▶</span>';
+    return item;
+}
+
+function renderPrehrajto() {
+    var container = document.getElementById('prehrajto-results');
+    if (!container) return;
+    var all = currentPrehrajto.all.slice();
+    // Primary key: direct > proxy > not-yet-validated.
+    // Secondary key (within each group): height DESC so 1080p > 720p > 480p > 304p.
+    all.sort(function(a, b) {
+        var ra = resolvedSources[a.url]; var rb = resolvedSources[b.url];
+        var ga = ra ? (ra.isDirect ? 0 : 1) : 2;
+        var gb = rb ? (rb.isDirect ? 0 : 1) : 2;
+        if (ga !== gb) return ga - gb;
+        var ha = ra && ra.height ? ra.height : 0;
+        var hb = rb && rb.height ? rb.height : 0;
+        return hb - ha;
+    });
+    container.innerHTML = '';
+    all.slice(0, currentPrehrajto.visibleCount).forEach(function(movie) {
+        container.appendChild(buildPrehrajtoItem(movie));
+    });
+    if (state.source2 && state.source2.movie) {
+        var it = container.querySelector('.prehrajto-item[data-movie-url="' + state.source2.movie.url.replace(/"/g, '\\"') + '"]');
+        if (it) { it.classList.add('active'); state.source2.activeItem = it; }
+    }
+}
+
+function validatePrehrajto(movies) {
+    movies.forEach(function(movie) {
+        if (resolvedSources[movie.url]) return;
+        fetch('/api/movies/validate?url=' + encodeURIComponent(movie.url))
+            .then(function(r) { return r.json(); })
+            .then(function(vdata) {
+                var isDirect = !!vdata.valid;
+                var height = vdata.height || null;
+                var duration_sec = vdata.duration_sec || null;
+                return fetch('/api/movies/video-url?url=' + encodeURIComponent(movie.url))
+                    .then(function(r) { return r.json(); })
+                    .then(function(data) {
+                        if (!data.success || !data.video_url) return;
+                        resolvedSources[movie.url] = {
+                            video_url: data.video_url.replace(/&amp;/g, '&'),
+                            subtitles: data.subtitles || [],
+                            isDirect: isDirect,
+                            height: height,
+                            duration_sec: duration_sec,
+                        };
+                        renderPrehrajto();
+                    });
+            })
+            .catch(function() {});
+    });
+}
+
+function playPrehrajtoEpisode(movie, item) {
+    var player = document.getElementById('tv-player');
+    var status = document.getElementById('source-status');
+    if (!player) return;
+    document.getElementById('player-section') && document.querySelector('.player-section').scrollIntoView({ behavior: 'smooth', block: 'start' });
+
+    function useResolved(resolved) {
+        var url = resolved.video_url;
+        var isHls = url.indexOf('.m3u8') !== -1;
+        state.source2 = {
+            movie: movie, url: url, isHls: isHls,
+            subtitles: resolved.subtitles || [], activeItem: item, label: movie.title || 'Externí zdroj',
+        };
+        ensureSource2Tab();
+        switchToSource2();
+    }
+    var cached = resolvedSources[movie.url];
+    if (cached) { useResolved(cached); return; }
+
+    item.classList.add('loading');
+    if (status) status.textContent = 'Načítání...';
+    fetch('/api/movies/video-url?url=' + encodeURIComponent(movie.url))
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+            item.classList.remove('loading');
+            if (!data.success || !data.video_url) { if (status) status.textContent = 'Zdroj nedostupný'; return; }
+            var resolved = { video_url: data.video_url.replace(/&amp;/g, '&'), subtitles: data.subtitles || [] };
+            resolvedSources[movie.url] = resolved;
+            useResolved(resolved);
+        })
+        .catch(function(e) { item.classList.remove('loading'); if (status) status.textContent = 'Chyba: ' + e.message; });
+}
+
+function playUrl(url, format) {
+    var player = document.getElementById('tv-player');
+    if (window._hls) { window._hls.destroy(); window._hls = null; }
+    if (format === 'hls' && window.Hls && Hls.isSupported()) {
+        var hls = new Hls(); hls.loadSource(url); hls.attachMedia(player);
+        hls.on(Hls.Events.MANIFEST_PARSED, function() { player.play().catch(function(){}); });
+        window._hls = hls;
+    } else {
+        player.src = url; player.play().catch(function(){});
+    }
+}
+
+function applySubtitles(subtitles) {
+    var player = document.getElementById('tv-player');
+    player.querySelectorAll('track').forEach(function(t) { t.remove(); });
+    if (!subtitles || !subtitles.length) {
+        var c0 = document.getElementById('subtitle-controls');
+        if (c0) c0.style.display = 'none';
+        if (_subPoll) { clearInterval(_subPoll); _subPoll = null; }
+        return;
+    }
+    subtitles.forEach(function(sub) {
+        var track = document.createElement('track');
+        track.kind = 'subtitles';
+        track.label = sub.label || (sub.lang || '').toUpperCase();
+        track.srclang = sub.lang || '';
+        track.src = '/api/movies/subtitle?url=' + encodeURIComponent(sub.url);
+        if (sub.lang === 'cze' || sub.lang === 'cs') track.default = true;
+        player.appendChild(track);
+    });
+    var tt = player.textTracks;
+    var cz = false;
+    for (var i = 0; i < tt.length; i++) {
+        if (!cz && (tt[i].language === 'cze' || tt[i].language === 'cs')) { tt[i].mode = 'showing'; cz = true; }
+        else tt[i].mode = 'hidden';
+    }
+    if (!cz && tt.length > 0) tt[0].mode = 'showing';
+    setSubSize(document.getElementById('sub-size-select').value || 20);
+    var controls = document.getElementById('subtitle-controls');
+    if (controls) {
+        function update() {
+            var any = false;
+            for (var j = 0; j < tt.length; j++) if (tt[j].mode === 'showing') { any = true; break; }
+            controls.style.display = any ? 'flex' : 'none';
+        }
+        for (var k = 0; k < tt.length; k++) tt[k].addEventListener('cuechange', update);
+        if (_subPoll) clearInterval(_subPoll);
+        _subPoll = setInterval(update, 1000);
+        update();
+    }
+}
+
+function setSubSize(px) {
+    var style = document.getElementById('sub-cue-style');
+    if (!style) { style = document.createElement('style'); style.id = 'sub-cue-style'; document.head.appendChild(style); }
+    style.textContent = 'video::cue { font-size: ' + px + 'px !important; }';
+}
+
+/* SK Torrent CDN fallback */
+(function() {
+    var player = document.getElementById('tv-player');
+    var tried = false;
+    player.addEventListener('error', function() {
+        if (tried || state.activeSource !== 1) return;
+        var vid = player.dataset.fallbackVideoId;
+        if (!vid || !player.src || player.src.indexOf('sktorrent.eu') === -1) return;
+        tried = true;
+        document.getElementById('source-status').textContent = 'Hledám aktuální zdroj...';
+        fetch('/api/films/sktorrent-resolve?video_id=' + vid)
+            .then(function(r) { return r.json(); })
+            .then(function(data) {
+                if (!data.sources || !data.sources.length) {
+                    document.getElementById('source-status').textContent = 'Zdroj nedostupný';
+                    return;
+                }
+                var fresh = data.sources.map(function(s) { return { url: s.url, quality: s.quality, res: s.res }; });
+                fresh.sort(function(a, b) { return b.res - a.res; });
+                state.source1.sources = fresh;
+                state.source1.currentIndex = 0;
+                renderQualityButtons1();
+                playQuality1(0, true);
+                setTimeout(function() { tried = false; }, 5000);
+            })
+            .catch(function() { document.getElementById('source-status').textContent = 'Chyba obnovy zdroje'; });
+    }, true);
+})();
+
+/* Header search autocomplete */
+function doSearch() {
+    var q = document.getElementById('tv-search').value.trim();
+    if (q.length >= 2) window.location = '/tv-porady/?q=' + encodeURIComponent(q);
+}
+(function() {
+    var input = document.getElementById('tv-search');
+    var dd = document.getElementById('search-results');
+    var timer = null;
+    if (!input || !dd) return;
+    input.addEventListener('input', function() {
+        clearTimeout(timer);
+        var q = this.value.trim();
+        if (q.length < 2) { dd.classList.remove('open'); return; }
+        timer = setTimeout(function() {
+            fetch('/api/tv-porady/search?q=' + encodeURIComponent(q))
+                .then(function(r) { return r.json(); })
+                .then(function(results) {
+                    if (!results.length) { dd.innerHTML = '<div style="padding:0.8rem;color:#888;text-align:center">Nic nenalezeno</div>'; }
+                    else {
+                        dd.innerHTML = results.map(function(r) {
+                            var cover = r.cover
+                                ? '<img src="/tv-porady/' + r.slug + '.webp" alt="' + r.title + '" title="' + r.title + '">'
+                                : '<div class="si-placeholder"></div>';
+                            var yr = r.year ? ' (' + r.year + ')' : '';
+                            var rat = r.imdb_rating ? ' — IMDB ' + r.imdb_rating : '';
+                            return '<a href="/tv-porady/' + r.slug + '/" class="search-item" alt="' + r.title + '" title="' + r.title + '">'
+                                + cover + '<div class="si-info"><span class="si-title">' + r.title + yr + '</span>'
+                                + '<span class="si-meta">' + rat + '</span></div></a>';
+                        }).join('');
+                    }
+                    dd.classList.add('open');
+                })
+                .catch(function() { dd.classList.remove('open'); });
+        }, 200);
+    });
+    document.addEventListener('click', function(e) { if (!e.target.closest('#header-search-box')) dd.classList.remove('open'); });
+    input.addEventListener('keydown', function(e) { if (e.key === 'Enter') { e.preventDefault(); doSearch(); } });
+})();
+
+initPlayer();
+</script>
+{% endblock %}

--- a/cr-web/templates/tv_porad_detail.html
+++ b/cr-web/templates/tv_porad_detail.html
@@ -1,0 +1,226 @@
+{% extends "base.html" %}
+
+{% block title %}{{ show.title }}{% match show.first_air_year %}{% when Some with (y) %} ({{ y }}){% when None %}{% endmatch %} — TV pořad online{% endblock %}
+
+{% block meta_description %}{% match show.description %}{% when Some with (d) %}{{ d }}{% when None %}{{ show.title }} — sledujte TV pořad online na ceskarepublika.wiki{% endmatch %}{% endblock %}
+
+{% block og_title %}{{ show.title }}{% match show.first_air_year %}{% when Some with (y) %} ({{ y }}){% when None %}{% endmatch %} — TV pořad online{% endblock %}
+{% block og_description %}{% match show.description %}{% when Some with (d) %}{{ d }}{% when None %}{{ show.title }} — TV pořad online zdarma{% endmatch %}{% endblock %}
+{% block og_image %}{% match show.cover_filename %}{% when Some with (c) %}https://ceskarepublika.wiki/tv-porady/{{ show.slug }}.webp{% when None %}https://ceskarepublika.wiki/static/img/og-filmy-a-serialy-v6.png{% endmatch %}{% endblock %}
+{% block og_type %}video.tv_show{% endblock %}
+
+{% block leaflet %}{% endblock %}
+
+{% block head %}
+<link rel="icon" type="image/svg+xml" href="/static/img/logo-filmy-a-serialy.svg?v=6">
+<meta property="og:url" content="https://ceskarepublika.wiki/tv-porady/{{ show.slug }}/">
+{% endblock %}
+
+{% block header_left %}
+<div class="logo-group" style="display:flex;align-items:center;gap:0.5rem;">
+    <a href="/tv-porady/" style="display:flex;align-items:center;text-decoration:none;" alt="TV pořady" title="TV pořady">
+        <img src="/static/img/logo-filmy-a-serialy.svg?v=6" alt="Logo TV pořady" title="TV pořady" class="header-emblem">
+    </a>
+    <h1>{{ show.title }}</h1>
+</div>
+{% endblock %}
+
+{% block header_search %}
+<div class="search-container" id="header-search-box">
+    <input type="text" id="tv-search" class="search-input" placeholder="Hledat TV pořad..." autocomplete="off">
+    <button class="search-btn" onclick="doSearch()" alt="Hledat" title="Hledat">Hledat</button>
+</div>
+{% endblock %}
+
+{% block header_right %}<div class="context-emblem"></div>{% endblock %}
+
+{% block content %}
+<main class="series-detail-page">
+    <nav class="breadcrumb">
+        <a href="/" alt="Česká republika" title="Česká republika">Česká republika</a>
+        <span>›</span> <a href="/tv-porady/" alt="TV pořady" title="TV pořady">TV pořady</a>
+        <span>›</span> <span>{{ show.title }}</span>
+    </nav>
+
+    <div class="film-hero">
+        <div class="film-cover">
+            {% match show.cover_filename %}
+            {% when Some with (c) %}
+            <div class="cover-zoom" data-gallery-open="show" data-index="0"
+                 data-gallery-photos="[&quot;/tv-porady/{{ show.slug }}-large.webp&quot;]">
+                <img src="/tv-porady/{{ show.slug }}.webp" alt="{{ show.title }}" title="{{ show.title }}" width="200" height="300">
+            </div>
+            {% when None %}
+            <div class="no-cover">{{ show.title }}</div>
+            {% endmatch %}
+        </div>
+        <div class="film-meta">
+            <h2>{{ show.title }}{% match show.first_air_year %}{% when Some with (y) %} <span class="year">({{ y }}{% match show.last_air_year %}{% when Some with (ly) %}{% if ly != y %}–{{ ly }}{% endif %}{% when None %}{% endmatch %})</span>{% when None %}{% endmatch %}</h2>
+            {% match show.original_title %}
+            {% when Some with (ot) %}{% if ot.as_str() != show.title.as_str() %}<p class="original-title">{{ ot }}</p>{% endif %}
+            {% when None %}{% endmatch %}
+            <div class="meta-row">
+                {% match show.imdb_rating %}
+                {% when Some with (r) %}<span class="meta-badge imdb" title="IMDB hodnocení">IMDB {{ r }}</span>
+                {% when None %}{% endmatch %}
+                {% match show.csfd_rating %}
+                {% when Some with (r) %}<span class="meta-badge csfd" title="ČSFD hodnocení">ČSFD {{ r }}%</span>
+                {% when None %}{% endmatch %}
+            </div>
+            {% match show.description %}
+            {% when Some with (d) %}<div class="film-description"><p>{{ d }}</p></div>
+            {% when None %}{% endmatch %}
+        </div>
+    </div>
+
+    <div class="seasons-section">
+        <div class="seasons-header">
+            <h3>Epizody</h3>
+            <div class="films-toolbar">
+                <button class="view-btn view-toggle" id="btn-view-toggle" onclick="toggleEpView()" alt="Přepnout zobrazení" title="Přepnout zobrazení mřížka / seznam">
+                    <svg class="view-icon-grid" width="18" height="18" viewBox="0 0 18 18"><rect x="1" y="2" width="16" height="3" rx="1" fill="currentColor"/><rect x="1" y="7.5" width="16" height="3" rx="1" fill="currentColor"/><rect x="1" y="13" width="16" height="3" rx="1" fill="currentColor"/></svg>
+                    <svg class="view-icon-list" width="18" height="18" viewBox="0 0 18 18" style="display:none;"><rect x="1" y="1" width="7" height="7" rx="1" fill="currentColor"/><rect x="10" y="1" width="7" height="7" rx="1" fill="currentColor"/><rect x="1" y="10" width="7" height="7" rx="1" fill="currentColor"/><rect x="10" y="10" width="7" height="7" rx="1" fill="currentColor"/></svg>
+                </button>
+            </div>
+        </div>
+
+        {% for season in seasons %}
+        <div class="season-block collapsed" data-season="{{ season.number }}">
+            <button class="season-title season-toggle" type="button" onclick="toggleSeason({{ season.number }})"
+                    alt="Sbalit nebo rozbalit sérii" title="Sbalit nebo rozbalit sérii">
+                <span class="chev">▾</span>
+                {% if season.number == 0 %}Speciály{% else %}{{ season.number }}. série{% endif %}
+                <span class="ep-count">({{ season.episodes.len() }} epizod)</span>
+            </button>
+            <div class="episode-grid" id="season-{{ season.number }}">
+                {% for ep in season.episodes %}
+                <a class="episode-card" href="/tv-porady/{{ show.slug }}/{% match ep.slug %}{% when Some with (s) %}{{ s }}{% when None %}{{ ep.season }}x{{ ep.episode }}{% endmatch %}/"
+                   alt="S{{ ep.season }}E{{ ep.episode }}{% match ep.episode_name %}{% when Some with (n) %} — {{ n }}{% when None %}{% endmatch %}"
+                   title="S{{ ep.season }}E{{ ep.episode }}{% match ep.episode_name %}{% when Some with (n) %} — {{ n }}{% when None %}{% endmatch %}">
+                    <div class="ep-head">
+                        <span class="ep-badge">S{{ "{:02}"|format(ep.season) }}E{{ "{:02}"|format(ep.episode) }}</span>
+                        <h5 class="ep-title">{% match ep.episode_name %}{% when Some with (n) %}{% if !n.is_empty() && !n.starts_with(char::is_numeric) %}{{ n }}{% else %}Epizoda {{ ep.episode }}{% endif %}{% when None %}Epizoda {{ ep.episode }}{% endmatch %}</h5>
+                    </div>
+                    <div class="ep-meta">
+                        {% match ep.air_date %}{% when Some with (d) %}<span>📅 {{ d }}</span>{% when None %}{% endmatch %}
+                        {% match ep.runtime %}{% when Some with (r) %}<span>⏱ {{ r }} min</span>{% when None %}{% endmatch %}
+                    </div>
+                    {% match ep.overview %}{% when Some with (o) %}<p class="ep-overview">{{ o }}</p>{% when None %}{% endmatch %}
+                </a>
+                {% endfor %}
+            </div>
+        </div>
+        {% endfor %}
+    </div>
+</main>
+
+<style>
+.series-detail-page { max-width: 1200px; margin: 0 auto; padding: 1rem; }
+.breadcrumb { font-size: 0.85rem; color: #888; margin-bottom: 1.2rem; }
+.breadcrumb a { color: #11457E; text-decoration: none; }
+
+.film-hero { display: flex; gap: 1.5rem; margin-bottom: 1.5rem; }
+@media (max-width: 600px) { .film-hero { flex-direction: column; align-items: center; } }
+.film-cover { flex-shrink: 0; width: 200px; }
+.film-cover img { width: 200px; border-radius: 8px; box-shadow: 0 2px 12px rgba(0,0,0,0.2); display: block; }
+.cover-zoom { cursor: zoom-in; display: inline-block; border-radius: 8px; overflow: hidden; }
+.no-cover { width: 200px; height: 300px; background: #222; border-radius: 8px; display: flex; align-items: center; justify-content: center; color: #888; padding: 1rem; text-align: center; }
+.film-meta h2 { margin: 0 0 0.4rem; font-size: 1.5rem; }
+.film-meta .year { color: #888; font-weight: 400; }
+.original-title { color: #888; font-style: italic; margin: 0 0 0.6rem; font-size: 0.9rem; }
+.meta-row { display: flex; gap: 0.4rem; margin-bottom: 0.8rem; }
+.meta-badge { padding: 0.2rem 0.5rem; border-radius: 4px; font-size: 0.82rem; font-weight: 600; }
+.meta-badge.imdb { background: #f5c518; color: #000; }
+.meta-badge.csfd { background: #ba0305; color: #fff; }
+.film-description { line-height: 1.6; color: #333; }
+
+.seasons-header { display: flex; justify-content: space-between; align-items: center; margin: 1rem 0 0.8rem; }
+.seasons-section h3 { font-size: 1.2rem; margin: 0; color: #333; }
+.films-toolbar { display: flex; gap: 0.4rem; }
+.view-btn { background: #f1f5f9; color: #555; border: none; padding: 0.4rem 0.7rem; border-radius: 6px; cursor: pointer; display: inline-flex; align-items: center; transition: background 0.15s; }
+.view-btn:hover { background: #e2e8f0; }
+.season-block { margin-bottom: 1.5rem; }
+.season-toggle { display: flex; align-items: center; gap: 0.5rem; width: 100%; background: #f1f5f9; border: none; padding: 0.6rem 0.9rem; border-radius: 8px; font-size: 1rem; font-weight: 600; color: #11457E; cursor: pointer; text-align: left; margin: 0.8rem 0 0.6rem; transition: background 0.15s; }
+.season-toggle:hover { background: #e2e8f0; }
+.season-toggle .chev { display: inline-block; transition: transform 0.15s; font-size: 0.8rem; }
+.season-block.collapsed .season-toggle .chev { transform: rotate(-90deg); }
+.season-block.collapsed .episode-grid { display: none; }
+.season-toggle .ep-count { color: #888; font-weight: 400; font-size: 0.85rem; margin-left: auto; }
+
+.episode-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 0.5rem; }
+.episode-card { display: block; background: white; border-radius: 8px; padding: 0.7rem 0.9rem; box-shadow: 0 1px 3px rgba(0,0,0,0.08); text-decoration: none; color: inherit; transition: transform 0.15s, box-shadow 0.15s; }
+.episode-card:hover { transform: translateY(-1px); box-shadow: 0 4px 10px rgba(0,0,0,0.12); }
+.ep-head { display: flex; align-items: baseline; gap: 0.5rem; margin-bottom: 0.25rem; }
+.ep-badge { flex-shrink: 0; background: #f1f5f9; color: #11457E; padding: 0.15rem 0.5rem; border-radius: 4px; font-size: 0.72rem; font-weight: 700; letter-spacing: 0.02em; transition: background 0.15s, color 0.15s; }
+.episode-card:hover .ep-badge { background: #11457E; color: white; }
+.ep-title { margin: 0; font-size: 0.9rem; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; min-width: 0; }
+.ep-meta { display: flex; gap: 0.6rem; font-size: 0.75rem; color: #888; flex-wrap: wrap; }
+.ep-overview { display: none; font-size: 0.82rem; color: #555; margin: 0.4rem 0 0; line-height: 1.4; }
+
+.episode-grid.list-view { grid-template-columns: 1fr; }
+.episode-grid.list-view .episode-card { padding: 0.8rem 1rem; }
+.episode-grid.list-view .ep-title { white-space: normal; }
+.episode-grid.list-view .ep-overview { display: block; }
+</style>
+
+<script>
+function toggleSeason(num) {
+    var block = document.querySelector('.season-block[data-season="' + num + '"]');
+    if (!block) return;
+    block.classList.toggle('collapsed');
+    var key = 'tvSeasonsCollapsed:' + location.pathname;
+    var state = {};
+    try { state = JSON.parse(localStorage.getItem(key) || '{}'); } catch (e) {}
+    state[num] = block.classList.contains('collapsed');
+    localStorage.setItem(key, JSON.stringify(state));
+}
+(function() {
+    var key = 'tvSeasonsCollapsed:' + location.pathname;
+    var state = {};
+    try { state = JSON.parse(localStorage.getItem(key) || '{}'); } catch (e) {}
+    Object.keys(state).forEach(function(num) {
+        var block = document.querySelector('.season-block[data-season="' + num + '"]');
+        if (!block) return;
+        if (state[num] === false) block.classList.remove('collapsed');
+    });
+})();
+
+function setEpView(mode) {
+    document.querySelectorAll('.episode-grid').forEach(function(g) {
+        g.classList.toggle('list-view', mode === 'list');
+    });
+    var iconGrid = document.querySelector('.view-icon-grid');
+    var iconList = document.querySelector('.view-icon-list');
+    if (iconGrid) iconGrid.style.display = (mode === 'list') ? 'none' : '';
+    if (iconList) iconList.style.display = (mode === 'list') ? '' : 'none';
+    localStorage.setItem('tvEpView', mode);
+}
+function toggleEpView() {
+    var cur = localStorage.getItem('tvEpView') || 'grid';
+    setEpView(cur === 'list' ? 'grid' : 'list');
+}
+(function() {
+    var saved = localStorage.getItem('tvEpView');
+    if (saved === 'list') setEpView('list');
+})();
+
+function doSearch() {
+    var q = document.getElementById('tv-search').value.trim();
+    if (q.length >= 2) window.location = '/tv-porady/?q=' + encodeURIComponent(q);
+}
+(function() {
+    var input = document.getElementById('tv-search');
+    if (!input) return;
+    input.addEventListener('keydown', function(e) { if (e.key === 'Enter') { e.preventDefault(); doSearch(); } });
+})();
+
+(function() {
+    var params = new URLSearchParams(window.location.search);
+    var s = parseInt(params.get('s'), 10);
+    var e = parseInt(params.get('e'), 10);
+    if (s && e) {
+        window.location.replace(window.location.pathname + s + 'x' + e + '/');
+    }
+})();
+</script>
+{% endblock %}

--- a/cr-web/templates/tv_porady_list.html
+++ b/cr-web/templates/tv_porady_list.html
@@ -1,0 +1,281 @@
+{% extends "base.html" %}
+
+{% block title %}TV pořady online{% endblock %}
+
+{% block meta_description %}TV pořady online zdarma — {{ total_count }} pořadů ke zhlédnutí na ceskarepublika.wiki.{% endblock %}
+
+{% block og_title %}TV pořady — ceskarepublika.wiki{% endblock %}
+{% block og_description %}TV pořady online zdarma — {{ total_count }} pořadů ke zhlédnutí.{% endblock %}
+{% block og_image %}https://ceskarepublika.wiki/static/img/og-filmy-a-serialy-v6.png{% endblock %}
+{% block og_type %}article{% endblock %}
+
+{% block leaflet %}{% endblock %}
+
+{% block head %}
+<link rel="icon" type="image/svg+xml" href="/static/img/logo-filmy-a-serialy.svg?v=6">
+<meta property="og:image:secure_url" content="https://ceskarepublika.wiki/static/img/og-filmy-a-serialy-v6.png">
+<meta property="og:image:type" content="image/png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:alt" content="TV pořady — ceskarepublika.wiki">
+<meta property="og:url" content="https://ceskarepublika.wiki/tv-porady/">
+{% endblock %}
+
+{% block header_left %}
+<div class="logo-group" style="display:flex;align-items:center;gap:0.5rem;">
+    <a href="/tv-porady/" style="display:flex;align-items:center;text-decoration:none;" alt="TV pořady" title="TV pořady">
+        <img src="/static/img/logo-filmy-a-serialy.svg?v=6" alt="Logo TV pořady" title="TV pořady" class="header-emblem">
+    </a>
+    <h1>TV pořady</h1>
+</div>
+{% endblock %}
+
+{% block header_search %}
+<div class="search-container" id="header-search-box">
+    <input type="text" id="tv-search" class="search-input" placeholder="Hledat TV pořad..." autocomplete="off" {% match search_query %}{% when Some with (q) %}value="{{ q }}"{% when None %}{% endmatch %}>
+    <button class="search-btn" onclick="doSearch()">Hledat</button>
+</div>
+{% endblock %}
+
+{% block header_right %}<div class="context-emblem"></div>{% endblock %}
+
+{% block content %}
+<main class="series-page">
+<nav class="breadcrumb">
+    <a href="/" alt="Česká republika" title="Česká republika">Česká republika</a>
+    <span>›</span> <a href="/tv-porady/" alt="TV pořady" title="TV pořady">TV pořady</a>
+</nav>
+
+<div class="films-header">
+    <h2>
+        {% match search_query %}
+        {% when Some with (q) %}Výsledky hledání pro „{{ q }}" <span class="count">({{ total_count }})</span>
+        {% when None %}Nejnovější epizody z {{ total_count }} TV pořadů
+        {% endmatch %}
+    </h2>
+    <div class="films-toolbar">
+        <label class="toolbar-group">
+            <span class="toolbar-label">Řazení:</span>
+            <select id="sort-select" onchange="applySortCombined(this.value)" aria-label="Řazení" class="sort-select-combined">
+                <option value="pridano:desc">Naposledy přidané</option>
+                <option value="rok:desc">Od nejnovějších</option>
+                <option value="imdb:desc">Nejlépe hodnocené IMDB</option>
+                <option value="nazev:asc">Podle názvu A–Z</option>
+            </select>
+        </label>
+        <button class="view-btn view-toggle" id="btn-view-toggle" onclick="toggleView()" aria-label="Přepnout zobrazení mřížka / seznam">
+            <svg class="view-icon-grid" width="18" height="18" viewBox="0 0 18 18"><rect x="1" y="2" width="16" height="3" rx="1" fill="currentColor"/><rect x="1" y="7.5" width="16" height="3" rx="1" fill="currentColor"/><rect x="1" y="13" width="16" height="3" rx="1" fill="currentColor"/></svg>
+            <svg class="view-icon-list" width="18" height="18" viewBox="0 0 18 18" style="display:none;"><rect x="1" y="1" width="7" height="7" rx="1" fill="currentColor"/><rect x="10" y="1" width="7" height="7" rx="1" fill="currentColor"/><rect x="1" y="10" width="7" height="7" rx="1" fill="currentColor"/><rect x="10" y="10" width="7" height="7" rx="1" fill="currentColor"/></svg>
+        </button>
+    </div>
+</div>
+
+{# Main grid: episodes (default) or shows (search mode) #}
+{% if !episodes.is_empty() %}
+<div class="films-grid" id="films-container">
+    {% for ep in episodes %}
+    <a href="/tv-porady/{{ ep.tv_show_slug }}/{% match ep.episode_slug %}{% when Some with (s) %}{{ s }}{% when None %}{{ ep.season }}x{{ ep.episode }}{% endmatch %}/" class="film-card" title="{{ ep.tv_show_title }} — S{{ ep.season }}E{{ ep.episode }}">
+        <div class="film-poster">
+            {% match ep.tv_show_cover_filename %}
+            {% when Some with (c) %}
+            <img src="/tv-porady/{{ ep.tv_show_slug }}.webp" alt="{{ ep.tv_show_title }}" title="{{ ep.tv_show_title }}" loading="lazy" width="200" height="300">
+            {% when None %}
+            <div class="no-poster">{{ ep.tv_show_title }}</div>
+            {% endmatch %}
+            <div class="rating-badges">
+                {% match ep.tv_show_imdb_rating %}
+                {% when Some with (r) %}<span class="rating-badge imdb" title="IMDB hodnocení">{{ r }}</span>{% when None %}{% endmatch %}
+                {% match ep.tv_show_csfd_rating %}
+                {% when Some with (r) %}<span class="rating-badge csfd" title="ČSFD hodnocení">{{ r }}%</span>{% when None %}{% endmatch %}
+            </div>
+            {% if ep.has_subtitles.unwrap_or(false) %}
+            <span class="cc-badge" title="České titulky">CC</span>
+            {% endif %}
+        </div>
+        <div class="film-body">
+            <div class="film-info">
+                <span class="film-title">{{ ep.tv_show_title }}</span>
+                {% match ep.tv_show_original_title %}{% when Some with (ot) %}{% if ot.as_str() != ep.tv_show_title.as_str() %}<span class="film-original">{{ ot }}</span>{% endif %}{% when None %}{% endmatch %}
+                <span class="film-episode-label">{% match ep.episode_name %}{% when Some with (n) %}{% if !n.is_empty() && !n.starts_with(char::is_numeric) %}{{ n }} {% endif %}{% when None %}{% endmatch %}S{{ "{:02}"|format(ep.season) }}E{{ "{:02}"|format(ep.episode) }}</span>
+            </div>
+            <div class="film-list-extra">
+                <div class="film-ratings">
+                    {% match ep.tv_show_imdb_rating %}{% when Some with (r) %}<span class="badge imdb">IMDB {{ r }}</span>{% when None %}{% endmatch %}
+                    {% match ep.tv_show_csfd_rating %}{% when Some with (r) %}<span class="badge csfd">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
+                    {% match ep.tv_show_first_air_year %}{% when Some with (y) %}<span class="badge year">{{ y }}</span>{% when None %}{% endmatch %}
+                </div>
+                {% match ep.tv_show_description %}{% when Some with (d) %}<p class="film-desc">{{ d }}</p>{% when None %}{% endmatch %}
+            </div>
+        </div>
+    </a>
+    {% endfor %}
+</div>
+{% else %}
+<div class="films-grid" id="films-container">
+    {% for s in shows %}
+    <a href="/tv-porady/{{ s.slug }}/" class="film-card" alt="{{ s.title }}" title="{{ s.title }}">
+        <div class="film-poster">
+            {% match s.cover_filename %}
+            {% when Some with (cover) %}
+            <img src="/tv-porady/{{ s.slug }}.webp" alt="{{ s.title }}" title="{{ s.title }}" loading="lazy" width="200" height="300">
+            {% when None %}
+            <div class="no-poster">{{ s.title }}</div>
+            {% endmatch %}
+            <div class="rating-badges">
+                {% match s.imdb_rating %}{% when Some with (r) %}<span class="rating-badge imdb" title="IMDB hodnocení">{{ r }}</span>{% when None %}{% endmatch %}
+                {% match s.csfd_rating %}{% when Some with (r) %}<span class="rating-badge csfd" title="ČSFD hodnocení">{{ r }}%</span>{% when None %}{% endmatch %}
+            </div>
+        </div>
+        <div class="film-body">
+            <div class="film-info">
+                <span class="film-title">{{ s.title }}</span>
+                {% match s.original_title %}{% when Some with (ot) %}{% if ot.as_str() != s.title.as_str() %}<span class="film-original">{{ ot }}</span>{% endif %}{% when None %}{% endmatch %}
+                {% match s.first_air_year %}{% when Some with (y) %}<span class="film-year">{{ y }}</span>{% when None %}{% endmatch %}
+            </div>
+            <div class="film-list-extra">
+                <div class="film-ratings">
+                    {% match s.imdb_rating %}{% when Some with (r) %}<span class="badge imdb">IMDB {{ r }}</span>{% when None %}{% endmatch %}
+                    {% match s.csfd_rating %}{% when Some with (r) %}<span class="badge csfd">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
+                </div>
+                {% match s.description %}{% when Some with (d) %}<p class="film-desc">{{ d }}</p>{% when None %}{% endmatch %}
+            </div>
+        </div>
+    </a>
+    {% endfor %}
+</div>
+{% endif %}
+
+{% if total_pages > 1 %}
+<nav class="pagination">
+    {% if page > 1 %}
+    <a href="?strana={{ page - 1 }}{{ query_string }}" class="page-link" alt="Předchozí stránka" title="Předchozí stránka">&laquo;</a>
+    {% endif %}
+    {% for p in 1..=total_pages %}
+    {% if p == page %}
+    <span class="page-link current">{{ p }}</span>
+    {% else %}
+    {% if p <= 2 || p > total_pages - 2 || (p >= page - 2 && p <= page + 2) %}
+    <a href="?strana={{ p }}{{ query_string }}" class="page-link" alt="Strana {{ p }}" title="Strana {{ p }}">{{ p }}</a>
+    {% else %}
+    {% if p == 3 && page > 5 %}<span class="page-dots">…</span>{% endif %}
+    {% if p == total_pages - 2 && page < total_pages - 4 %}<span class="page-dots">…</span>{% endif %}
+    {% endif %}
+    {% endif %}
+    {% endfor %}
+    {% if page < total_pages %}
+    <a href="?strana={{ page + 1 }}{{ query_string }}" class="page-link" alt="Další stránka" title="Další stránka">&raquo;</a>
+    {% endif %}
+</nav>
+{% endif %}
+</main>
+
+<style>
+.series-page { max-width: 1200px; margin: 0 auto; padding: 1rem; }
+.breadcrumb { font-size: 0.85rem; color: #888; margin: 0.5rem 0 1rem; }
+.breadcrumb a { color: #11457E; text-decoration: none; }
+.films-header { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 0.8rem; }
+.films-header h2 { margin: 0; font-size: 1.3rem; }
+.films-header .count { color: #888; font-weight: 400; }
+.films-toolbar { display: flex; align-items: center; gap: 0.4rem; }
+.toolbar-group { display: inline-flex; align-items: center; gap: 0.4rem; }
+.toolbar-label { font-size: 0.82rem; color: #555; font-weight: 500; }
+.sort-select-combined { padding: 0.4rem 0.7rem; border: 1px solid #ddd; border-radius: 6px; font-size: 0.85rem; cursor: pointer; background: white; min-width: 200px; }
+.view-btn { background: #f0f0f0; border: none; padding: 0.4rem; border-radius: 6px; cursor: pointer; color: #666; display: flex; align-items: center; transition: background 0.15s; }
+.view-btn:hover { background: #e0e0e0; }
+.view-toggle { background: #f1f5f9; color: #555; border-radius: 6px; padding: 0.4rem 0.7rem; }
+.films-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 1rem; }
+.films-grid .film-card { text-decoration: none; color: inherit; display: block; border-radius: 8px; overflow: hidden; background: white; box-shadow: 0 1px 4px rgba(0,0,0,0.1); transition: transform 0.15s, box-shadow 0.15s; }
+.films-grid .film-card:hover { transform: translateY(-2px); box-shadow: 0 4px 12px rgba(0,0,0,0.15); }
+.film-poster { aspect-ratio: 2/3; background: #222; position: relative; }
+.film-poster img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.no-poster { width: 100%; height: 100%; display: flex; align-items: center; justify-content: center; color: #888; padding: 1rem; text-align: center; }
+.rating-badges { position: absolute; top: 0.4rem; left: 0.4rem; display: flex; gap: 0.25rem; }
+.rating-badge { padding: 0.15rem 0.4rem; border-radius: 4px; font-size: 0.7rem; font-weight: 700; box-shadow: 0 1px 3px rgba(0,0,0,0.3); }
+.rating-badge.imdb { background: #f5c518; color: #000; }
+.rating-badge.csfd { background: #b01020; color: #fff; }
+.cc-badge { position: absolute; bottom: 0.4rem; right: 0.4rem; background: #4ade80; color: #003c1c; padding: 0.1rem 0.4rem; border-radius: 4px; font-size: 0.7rem; font-weight: 700; letter-spacing: 0.03em; box-shadow: 0 1px 3px rgba(0,0,0,0.3); }
+.film-body { padding: 0.6rem; }
+.film-info { display: flex; flex-direction: column; }
+.film-title { font-weight: 600; font-size: 0.95rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.film-original { font-size: 0.8rem; color: #888; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.film-year { font-size: 0.8rem; color: #555; }
+.film-episode-label { display: inline-block; padding: 0.15rem 0.5rem; border-radius: 999px; background: #f1f5f9; color: #11457E; font-size: 0.78rem; font-weight: 600; margin-top: 0.15rem; align-self: flex-start; transition: background 0.15s, color 0.15s; }
+.film-card:hover .film-episode-label { background: #11457E; color: white; }
+.film-list-extra { display: none; }
+.film-ratings { display: flex; gap: 0.3rem; margin: 0.3rem 0; flex-wrap: wrap; }
+.badge { font-size: 0.72rem; padding: 0.1rem 0.4rem; border-radius: 4px; font-weight: 600; }
+.badge.imdb { background: #f5c518; color: #000; }
+.badge.csfd { background: #b01020; color: #fff; }
+.badge.year { background: #e2e8f0; color: #333; }
+.film-desc { font-size: 0.8rem; color: #555; margin: 0.3rem 0 0; display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
+.films-grid.list-view { grid-template-columns: 1fr; }
+.films-grid.list-view .film-card { display: grid; grid-template-columns: 120px 1fr; }
+.films-grid.list-view .film-poster { aspect-ratio: 2/3; max-width: 120px; }
+.films-grid.list-view .film-body { padding: 0.8rem 1rem; }
+.films-grid.list-view .film-list-extra { display: block; }
+.pagination { display: flex; justify-content: center; align-items: center; gap: 0.3rem; margin: 2rem 0; flex-wrap: wrap; }
+.page-link { display: inline-flex; align-items: center; justify-content: center; padding: 0.4rem 0.8rem; border-radius: 999px; background: #f1f5f9; color: #11457E; text-decoration: none; font-size: 0.85rem; font-weight: 600; min-width: 2.2rem; transition: background 0.15s, color 0.15s; }
+.page-link:hover { background: #11457E; color: white; }
+.page-link.current { background: #C5A059; color: white; cursor: default; }
+.page-dots { padding: 0.4rem 0.2rem; color: #888; }
+</style>
+
+<script>
+function doSearch() {
+    var q = document.getElementById('tv-search').value.trim();
+    if (q.length >= 2) window.location = '/tv-porady/?q=' + encodeURIComponent(q);
+}
+
+function setView(mode) {
+    var c = document.getElementById('films-container');
+    var iconGrid = document.querySelector('.view-icon-grid');
+    var iconList = document.querySelector('.view-icon-list');
+    if (mode === 'list') {
+        c.classList.add('list-view');
+        if (iconGrid) iconGrid.style.display = 'none';
+        if (iconList) iconList.style.display = '';
+    } else {
+        c.classList.remove('list-view');
+        if (iconGrid) iconGrid.style.display = '';
+        if (iconList) iconList.style.display = 'none';
+    }
+    localStorage.setItem('tvPoradyView', mode);
+}
+function toggleView() {
+    var current = localStorage.getItem('tvPoradyView') || 'grid';
+    setView(current === 'list' ? 'grid' : 'list');
+}
+(function(){ var s = localStorage.getItem('tvPoradyView'); if (s === 'list') setView('list'); })();
+
+function applySortCombined(v) {
+    var field = v.split(':')[0];
+    var u = new URL(window.location);
+    if (field === 'pridano') u.searchParams.delete('razeni');
+    else u.searchParams.set('razeni', field);
+    u.searchParams.delete('strana');
+    window.location = u.toString();
+}
+(function() {
+    var urlParams = new URLSearchParams(window.location.search);
+    var razeni = urlParams.get('razeni') || 'pridano';
+    var sortSel = document.getElementById('sort-select');
+    if (sortSel) {
+        var target = razeni === 'nazev' ? 'nazev:asc' : razeni + ':desc';
+        for (var i = 0; i < sortSel.options.length; i++) {
+            if (sortSel.options[i].value === target) {
+                sortSel.selectedIndex = i;
+                break;
+            }
+        }
+    }
+})();
+
+(function() {
+    var input = document.getElementById('tv-search');
+    if (!input) return;
+    input.addEventListener('keydown', function(e) {
+        if (e.key === 'Enter') { e.preventDefault(); doSearch(); }
+    });
+})();
+</script>
+{% endblock %}

--- a/scripts/import-tv-porady.py
+++ b/scripts/import-tv-porady.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
-"""Import TMDB-matched TV pořady from staging to production series/episodes.
+"""Import TMDB-matched TV pořady from staging to production tv_shows/tv_episodes.
 
 Source: sktorrent_tv_porady (staging, 864 videos, 745 matched to TMDB)
-Target: series + episodes (production tables)
+Target: tv_shows + tv_episodes (production tables; see migration 041)
 
 Strategy:
 - For each unique tmdb_id in staging:
-  - If series exists (by tmdb_id): reuse it, only add new episodes
-  - Otherwise: INSERT series with TMDB metadata
-  - Covers auto-fetch via existing series_cover handler (TMDB fallback)
+  - If tv_show exists (by tmdb_id): reuse it, only add new episodes
+  - Otherwise: INSERT tv_show with TMDB metadata
+  - Covers auto-fetch via tv_porad_cover handler (TMDB fallback)
 - For each video:
   - season = season_number OR 1 (default if only episode_number present)
   - Skip if episode_number is NULL
@@ -106,7 +106,7 @@ def main():
 
     log.info("Processing %d TMDB-matched shows...", len(shows))
 
-    stats = {"series_created": 0, "series_reused": 0, "episodes_inserted": 0,
+    stats = {"shows_created": 0, "shows_reused": 0, "episodes_inserted": 0,
              "episodes_skipped": 0, "videos_skipped_no_ep": 0}
 
     for show in shows:
@@ -117,45 +117,44 @@ def main():
         if first_air and len(first_air) >= 4 and first_air[:4].isdigit():
             first_year = int(first_air[:4])
 
-        # Find or create series
+        # Find or create tv_show
         with conn.cursor() as cur:
-            cur.execute("SELECT id, slug FROM series WHERE tmdb_id = %s LIMIT 1", (tmdb_id,))
+            cur.execute("SELECT id, slug FROM tv_shows WHERE tmdb_id = %s LIMIT 1", (tmdb_id,))
             existing = cur.fetchone()
 
         if existing:
-            series_id, series_slug = existing
-            stats["series_reused"] += 1
-            log.info("Reusing series id=%d slug='%s' (tmdb=%d '%s')",
-                     series_id, series_slug, tmdb_id, tmdb_name)
+            tv_show_id, tv_show_slug = existing
+            stats["shows_reused"] += 1
+            log.info("Reusing tv_show id=%d slug='%s' (tmdb=%d '%s')",
+                     tv_show_id, tv_show_slug, tmdb_id, tmdb_name)
         else:
-            # Create new series
             base_slug = slugify(tmdb_name) or f"tv-porad-{tmdb_id}"
             with conn.cursor() as cur:
-                series_slug = unique_slug(cur, base_slug, "series")
+                tv_show_slug = unique_slug(cur, base_slug, "tv_shows")
                 if args.dry_run:
-                    log.info("[DRY] Would create series '%s' (slug=%s, tmdb=%d, year=%s)",
-                             tmdb_name, series_slug, tmdb_id, first_year)
-                    series_id = -1
+                    log.info("[DRY] Would create tv_show '%s' (slug=%s, tmdb=%d, year=%s)",
+                             tmdb_name, tv_show_slug, tmdb_id, first_year)
+                    tv_show_id = -1
                 else:
                     cur.execute("""
-                        INSERT INTO series (title, slug, tmdb_id, imdb_id,
+                        INSERT INTO tv_shows (title, slug, tmdb_id, imdb_id,
                           first_air_year, description, cover_filename, added_at)
                         VALUES (%s, %s, %s, %s, %s, %s, %s, now())
                         RETURNING id
                     """, (
                         tmdb_name[:255],
-                        series_slug,
+                        tv_show_slug,
                         tmdb_id,
                         show["imdb_id"],
                         first_year,
                         show["tmdb_overview"],
-                        series_slug,  # cover_filename = slug; actual WebP fetched on demand
+                        tv_show_slug,  # cover_filename = slug; actual WebP fetched on demand
                     ))
-                    series_id = cur.fetchone()[0]
+                    tv_show_id = cur.fetchone()[0]
                     conn.commit()
-                    log.info("Created series id=%d slug='%s' (tmdb=%d '%s')",
-                             series_id, series_slug, tmdb_id, tmdb_name)
-            stats["series_created"] += 1
+                    log.info("Created tv_show id=%d slug='%s' (tmdb=%d '%s')",
+                             tv_show_id, tv_show_slug, tmdb_id, tmdb_name)
+            stats["shows_created"] += 1
 
         if args.dry_run:
             continue
@@ -191,17 +190,17 @@ def main():
             try:
                 with conn.cursor() as cur:
                     cur.execute("""
-                        INSERT INTO episodes (
-                          series_id, season, episode, slug,
+                        INSERT INTO tv_episodes (
+                          tv_show_id, season, episode, slug,
                           sktorrent_video_id, sktorrent_cdn, sktorrent_qualities,
                           sktorrent_added_at
                         )
                         VALUES (%s, %s, %s, %s, %s, %s, %s, now())
-                        ON CONFLICT (series_id, season, episode, sktorrent_video_id)
+                        ON CONFLICT (tv_show_id, season, episode, sktorrent_video_id)
                         DO NOTHING
                         RETURNING id
                     """, (
-                        series_id, season, ep, ep_slug,
+                        tv_show_id, season, ep, ep_slug,
                         v["sktorrent_video_id"], v["cdn"], qualities_str,
                     ))
                     row = cur.fetchone()
@@ -212,42 +211,40 @@ def main():
                 conn.commit()
             except psycopg2.errors.UniqueViolation as e:
                 conn.rollback()
-                # Slug collision — try with suffix
-                log.warning("Slug collision for series=%d s%de%d, adding suffix", series_id, season, ep)
+                log.warning("Slug collision for tv_show=%d s%de%d, adding suffix", tv_show_id, season, ep)
                 with conn.cursor() as cur:
-                    suffix_slug = unique_slug(cur, ep_slug, "episodes",
-                                              extra_where=f"AND series_id = {series_id}")
+                    suffix_slug = unique_slug(cur, ep_slug, "tv_episodes",
+                                              extra_where=f"AND tv_show_id = {tv_show_id}")
                     cur.execute("""
-                        INSERT INTO episodes (
-                          series_id, season, episode, slug,
+                        INSERT INTO tv_episodes (
+                          tv_show_id, season, episode, slug,
                           sktorrent_video_id, sktorrent_cdn, sktorrent_qualities,
                           sktorrent_added_at
                         )
                         VALUES (%s, %s, %s, %s, %s, %s, %s, now())
-                        ON CONFLICT (series_id, season, episode, sktorrent_video_id) DO NOTHING
+                        ON CONFLICT (tv_show_id, season, episode, sktorrent_video_id) DO NOTHING
                     """, (
-                        series_id, season, ep, suffix_slug,
+                        tv_show_id, season, ep, suffix_slug,
                         v["sktorrent_video_id"], v["cdn"], qualities_str,
                     ))
                 conn.commit()
                 stats["episodes_inserted"] += 1
 
-    # Update season_count / episode_count on all touched series
     if not args.dry_run:
         with conn.cursor() as cur:
             cur.execute("""
-                UPDATE series s SET
+                UPDATE tv_shows s SET
                   season_count = sub.s_count,
                   episode_count = sub.e_count
                 FROM (
-                  SELECT series_id,
+                  SELECT tv_show_id,
                          MAX(season) as s_count,
                          COUNT(*) as e_count
-                  FROM episodes
-                  WHERE series_id IN (SELECT id FROM series WHERE tmdb_id IN %s)
-                  GROUP BY series_id
+                  FROM tv_episodes
+                  WHERE tv_show_id IN (SELECT id FROM tv_shows WHERE tmdb_id IN %s)
+                  GROUP BY tv_show_id
                 ) sub
-                WHERE s.id = sub.series_id
+                WHERE s.id = sub.tv_show_id
             """, (tuple(s["tmdb_id"] for s in shows),))
             conn.commit()
 

--- a/scripts/move-tv-porady-to-new-tables.py
+++ b/scripts/move-tv-porady-to-new-tables.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Move TV pořady from series/episodes into the new tv_shows/tv_episodes tables.
+
+The import pipeline (#457) put 37 TV pořady + 684 episodes into the
+scripted-series tables by mistake. Issue #463 moves them into the
+dedicated `tv_shows` / `tv_episodes` catalog created in #462.
+
+Selection: any `series.tmdb_id` that appears in `sktorrent_tv_porady`
+(the staging table that holds everything scraped from /videos/tv-porady).
+
+Per-show transaction — idempotent:
+- If the series is still in `series`: lock row, copy all columns to
+  `tv_shows` (with original id preserved so any external references
+  keep pointing at the same PK), copy episodes to `tv_episodes`
+  (one row per episode, slug recomputed from s/e), then DELETE from
+  `series` (CASCADE wipes `episodes`).
+- The DELETE happens BEFORE the INSERT into `tv_shows` so the
+  cross-slug trigger doesn't reject the new row.
+- Already-moved shows (tmdb_id no longer in `series` but present in
+  `tv_shows`) are skipped on re-run.
+
+Usage:
+    DATABASE_URL=... python3 scripts/move-tv-porady-to-new-tables.py [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+import psycopg2
+import psycopg2.extras
+
+log = logging.getLogger(__name__)
+
+SERIES_COPY_COLUMNS = [
+    "id",
+    "title",
+    "original_title",
+    "slug",
+    "first_air_year",
+    "last_air_year",
+    "description",
+    "generated_description",
+    "tmdb_overview_en",
+    "imdb_id",
+    "tmdb_id",
+    "csfd_id",
+    "imdb_rating",
+    "csfd_rating",
+    "season_count",
+    "episode_count",
+    "cover_filename",
+    "has_dub",
+    "has_subtitles",
+    "old_slug",
+    "added_at",
+    "created_at",
+]
+
+EPISODE_COPY_COLUMNS = [
+    "season",
+    "episode",
+    "title",
+    "slug",
+    "episode_name",
+    "overview",
+    "overview_en",
+    "generated_description",
+    "air_date",
+    "runtime",
+    "still_filename",
+    "vote_average",
+    "sktorrent_video_id",
+    "sktorrent_cdn",
+    "sktorrent_qualities",
+    "sktorrent_added_at",
+    "prehrajto_url",
+    "prehrajto_has_dub",
+    "prehrajto_has_subs",
+    "has_dub",
+    "has_subtitles",
+    "created_at",
+]
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Report what would be moved without writing")
+    ap.add_argument("--verbose", "-v", action="store_true")
+    args = ap.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)-7s %(message)s",
+    )
+
+    db_url = os.environ.get("DATABASE_URL", "")
+    if not db_url:
+        log.error("DATABASE_URL not set")
+        sys.exit(1)
+
+    conn = psycopg2.connect(db_url)
+
+    with conn.cursor() as cur:
+        cur.execute("""
+            SELECT DISTINCT tmdb_id
+            FROM sktorrent_tv_porady
+            WHERE tmdb_id IS NOT NULL
+            ORDER BY tmdb_id
+        """)
+        tmdb_ids = [row[0] for row in cur.fetchall()]
+
+    log.info("TV pořady staging has %d distinct tmdb_ids", len(tmdb_ids))
+
+    stats = {
+        "already_moved": 0,
+        "shows_moved": 0,
+        "episodes_moved": 0,
+        "shows_not_in_series": 0,
+    }
+
+    series_cols_sql = ", ".join(SERIES_COPY_COLUMNS)
+    episode_cols_sql = ", ".join(EPISODE_COPY_COLUMNS)
+    episode_insert_cols_sql = "tv_show_id, " + episode_cols_sql
+    episode_placeholders = ", ".join(["%s"] * (len(EPISODE_COPY_COLUMNS) + 1))
+    series_insert_placeholders = ", ".join(["%s"] * len(SERIES_COPY_COLUMNS))
+
+    for tmdb_id in tmdb_ids:
+        with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as cur:
+            cur.execute(
+                f"SELECT {series_cols_sql} FROM series WHERE tmdb_id = %s LIMIT 1",
+                (tmdb_id,),
+            )
+            series_row = cur.fetchone()
+
+            if series_row is None:
+                cur.execute(
+                    "SELECT 1 FROM tv_shows WHERE tmdb_id = %s LIMIT 1",
+                    (tmdb_id,),
+                )
+                if cur.fetchone():
+                    stats["already_moved"] += 1
+                    log.debug("tmdb=%d already in tv_shows — skipping", tmdb_id)
+                else:
+                    stats["shows_not_in_series"] += 1
+                    log.warning("tmdb=%d not in series and not in tv_shows", tmdb_id)
+                continue
+
+            series_id = series_row["id"]
+            title = series_row["title"]
+            slug = series_row["slug"]
+
+            cur.execute(
+                f"""SELECT {episode_cols_sql}
+                    FROM episodes
+                    WHERE series_id = %s
+                    ORDER BY season, episode, id""",
+                (series_id,),
+            )
+            episode_rows = cur.fetchall()
+
+        log.info(
+            "[move] tmdb=%d id=%d '%s' slug='%s' episodes=%d",
+            tmdb_id, series_id, title, slug, len(episode_rows),
+        )
+
+        if args.dry_run:
+            stats["shows_moved"] += 1
+            stats["episodes_moved"] += len(episode_rows)
+            continue
+
+        try:
+            with conn:
+                with conn.cursor() as cur:
+                    cur.execute("DELETE FROM series WHERE id = %s", (series_id,))
+
+                    cur.execute(
+                        f"""INSERT INTO tv_shows ({series_cols_sql})
+                            VALUES ({series_insert_placeholders})
+                            RETURNING id""",
+                        tuple(series_row[c] for c in SERIES_COPY_COLUMNS),
+                    )
+                    new_id = cur.fetchone()[0]
+
+                    for ep in episode_rows:
+                        cur.execute(
+                            f"""INSERT INTO tv_episodes ({episode_insert_cols_sql})
+                                VALUES ({episode_placeholders})""",
+                            (new_id,) + tuple(ep[c] for c in EPISODE_COPY_COLUMNS),
+                        )
+
+            stats["shows_moved"] += 1
+            stats["episodes_moved"] += len(episode_rows)
+
+        except Exception as exc:
+            log.error("tmdb=%d failed: %s", tmdb_id, exc)
+
+    cur_max = None
+    with conn.cursor() as cur:
+        cur.execute("SELECT setval('tv_shows_id_seq', COALESCE((SELECT MAX(id) FROM tv_shows), 1), true)")
+        cur_max = cur.fetchone()[0]
+        cur.execute("SELECT setval('tv_episodes_id_seq', COALESCE((SELECT MAX(id) FROM tv_episodes), 1), true)")
+    conn.commit()
+    log.info("Sequences advanced to match moved data (tv_shows max id=%s)", cur_max)
+
+    log.info("==== DONE ====")
+    for k, v in stats.items():
+        log.info("  %s: %d", k, v)
+
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!-- claude-session: c0717c9a-16b7-4690-af5a-437a07586132 -->

Closes #468, #469
Part of #461
Stacked on: #473 (#466, #467) → #472 (#464, #465) → #471 (#463) → #470 (#462)

## Summary
Finishes the TV pořady separation.

### #468 — auto-import → new tables
`scripts/import-tv-porady.py` now writes into `tv_shows` / `tv_episodes`. Existing rows are detected via `tv_shows.tmdb_id`. `season_count` / `episode_count` are rolled up on the `tv_shows` side. Next run of the daily importer lands new reality-show episodes in the dedicated catalog automatically.

### #469 — 301 redirects
`series_resolve` and `episode_detail` (both in `cr-web/src/handlers/series.rs`) look up the incoming slug (or `old_slug`) in `tv_shows` when it's missing in `series`. If found, the request is answered with `301 Moved Permanently → /tv-porady/{slug}/` (or `/{slug}/{ep}/`). Old indexed URLs keep working without 404s.

## Test plan
- [ ] CI green
- [ ] After deploy: `curl -I https://ceskarepublika.wiki/serialy-online/jamie-vari-doma/` returns `301` with `Location: /tv-porady/jamie-vari-doma/`
- [ ] After deploy: episode redirect works for an episode slug
- [ ] Next auto-import run: verify new rows appear in `tv_shows` and `tv_episodes`, not `series`