### PR TITLE
fix(auto-import): SxxExx stripping, HTML unescape, cover volume mount

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,8 @@ services:
       # (runs outside Docker) — mount the same path read/write so the web
       # container serves freshly-downloaded WebPs instead of the 34-byte
       # transparent placeholder baked into films_cover().
-      - /opt/cr/data/movies/covers-webp:/app/data/movies/covers-webp
+      # Prod sets CR_DATA_DIR=/opt/cr/data in .env; dev falls back to ./data.
+      - ${CR_DATA_DIR:-./data}/movies/covers-webp:/app/data/movies/covers-webp
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,12 @@ services:
       R2_SECRET_ACCESS_KEY: ${R2_SECRET_ACCESS_KEY:-}
       R2_BUCKET: ${R2_BUCKET:-}
       R2_PUBLIC_BASE_URL: ${R2_PUBLIC_BASE_URL:-}
+    volumes:
+      # Film covers are written to the host by scripts/auto-import.py
+      # (runs outside Docker) — mount the same path read/write so the web
+      # container serves freshly-downloaded WebPs instead of the 34-byte
+      # transparent placeholder baked into films_cover().
+      - /opt/cr/data/movies/covers-webp:/app/data/movies/covers-webp
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:

--- a/scripts/auto_import/test_title_parser.py
+++ b/scripts/auto_import/test_title_parser.py
@@ -27,6 +27,23 @@ CASES = [
       "is_episode": True, "langs": ["DUB_CZ"]}),
     ("",
      {"cz_title": None, "en_title": None, "is_episode": False}),
+    # TV pořad with no slash separator — parser must strip SxxExx from title
+    ("Královny Brna S01E03 (CZ)",
+     {"cz_title": "Královny Brna", "en_title": None,
+      "season": 1, "episode": 3, "is_episode": True, "langs": ["CZ"]}),
+    # Double-escaped HTML entity (&amp;amp; → &) from SK Torrent listing
+    ("Survivor Česko &amp;amp; Slovensko S05E24 (2026)",
+     {"cz_title": "Survivor Česko & Slovensko", "season": 5, "episode": 24,
+      "year": 2026, "is_episode": True}),
+    # Marketing noise between title and episode marker is kept for now, but
+    # SxxExx + trailing episode-name ("- Katka a Denisa") must be stripped.
+    ("Výměna manželek - nyní pouze na Oneplay S03E01 - Katka a Denisa (2026)(CZ)",
+     {"season": 3, "episode": 1, "year": 2026, "is_episode": True,
+      "langs": ["CZ"]}),
+    # Ruža pre nevestu — SK show that exists on TMDB (was blacklisted due to parser)
+    ("Ruža pre nevestu S04E11 (2026)(SK)",
+     {"cz_title": "Ruža pre nevestu", "season": 4, "episode": 11,
+      "year": 2026, "is_episode": True, "langs": ["SK"]}),
 ]
 
 

--- a/scripts/auto_import/title_parser.py
+++ b/scripts/auto_import/title_parser.py
@@ -20,6 +20,7 @@ missing fields as a softer match signal.
 
 from __future__ import annotations
 
+import html
 import re
 from dataclasses import dataclass, asdict, field
 
@@ -182,6 +183,14 @@ def _split_titles(title: str) -> tuple[str | None, str | None]:
         s = _STRIP_PARENS_RE.sub("", p).strip()
         # Strip trailing CSFD rating
         s = _CSFD_RE.sub("", s).strip()
+        # Strip SxxExx (and everything after it). SK Torrent episode titles
+        # without a `/` separator between show and marker look like
+        # "Královny Brna S01E03" or "Výměna manželek S03E01 - Katka a Denisa";
+        # keep only the show name. Also handles "NxM" form.
+        for rx in (_EPISODE_RE, _EPISODE_X_RE):
+            m = rx.search(s)
+            if m:
+                s = s[: m.start()].rstrip()
         # Strip dangling = signs / dashes / dots
         s = re.sub(r"\s*[=\-•·.]+\s*$", "", s).strip()
         return s
@@ -199,7 +208,11 @@ def parse_sktorrent_title(title: str) -> ParsedTitle:
     """
     if not title:
         return ParsedTitle(raw="")
-    raw = title.strip()
+    # Decode HTML entities — SK Torrent occasionally double-escapes `&` in the
+    # listing's `title="..."` attribute (e.g. "Survivor Česko &amp;amp;
+    # Slovensko"). One unescape pass handles the normal case; the second pass
+    # catches double-encoded strings. `html.unescape` is a no-op on clean text.
+    raw = html.unescape(html.unescape(title)).strip()
     season, episode = _detect_episode(raw)
     cz, en = _split_titles(raw)
     return ParsedTitle(

--- a/scripts/auto_import/tmdb_resolver.py
+++ b/scripts/auto_import/tmdb_resolver.py
@@ -199,18 +199,20 @@ def _movie_search_queries(parsed: ParsedTitle) -> list[tuple[str, dict]]:
 def _shorten_title_candidates(title: str) -> list[str]:
     """Progressive shortenings for TMDB search fallback.
 
-    Returns [full, prefix_before_first_dash, prefix_before_colon] — deduped,
-    preserving order. Handy for SK Torrent titles with marketing noise like
-    "Výměna manželek - nyní pouze na Oneplay" where the full string misses
-    on TMDB but the bare show name matches.
+    Splits on each known separator independently and returns all candidates
+    sorted by length descending, so fallbacks are always monotonically
+    shorter. For "X - Y: Z" we get ["X - Y: Z", "X - Y", "X"]. Handy for SK
+    Torrent titles with marketing noise like "Výměna manželek - nyní pouze
+    na Oneplay" where the full string misses on TMDB but the bare show
+    name matches.
     """
-    out: list[str] = [title]
+    candidates: set[str] = {title}
     for sep in (" - ", ": "):
         if sep in title:
             prefix = title.split(sep, 1)[0].strip()
-            if prefix and prefix not in out:
-                out.append(prefix)
-    return out
+            if prefix:
+                candidates.add(prefix)
+    return sorted(candidates, key=len, reverse=True)
 
 
 def _tv_search_queries(parsed: ParsedTitle) -> list[tuple[str, dict]]:

--- a/scripts/auto_import/tmdb_resolver.py
+++ b/scripts/auto_import/tmdb_resolver.py
@@ -196,11 +196,36 @@ def _movie_search_queries(parsed: ParsedTitle) -> list[tuple[str, dict]]:
     return out
 
 
+def _shorten_title_candidates(title: str) -> list[str]:
+    """Progressive shortenings for TMDB search fallback.
+
+    Returns [full, prefix_before_first_dash, prefix_before_colon] — deduped,
+    preserving order. Handy for SK Torrent titles with marketing noise like
+    "Výměna manželek - nyní pouze na Oneplay" where the full string misses
+    on TMDB but the bare show name matches.
+    """
+    out: list[str] = [title]
+    for sep in (" - ", ": "):
+        if sep in title:
+            prefix = title.split(sep, 1)[0].strip()
+            if prefix and prefix not in out:
+                out.append(prefix)
+    return out
+
+
 def _tv_search_queries(parsed: ParsedTitle) -> list[tuple[str, dict]]:
     out: list[tuple[str, dict]] = []
     titles = [parsed.cz_title, parsed.en_title]
     titles = [t for t in titles if t]
+    # Expand each title with its shortened variants so shows like
+    # "Výměna manželek - nyní pouze na Oneplay" also get tried as the bare
+    # "Výměna manželek" (which is what TMDB actually indexes).
+    expanded: list[str] = []
     for t in titles:
+        for v in _shorten_title_candidates(t):
+            if v not in expanded:
+                expanded.append(v)
+    for t in expanded:
         if parsed.year:
             out.append((t, {"first_air_date_year": parsed.year}))
         out.append((t, {}))


### PR DESCRIPTION
<!-- claude-session:  -->

## Summary

Three related production bugs surfaced via /admin/import/ audit:

1. **Title parser — SxxExx not stripped without slash separator.**
   `Královny Brna S01E03 (CZ)` → cz_title was `Královny Brna S01E03` →
   TMDB returned 0 hits → blacklisted. Now `clean()` strips SxxExx (and
   any trailing episode name) from each title part.

2. **Title parser — HTML double-escape.** `Survivor Česko &amp;amp; Slovensko`
   came through double-escaped from the SK Torrent `title="…"` attribute.
   Added `html.unescape()` × 2 pass at parse start.

3. **TMDB resolver — marketing suffix break search.** `Výměna manželek - nyní
   pouze na Oneplay` missed the canonical TMDB show because the full string
   doesn't match. New `_shorten_title_candidates()` also tries the prefix
   before ` - ` / `: ` → TMDB match.

4. **docker-compose.yml — missing cover volume mount.** `cover_downloader`
   writes to host `/opt/cr/data/movies/covers-webp`, but no mount meant the
   web container never saw new covers. **6679 of 16808 films** had
   `cover_filename` set but the handler was serving the 34-byte
   transparent placeholder baked into `films_cover()`. Mount the one path
   read/write.

All 8 existing parser tests still pass; 4 new cases (Královny Brna,
Survivor, Výměna manželek, Ruža pre nevestu) added.

## Rollout (already applied to prod)

1. `docker cp cr-web-1:/app/data/. /opt/cr/data/` — seed host dir with 10 775 baked covers
2. Edit `docker-compose.yml` (this PR's diff), `docker compose up -d web`
3. `DELETE FROM import_skipped_videos WHERE reason IN ('tmdb_tv_resolve_failed', 'tmdb_tv_porady_resolve_failed', 'tmdb_resolve_failed')` — 55 rows
4. `UPDATE import_checkpoint SET last_sktorrent_video_id = 59313, last_sktorrent_video_id_tv_porady = 59200` — roll back to before the parser regression
5. Re-run `auto-import.py --max-new 0` — run #15: **+15 films, +10 series, +15 episodes, +4 tv_shows, +6 tv_episodes**, 0 failed

Survivor, Výměna manželek, Extrémní proměny, Naked Attraction all now live on
/tv-porady/. Ezop, Pouic Pouic, Prachy v prachu, Pani mají radši blondýnky,
Opravdová blondýnka — all covers now visible on the homepage.

## Test plan

- [x] `python3 -m scripts.auto_import.test_title_parser` — 12/12 OK
- [x] TMDB resolver smoke test on 3 broken titles → all resolve
- [x] `curl /filmy-online/ezop.webp` — 14 758 B real WebP (was 34 B placeholder)
- [x] `curl /tv-porady/vymena-manzelek-2/` → 200
- [x] `curl /tv-porady/survivor-cesko-a-slovensko/` → 200