### PR TITLE
fix(tv-porady): Copilot follow-ups from #475 review

### DIFF
--- a/cr-web/src/handlers/tv_porady.rs
+++ b/cr-web/src/handlers/tv_porady.rs
@@ -571,35 +571,40 @@ pub async fn tv_porad_cover(
                     .timeout(std::time::Duration::from_secs(15))
                     .send()
                     .await
+                    && img_resp.status().is_success()
                     && let Ok(raw_bytes) = img_resp.bytes().await
                 {
-                    // TMDB returns JPEG; re-encode to WebP so we can honour
-                    // the .webp Content-Type + avoid content/extension mismatch.
-                    let output_bytes = if let Ok(img) = image::load_from_memory(&raw_bytes) {
+                    // TMDB returns JPEG; re-encode to WebP off the async
+                    // runtime (CPU-bound) and bail out if transcoding fails
+                    // so we don't cache raw JPEG under a .webp filename.
+                    let raw = raw_bytes.to_vec();
+                    let output_bytes = tokio::task::spawn_blocking(move || -> Option<Vec<u8>> {
+                        let img = image::load_from_memory(&raw).ok()?;
                         let mut buf = Vec::new();
                         let mut cursor = std::io::Cursor::new(&mut buf);
-                        if img.write_to(&mut cursor, image::ImageFormat::WebP).is_ok() {
-                            buf
-                        } else {
-                            raw_bytes.to_vec()
-                        }
-                    } else {
-                        raw_bytes.to_vec()
-                    };
+                        img.write_to(&mut cursor, image::ImageFormat::WebP).ok()?;
+                        Some(buf)
+                    })
+                    .await
+                    .ok()
+                    .flatten();
 
-                    let cache_path = std::path::Path::new(&covers_dir).join(format!("{slug}.webp"));
-                    let _ = tokio::fs::create_dir_all(&covers_dir).await;
-                    let _ = tokio::fs::write(&cache_path, &output_bytes).await;
+                    if let Some(output_bytes) = output_bytes {
+                        let cache_path =
+                            std::path::Path::new(&covers_dir).join(format!("{slug}.webp"));
+                        let _ = tokio::fs::create_dir_all(&covers_dir).await;
+                        let _ = tokio::fs::write(&cache_path, &output_bytes).await;
 
-                    return Ok((
-                        StatusCode::OK,
-                        [
-                            (header::CONTENT_TYPE, "image/webp"),
-                            (header::CACHE_CONTROL, "public, max-age=31536000, immutable"),
-                        ],
-                        output_bytes,
-                    )
-                        .into_response());
+                        return Ok((
+                            StatusCode::OK,
+                            [
+                                (header::CONTENT_TYPE, "image/webp"),
+                                (header::CACHE_CONTROL, "public, max-age=31536000, immutable"),
+                            ],
+                            output_bytes,
+                        )
+                            .into_response());
+                    }
                 }
             }
         }
@@ -683,30 +688,32 @@ pub async fn tv_porad_cover_large(
                     && img_resp.status().is_success()
                     && let Ok(bytes) = img_resp.bytes().await
                 {
-                    let output_bytes = if let Ok(img) = image::load_from_memory(&bytes) {
+                    let raw = bytes.to_vec();
+                    let output_bytes = tokio::task::spawn_blocking(move || -> Option<Vec<u8>> {
+                        let img = image::load_from_memory(&raw).ok()?;
                         let mut buf = Vec::new();
                         let mut cursor = std::io::Cursor::new(&mut buf);
-                        if img.write_to(&mut cursor, image::ImageFormat::WebP).is_ok() {
-                            buf
-                        } else {
-                            bytes.to_vec()
-                        }
-                    } else {
-                        bytes.to_vec()
-                    };
+                        img.write_to(&mut cursor, image::ImageFormat::WebP).ok()?;
+                        Some(buf)
+                    })
+                    .await
+                    .ok()
+                    .flatten();
 
-                    let _ = tokio::fs::create_dir_all(&cache_dir).await;
-                    let _ = tokio::fs::write(&cache_path, &output_bytes).await;
+                    if let Some(output_bytes) = output_bytes {
+                        let _ = tokio::fs::create_dir_all(&cache_dir).await;
+                        let _ = tokio::fs::write(&cache_path, &output_bytes).await;
 
-                    return Ok((
-                        StatusCode::OK,
-                        [
-                            (header::CONTENT_TYPE, "image/webp"),
-                            (header::CACHE_CONTROL, "public, max-age=31536000, immutable"),
-                        ],
-                        output_bytes,
-                    )
-                        .into_response());
+                        return Ok((
+                            StatusCode::OK,
+                            [
+                                (header::CONTENT_TYPE, "image/webp"),
+                                (header::CACHE_CONTROL, "public, max-age=31536000, immutable"),
+                            ],
+                            output_bytes,
+                        )
+                            .into_response());
+                    }
                 }
             }
         }

--- a/cr-web/src/handlers/tv_porady.rs
+++ b/cr-web/src/handlers/tv_porady.rs
@@ -571,11 +571,25 @@ pub async fn tv_porad_cover(
                     .timeout(std::time::Duration::from_secs(15))
                     .send()
                     .await
-                    && let Ok(img_bytes) = img_resp.bytes().await
+                    && let Ok(raw_bytes) = img_resp.bytes().await
                 {
+                    // TMDB returns JPEG; re-encode to WebP so we can honour
+                    // the .webp Content-Type + avoid content/extension mismatch.
+                    let output_bytes = if let Ok(img) = image::load_from_memory(&raw_bytes) {
+                        let mut buf = Vec::new();
+                        let mut cursor = std::io::Cursor::new(&mut buf);
+                        if img.write_to(&mut cursor, image::ImageFormat::WebP).is_ok() {
+                            buf
+                        } else {
+                            raw_bytes.to_vec()
+                        }
+                    } else {
+                        raw_bytes.to_vec()
+                    };
+
                     let cache_path = std::path::Path::new(&covers_dir).join(format!("{slug}.webp"));
                     let _ = tokio::fs::create_dir_all(&covers_dir).await;
-                    let _ = tokio::fs::write(&cache_path, &img_bytes).await;
+                    let _ = tokio::fs::write(&cache_path, &output_bytes).await;
 
                     return Ok((
                         StatusCode::OK,
@@ -583,7 +597,7 @@ pub async fn tv_porad_cover(
                             (header::CONTENT_TYPE, "image/webp"),
                             (header::CACHE_CONTROL, "public, max-age=31536000, immutable"),
                         ],
-                        img_bytes.to_vec(),
+                        output_bytes,
                     )
                         .into_response());
                 }

--- a/cr-web/templates/tv_epizoda_detail.html
+++ b/cr-web/templates/tv_epizoda_detail.html
@@ -30,7 +30,6 @@
 <div class="search-container" id="header-search-box">
     <input type="text" id="tv-search" class="search-input" placeholder="Hledat TV pořad..." autocomplete="off">
     <button class="search-btn" onclick="doSearch()" alt="Hledat" title="Hledat">Hledat</button>
-    <div id="search-results" class="search-dropdown"></div>
 </div>
 {% endblock %}
 
@@ -507,7 +506,8 @@ function playPrehrajtoEpisode(movie, item) {
     var player = document.getElementById('tv-player');
     var status = document.getElementById('source-status');
     if (!player) return;
-    document.getElementById('player-section') && document.querySelector('.player-section').scrollIntoView({ behavior: 'smooth', block: 'start' });
+    var ps = document.querySelector('.player-section');
+    if (ps) ps.scrollIntoView({ behavior: 'smooth', block: 'start' });
 
     function useResolved(resolved) {
         var url = resolved.video_url;
@@ -623,44 +623,17 @@ function setSubSize(px) {
     }, true);
 })();
 
-/* Header search autocomplete */
+/* Header search: submit-on-Enter, no autocomplete (no /api/tv-porady/search yet) */
 function doSearch() {
     var q = document.getElementById('tv-search').value.trim();
     if (q.length >= 2) window.location = '/tv-porady/?q=' + encodeURIComponent(q);
 }
 (function() {
     var input = document.getElementById('tv-search');
-    var dd = document.getElementById('search-results');
-    var timer = null;
-    if (!input || !dd) return;
-    input.addEventListener('input', function() {
-        clearTimeout(timer);
-        var q = this.value.trim();
-        if (q.length < 2) { dd.classList.remove('open'); return; }
-        timer = setTimeout(function() {
-            fetch('/api/tv-porady/search?q=' + encodeURIComponent(q))
-                .then(function(r) { return r.json(); })
-                .then(function(results) {
-                    if (!results.length) { dd.innerHTML = '<div style="padding:0.8rem;color:#888;text-align:center">Nic nenalezeno</div>'; }
-                    else {
-                        dd.innerHTML = results.map(function(r) {
-                            var cover = r.cover
-                                ? '<img src="/tv-porady/' + r.slug + '.webp" alt="' + r.title + '" title="' + r.title + '">'
-                                : '<div class="si-placeholder"></div>';
-                            var yr = r.year ? ' (' + r.year + ')' : '';
-                            var rat = r.imdb_rating ? ' — IMDB ' + r.imdb_rating : '';
-                            return '<a href="/tv-porady/' + r.slug + '/" class="search-item" alt="' + r.title + '" title="' + r.title + '">'
-                                + cover + '<div class="si-info"><span class="si-title">' + r.title + yr + '</span>'
-                                + '<span class="si-meta">' + rat + '</span></div></a>';
-                        }).join('');
-                    }
-                    dd.classList.add('open');
-                })
-                .catch(function() { dd.classList.remove('open'); });
-        }, 200);
+    if (!input) return;
+    input.addEventListener('keydown', function(e) {
+        if (e.key === 'Enter') { e.preventDefault(); doSearch(); }
     });
-    document.addEventListener('click', function(e) { if (!e.target.closest('#header-search-box')) dd.classList.remove('open'); });
-    input.addEventListener('keydown', function(e) { if (e.key === 'Enter') { e.preventDefault(); doSearch(); } });
 })();
 
 initPlayer();

--- a/cr-web/templates/tv_epizoda_detail.html
+++ b/cr-web/templates/tv_epizoda_detail.html
@@ -110,18 +110,6 @@
 .breadcrumb { font-size: 0.85rem; color: #888; margin-bottom: 1.2rem; }
 .breadcrumb a { color: #11457E; text-decoration: none; }
 
-/* Search dropdown */
-#header-search-box { position: relative; overflow: visible !important; }
-.search-dropdown { display: none; position: absolute; top: calc(100% + 4px); left: 0; right: 0; background: white; border: 1px solid #ddd; border-radius: 12px; box-shadow: 0 8px 24px rgba(0,0,0,0.18); z-index: 200; max-height: 420px; overflow-y: auto; }
-.search-dropdown.open { display: block; }
-.search-item { display: flex; align-items: center; gap: 0.7rem; padding: 0.5rem 0.8rem; text-decoration: none; color: inherit; border-bottom: 1px solid #f0f0f0; }
-.search-item:hover { background: #f5f5f5; }
-.search-item img { width: 40px; height: 60px; object-fit: cover; border-radius: 4px; }
-.search-item .si-placeholder { width: 40px; height: 60px; background: #eee; border-radius: 4px; }
-.search-item .si-info { flex: 1; min-width: 0; }
-.search-item .si-title { font-weight: 500; display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.search-item .si-meta { font-size: 0.8rem; color: #888; }
-
 /* Player */
 .player-section { margin-bottom: 1.5rem; }
 .source-tabs { display: flex; gap: 0.3rem; background: #1a1a1a; padding: 0.4rem 0.6rem; border-radius: 10px 10px 0 0; }

--- a/scripts/import-tv-porady.py
+++ b/scripts/import-tv-porady.py
@@ -230,7 +230,9 @@ def main():
                 conn.commit()
                 stats["episodes_inserted"] += 1
 
-    if not args.dry_run:
+    if not args.dry_run and shows:
+        # Empty tuple would render as `IN ()` — invalid SQL. Skip the rollup
+        # when there's nothing to update.
         with conn.cursor() as cur:
             cur.execute("""
                 UPDATE tv_shows s SET

--- a/scripts/import-tv-porady.py
+++ b/scripts/import-tv-porady.py
@@ -49,8 +49,14 @@ def slugify(text: str) -> str:
     return s
 
 
-def unique_slug(cur, base: str, table: str, column: str = "slug", extra_where: str = "") -> str:
-    """Generate unique slug by appending -N if needed."""
+def unique_slug(cur, base: str, table: str, column: str = "slug", extra_where: str = "",
+                cross_tables: tuple = ()) -> str:
+    """Generate unique slug by appending -N if needed.
+
+    Checks `table.column` for collisions, plus any additional `cross_tables`
+    (flat slug columns) so that tv_shows slug won't collide with films, series
+    or genres — which the DB triggers would reject.
+    """
     if not base:
         base = "tv-porad"
     candidate = base
@@ -58,7 +64,14 @@ def unique_slug(cur, base: str, table: str, column: str = "slug", extra_where: s
     while True:
         q = f"SELECT 1 FROM {table} WHERE {column} = %s {extra_where} LIMIT 1"
         cur.execute(q, (candidate,))
-        if not cur.fetchone():
+        collision = cur.fetchone() is not None
+        if not collision:
+            for other in cross_tables:
+                cur.execute(f"SELECT 1 FROM {other} WHERE slug = %s LIMIT 1", (candidate,))
+                if cur.fetchone():
+                    collision = True
+                    break
+        if not collision:
             return candidate
         n += 1
         candidate = f"{base}-{n}"
@@ -130,7 +143,10 @@ def main():
         else:
             base_slug = slugify(tmdb_name) or f"tv-porad-{tmdb_id}"
             with conn.cursor() as cur:
-                tv_show_slug = unique_slug(cur, base_slug, "tv_shows")
+                tv_show_slug = unique_slug(
+                    cur, base_slug, "tv_shows",
+                    cross_tables=("films", "series", "genres"),
+                )
                 if args.dry_run:
                     log.info("[DRY] Would create tv_show '%s' (slug=%s, tmdb=%d, year=%s)",
                              tmdb_name, tv_show_slug, tmdb_id, first_year)


### PR DESCRIPTION
<!-- claude-session: c0717c9a-16b7-4690-af5a-437a07586132 -->

Addresses Copilot review comments on #475.

## Status: deployed + smoke-tested on production first

Per workflow (test-on-prod-first, then PR): fixes built + shipped to prod via `scp`+`docker cp`, then verified.

## What changed
- **tv_epizoda_detail.html**: remove dead `/api/tv-porady/search` autocomplete that was 404-spamming on every keypress (no such endpoint registered). Enter-to-search behaviour kept.
- **tv_epizoda_detail.html**: replace the broken `document.getElementById('player-section') && …` guard (no such id) with a proper `querySelector('.player-section')` lookup.
- **tv_porady.rs**: re-encode TMDB poster JPEGs to WebP before caching / serving under a `.webp` filename with `Content-Type: image/webp`. Previously the raw JPEG bytes went out under that MIME type — broken in strict browsers.
- **import-tv-porady.py**: guard the final `season_count / episode_count` rollup with `if shows`, so an empty staging set doesn't render invalid `IN ()` SQL on a future run.

## Still open from the review (intentional, not blockers)
- `#serialy-online/` handler style (env-var reads vs `AppState.config`, `unwrap_or_default` silencing DB errors, subselects in `fetch_latest_episode_cards`) — all pre-existing patterns also used in the series handler. Leaving for a separate consistency sweep.
- `/tv-porady/still/` route — `still_filename` is NULL for every imported TV pořad, so the template path never renders. Will add when we start downloading stills.
- Move script exit-code and dry-run setval — one-shot script already executed successfully on prod; not worth churning.

## Verification on prod
```
GET /tv-porady/kralovny-brna/s01e01/  → 200 (no longer fetches the 404 search endpoint)
GET /serialy-online/kralovny-brna/    → 301 → /tv-porady/kralovny-brna/
GET /health                            → 200
```