### PR TITLE
feat(admin-import): link to imported tv_show / tv_episode (#484)

### DIFF
--- a/cr-infra/migrations/20260505_045_import_items_action_tv_porady.sql
+++ b/cr-infra/migrations/20260505_045_import_items_action_tv_porady.sql
@@ -1,0 +1,25 @@
+-- #484 — admit the two TV pořad action codes the auto-import pipeline now
+-- writes (`added_tv_show`, `added_tv_episode`). The old CHECK constraint
+-- pre-dated the TV pořady catalog and rejects those inserts, so without
+-- this migration every tv-porady row the pipeline tries to persist bombs
+-- with `import_items_action_check` and the whole run fails.
+--
+-- Postgres doesn't support `ALTER … ADD VALUE` on CHECK-with-IN, so drop
+-- and recreate.
+
+ALTER TABLE import_items
+    DROP CONSTRAINT IF EXISTS import_items_action_check;
+
+ALTER TABLE import_items
+    ADD CONSTRAINT import_items_action_check
+    CHECK (action IN (
+        'added_film',
+        'added_series',
+        'added_episode',
+        'added_tv_show',
+        'added_tv_episode',
+        'updated_film',
+        'updated_episode',
+        'skipped',
+        'failed'
+    ));

--- a/cr-web/src/handlers/admin_import.rs
+++ b/cr-web/src/handlers/admin_import.rs
@@ -132,6 +132,14 @@ impl ImportItemRow {
         ) {
             return Some(format!("/tv-porady/{show_slug}/{ep_slug}/"));
         }
+        if let (Some(show_slug), Some(season), Some(episode)) = (
+            self.target_tv_episode_show_slug.as_deref(),
+            self.season,
+            self.episode,
+        ) {
+            // TV episode slug not set yet — fall back to legacy N×M URL.
+            return Some(format!("/tv-porady/{show_slug}/{season}x{episode}/"));
+        }
         if let Some(slug) = self.target_tv_show_slug.as_deref() {
             return Some(format!("/tv-porady/{slug}/"));
         }
@@ -332,10 +340,7 @@ pub async fn admin_import_detail(
     let mut skipped = Vec::new();
     for it in items {
         match it.action.as_str() {
-            "added_film"
-            | "added_series"
-            | "added_episode"
-            | "added_tv_show"
+            "added_film" | "added_series" | "added_episode" | "added_tv_show"
             | "added_tv_episode" => added.push(it),
             "updated_film" | "updated_episode" => updated.push(it),
             "failed" => failed.push(it),

--- a/cr-web/src/handlers/admin_import.rs
+++ b/cr-web/src/handlers/admin_import.rs
@@ -75,6 +75,8 @@ struct ImportItemRow {
     target_film_id: Option<i32>,
     target_series_id: Option<i32>,
     target_episode_id: Option<i32>,
+    target_tv_show_id: Option<i32>,
+    target_tv_episode_id: Option<i32>,
     #[sqlx(default)]
     target_film_slug: Option<String>,
     #[sqlx(default)]
@@ -85,6 +87,16 @@ struct ImportItemRow {
     /// Used to build /serialy-online/{series-slug}/{episode-slug}/ URLs.
     #[sqlx(default)]
     target_episode_series_slug: Option<String>,
+    #[sqlx(default)]
+    target_tv_show_slug: Option<String>,
+    /// Episode slug on tv_episodes (e.g. "s01e03"). Used alongside the show
+    /// slug to build /tv-porady/{show}/{ep}/ URLs.
+    #[sqlx(default)]
+    target_tv_episode_slug: Option<String>,
+    /// tv_shows.slug reached via target_tv_episode_id → tv_episodes.tv_show_id.
+    /// Required to build the episode URL when only target_tv_episode_id is set.
+    #[sqlx(default)]
+    target_tv_episode_show_slug: Option<String>,
     failure_step: Option<String>,
     failure_message: Option<String>,
     raw_log: Option<JsonValue>,
@@ -113,6 +125,15 @@ impl ImportItemRow {
         }
         if let Some(slug) = self.target_series_slug.as_deref() {
             return Some(format!("/serialy-online/{slug}/"));
+        }
+        if let (Some(show_slug), Some(ep_slug)) = (
+            self.target_tv_episode_show_slug.as_deref(),
+            self.target_tv_episode_slug.as_deref(),
+        ) {
+            return Some(format!("/tv-porady/{show_slug}/{ep_slug}/"));
+        }
+        if let Some(slug) = self.target_tv_show_slug.as_deref() {
+            return Some(format!("/tv-porady/{slug}/"));
         }
         None
     }
@@ -275,16 +296,23 @@ pub async fn admin_import_detail(
         "SELECT i.id, i.sktorrent_video_id, i.sktorrent_url, i.sktorrent_title, \
          i.detected_type, i.imdb_id, i.season, i.episode, i.action, \
          i.target_film_id, i.target_series_id, i.target_episode_id, \
+         i.target_tv_show_id, i.target_tv_episode_id, \
          f.slug AS target_film_slug, \
          s.slug AS target_series_slug, \
          e.slug AS target_episode_slug, \
          es.slug AS target_episode_series_slug, \
+         ts.slug AS target_tv_show_slug, \
+         te.slug AS target_tv_episode_slug, \
+         tes.slug AS target_tv_episode_show_slug, \
          i.failure_step, i.failure_message, i.raw_log \
          FROM import_items i \
-         LEFT JOIN films f    ON f.id  = i.target_film_id \
-         LEFT JOIN series s   ON s.id  = i.target_series_id \
-         LEFT JOIN episodes e ON e.id  = i.target_episode_id \
-         LEFT JOIN series es  ON es.id = e.series_id \
+         LEFT JOIN films f     ON f.id   = i.target_film_id \
+         LEFT JOIN series s    ON s.id   = i.target_series_id \
+         LEFT JOIN episodes e  ON e.id   = i.target_episode_id \
+         LEFT JOIN series es   ON es.id  = e.series_id \
+         LEFT JOIN tv_shows ts ON ts.id  = i.target_tv_show_id \
+         LEFT JOIN tv_episodes te ON te.id = i.target_tv_episode_id \
+         LEFT JOIN tv_shows tes ON tes.id = te.tv_show_id \
          WHERE i.run_id = $1 \
          ORDER BY i.id",
     )
@@ -304,7 +332,11 @@ pub async fn admin_import_detail(
     let mut skipped = Vec::new();
     for it in items {
         match it.action.as_str() {
-            "added_film" | "added_series" | "added_episode" => added.push(it),
+            "added_film"
+            | "added_series"
+            | "added_episode"
+            | "added_tv_show"
+            | "added_tv_episode" => added.push(it),
             "updated_film" | "updated_episode" => updated.push(it),
             "failed" => failed.push(it),
             "skipped" => skipped.push(it),
@@ -364,6 +396,8 @@ struct ItemJson<'a> {
     target_film_id: Option<i32>,
     target_series_id: Option<i32>,
     target_episode_id: Option<i32>,
+    target_tv_show_id: Option<i32>,
+    target_tv_episode_id: Option<i32>,
     failure_step: Option<&'a str>,
     failure_message: Option<&'a str>,
     raw_log: Option<&'a JsonValue>,
@@ -408,6 +442,8 @@ fn serialize_run_detail<'a>(
                 target_film_id: it.target_film_id,
                 target_series_id: it.target_series_id,
                 target_episode_id: it.target_episode_id,
+                target_tv_show_id: it.target_tv_show_id,
+                target_tv_episode_id: it.target_tv_episode_id,
                 failure_step: it.failure_step.as_deref(),
                 failure_message: it.failure_message.as_deref(),
                 raw_log: it.raw_log.as_ref(),

--- a/cr-web/templates/admin_import_detail.html
+++ b/cr-web/templates/admin_import_detail.html
@@ -164,7 +164,7 @@
 .items-table th { background: #f8fafc; font-weight: 600; color: #555; }
 .items-table a { color: #11457E; text-decoration: none; }
 .items-table a:hover { text-decoration: underline; }
-.action-added_film, .action-added_series, .action-added_episode { background: #d1fae5; color: #065f46; padding: 0.1rem 0.4rem; border-radius: 4px; font-size: 0.75rem; font-weight: 600; }
+.action-added_film, .action-added_series, .action-added_episode, [class^="action-added_tv"] { background: #d1fae5; color: #065f46; padding: 0.1rem 0.4rem; border-radius: 4px; font-size: 0.75rem; font-weight: 600; }
 .action-updated_film, .action-updated_episode { background: #dbeafe; color: #1e40af; padding: 0.1rem 0.4rem; border-radius: 4px; font-size: 0.75rem; font-weight: 600; }
 .failure-item { margin: 0.5rem 0; padding: 0.6rem 0.8rem; border: 1px solid #fee2e2; background: #fef2f2; border-radius: 6px; }
 .failure-item summary { cursor: pointer; display: flex; gap: 0.6rem; align-items: center; font-size: 0.9rem; }


### PR DESCRIPTION
<!-- claude-session: c0717c9a-16b7-4690-af5a-437a07586132 -->

Closes #484

## Summary
- Detail handler (`/admin/import/{run_id}`) now LEFT-JOINs `tv_shows` and `tv_episodes` so rows with `target_tv_show_id` / `target_tv_episode_id` render real links into `/tv-porady/`.
- `target_url()` builds `/tv-porady/{slug}/` for shows and `/tv-porady/{show}/{ep}/` for episodes; existing film/series logic untouched.
- JSON export (`/admin/import/{run_id}.json`) carries the two new ids for Claude Code debugging.
- Added-tab grouping recognises the `added_tv_show` / `added_tv_episode` action codes the pipeline from #483 writes.
- Migration **045** extends `import_items_action_check` to admit those action codes — without it the pipeline from #483 bombs on the first tv-porady insert.

## Test plan
- [x] `cargo check` / `cargo clippy -- -D warnings` / `cargo fmt --check` / `cargo test -p cr-web`
- [x] Built binary, deployed to prod via scp + docker cp, restart clean (migrations applied ok on startup).
- [x] Inserted temporary rows on prod pointing at `tv_show` #186 (Hra na oliheň: Výzva) and `tv_episode` #2 (Jamie vaří doma s01e01); opened `/admin/import/10` — links rendered as `/tv-porady/hra-na-olihen-vyzva/` and `/tv-porady/jamie-vari-doma/s01e01/`, both return 200. Test rows deleted afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)