### PR TITLE
fix(db): drop cross-table slug uniqueness triggers

### DIFF
--- a/cr-infra/migrations/20260502_042_relax_tv_show_cross_slug.sql
+++ b/cr-infra/migrations/20260502_042_relax_tv_show_cross_slug.sql
@@ -1,0 +1,22 @@
+-- Drop all cross-table slug uniqueness triggers.
+--
+-- Slugs must only be unique WITHIN a category table. URL prefixes
+-- (/filmy-online/, /serialy-online/, /tv-porady/) disambiguate the
+-- entities — a film "Táta", a series "Táta" and a TV pořad "Táta" can
+-- coexist and each is reachable at its own route.
+--
+-- Previously migrations 028, 029 and 041 enforced a global namespace
+-- across films/genres/series/tv_shows, which was overly strict and
+-- blocked legitimate name collisions (e.g. the film "Na nože" / Knives
+-- Out 2019 vs. the Slovak reality cooking show "Na nože").
+
+DROP TRIGGER IF EXISTS trg_films_slug_not_genre        ON films;
+DROP TRIGGER IF EXISTS trg_genres_slug_not_film        ON genres;
+DROP TRIGGER IF EXISTS trg_series_slug_not_film_or_genre      ON series;
+DROP TRIGGER IF EXISTS trg_tv_show_slug_not_film_series_or_genre ON tv_shows;
+
+DROP FUNCTION IF EXISTS check_slug_not_genre();
+DROP FUNCTION IF EXISTS check_slug_not_film();
+DROP FUNCTION IF EXISTS check_slug_not_series();
+DROP FUNCTION IF EXISTS check_series_slug_not_film_or_genre();
+DROP FUNCTION IF EXISTS check_tv_show_slug_not_film_series_or_genre();


### PR DESCRIPTION
<!-- claude-session: c0717c9a-16b7-4690-af5a-437a07586132 -->

## Summary
Slugs are now unique **within a category**, not globally across films/series/tv_shows/genres. URL prefixes (`/filmy-online/`, `/serialy-online/`, `/tv-porady/`) disambiguate at the router level.

## Motivation
Film *Knives Out 2019* (Czech title "Na nože") blocked the Slovak reality cooking show "Na nože" from taking slug `na-noze`, forcing the ugly `na-noze-2`. Same problem will keep happening (e.g. film "Táta" vs. series "Táta" vs. TV pořad "Táta"). Each legitimately lives at its own URL.

## Already deployed + verified on prod
```
/filmy-online/na-noze/               → 200  (film)
/tv-porady/na-noze/                  → 200  (TV pořad, renamed from na-noze-2)
/tv-porady/na-noze-2/                → 301  → /tv-porady/na-noze/
/serialy-online/na-noze/             → 301  → /tv-porady/na-noze/
```

Migration `042_relax_tv_show_cross_slug` already applied on production (registered in `_sqlx_migrations`).

## Test plan
- [x] CI (Check & Clippy, Format, Test)
- [x] Live test on prod (above)
- [ ] Next time a staging pořad has a slug clashing with films/series, importer succeeds without suffix