### PR TITLE
fix(auto-import): populate imdb_rating + csfd_rating on new films

### DIFF
--- a/scripts/auto-import.py
+++ b/scripts/auto-import.py
@@ -278,6 +278,7 @@ def _process_film(conn, *, run_id: int, video: ScannedVideo,
             cover_dir=movies_covers,
             has_dub=film_has_dub,
             has_subtitles=film_has_subs,
+            csfd_rating=parsed.csfd_rating,
         )
     except Exception as e:
         conn.rollback()

--- a/scripts/auto_import/enricher.py
+++ b/scripts/auto_import/enricher.py
@@ -96,6 +96,7 @@ def upsert_film(
     cover_dir: Path,
     has_dub: bool = False,
     has_subtitles: bool = False,
+    csfd_rating: int | None = None,
 ) -> tuple[str, int | None]:
     """Decide between updated_film / added_film / skipped and execute it.
 
@@ -174,19 +175,27 @@ def upsert_film(
     generated = generate_unique_cs(title_cs, movie.year, sources, is_series=False)
     description = generated or movie.overview_cs or movie.overview_en
 
+    # imdb_rating is seeded from TMDB's vote_average (acceptable proxy —
+    # same 0–10 scale, usually ≤0.5 apart for films with votes). csfd_rating
+    # comes straight from the SK Torrent title when present ("= CSFD 82%").
+    # Both NULL for new-release films and obscure CZ titles; the list page
+    # already handles missing ratings gracefully.
+    imdb_rating = movie.vote_average
     cur.execute(
         """INSERT INTO films
            (title, original_title, slug, year, description, generated_description,
             imdb_id, tmdb_id, runtime_min, cover_filename,
+            imdb_rating, csfd_rating,
             sktorrent_video_id, sktorrent_cdn, sktorrent_qualities,
             has_dub, has_subtitles,
             added_at, sktorrent_added_at)
-           VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, now(), now())
+           VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, now(), now())
            RETURNING id""",
         (
             title_cs, title_en if title_en != title_cs else None, slug, movie.year,
             description, generated,
             movie.imdb_id, movie.tmdb_id, movie.runtime_min, cover_filename,
+            imdb_rating, csfd_rating,
             sktorrent_video_id, sktorrent_cdn, qualities_str,
             has_dub, has_subtitles,
         ),

--- a/scripts/auto_import/tmdb_resolver.py
+++ b/scripts/auto_import/tmdb_resolver.py
@@ -56,6 +56,12 @@ class MovieResolution:
     runtime_min: int | None
     poster_path: str | None        # TMDB path like "/abc.jpg" — caller fetches via image.tmdb.org
     genre_ids: list[int]           # raw TMDB genre ids
+    # TMDB's own vote_average on 0–10. Our films table stores imdb_rating
+    # (0–10) and TMDB/IMDB usually agree within ±0.5 on popular titles, so
+    # we use it as an imdb_rating proxy until we wire in the real IMDB
+    # endpoint. Small indie/obscure CZ titles may diverge more — accept
+    # that for now.
+    vote_average: float | None = None
     popularity: float = 0.0
     raw_search_score: float = 0.0  # how confident we are in the match
 
@@ -249,6 +255,12 @@ def _build_movie_resolution(session: requests.Session, candidate: dict, score: f
     rd = (cs or src_en).get("release_date") or ""
     year = int(rd[:4]) if len(rd) >= 4 and rd[:4].isdigit() else None
 
+    # TMDB returns vote_average=0 for brand-new films with no votes yet —
+    # treat that as "no rating" to avoid seeding the column with a bogus 0.0
+    # that the list page would then display as a legit rating.
+    va_raw = src.get("vote_average") or src_en.get("vote_average")
+    vote_average = float(va_raw) if va_raw else None
+
     return MovieResolution(
         tmdb_id=tmdb_id,
         imdb_id=src.get("imdb_id") or src_en.get("imdb_id"),
@@ -261,6 +273,7 @@ def _build_movie_resolution(session: requests.Session, candidate: dict, score: f
         runtime_min=src.get("runtime") or src_en.get("runtime"),
         poster_path=src.get("poster_path") or src_en.get("poster_path"),
         genre_ids=[g["id"] for g in (src.get("genres") or src_en.get("genres") or []) if g.get("id")],
+        vote_average=vote_average,
         popularity=float(candidate.get("popularity") or 0.0),
         raw_search_score=score,
     )


### PR DESCRIPTION
<!-- claude-session: c0717c9a-16b7-4690-af5a-437a07586132 -->

## Summary

New films from auto-import had both `films.imdb_rating` and `films.csfd_rating` NULL, which is why every recent entry on /filmy-online/ showed "—" instead of a score.

Root cause: the enricher's INSERT never listed those columns, and `MovieResolution` didn't even carry `vote_average` from TMDB.

## Changes

- `MovieResolution` now has `vote_average: float | None`. TMDB returns 0.0 for films with zero votes — we map that to None so the column stays NULL instead of showing a bogus 0.
- `upsert_film(..., csfd_rating=None)` writes both columns.
- `auto-import.py` forwards `parsed.csfd_rating` (already parsed from "= CSFD 82%" suffixes).

## Disclosure

`imdb_rating` gets seeded from TMDB's `vote_average`, not a real IMDB scrape. Same 0-10 scale and usually ≤0.5 apart on popular titles. If we want exact IMDB numbers later, wiring in OMDb or scraping IMDB is a separate follow-up.

## Backfill applied on prod

47 films (imdb_rating NULL, added since 2026-04-15) updated from TMDB:

```
21081 'Most': 4.3
21080 'Ninjova pomsta': 6.246
21079 'Profesionál': 3.7
…
18539 'Private Gold 134: Sex Studio': 10.0
18454 'Skinford: Death Sentence': HTTP 404
updated 47 rows
```

## Test plan

- [x] TMDB resolver smoke test on Ezop → vote_average=7.0 propagates
- [x] Parser tests still 12/12 OK
- [x] `/filmy-online/?strana=1` — recent films now show IMDB scores