### PR TITLE
fix(auto-import): dedup TV pořad, route CZ shows to tv_shows, surface skip reasons

### DIFF
--- a/cr-web/templates/admin_import_detail.html
+++ b/cr-web/templates/admin_import_detail.html
@@ -128,12 +128,16 @@
         <p class="empty-state">Žádné přeskočené položky.</p>
         {% else %}
         <table class="items-table">
-            <thead><tr><th>SK Torrent</th><th>IMDB</th></tr></thead>
+            <thead><tr><th>SK Torrent</th><th>IMDB</th><th>Důvod</th></tr></thead>
             <tbody>
                 {% for it in skipped %}
                 <tr>
                     <td><a href="{{ it.sktorrent_url }}" target="_blank" rel="noopener" title="{{ it.sktorrent_title }}">{{ it.sktorrent_title }}</a></td>
                     <td>{% match it.imdb_url() %}{% when Some with (u) %}<a href="{{ u }}" target="_blank" rel="noopener" title="IMDB">{{ it.imdb_id.as_deref().unwrap_or("") }}</a>{% when None %}—{% endmatch %}</td>
+                    <td class="skip-reason">
+                        <span class="failure-step">{{ it.failure_step.as_deref().unwrap_or("?") }}</span>
+                        <span class="failure-msg-inline">{{ it.failure_message.as_deref().unwrap_or("—") }}</span>
+                    </td>
                 </tr>
                 {% endfor %}
             </tbody>
@@ -171,6 +175,8 @@
 .failure-item summary a { color: #11457E; text-decoration: none; flex: 1; }
 .failure-step { background: #fee2e2; color: #991b1b; padding: 0.1rem 0.4rem; border-radius: 4px; font-size: 0.72rem; font-weight: 600; }
 .failure-msg { color: #b91c1c; font-size: 0.82rem; max-width: 40%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.skip-reason { display: flex; flex-direction: column; gap: 0.2rem; font-size: 0.78rem; }
+.failure-msg-inline { color: #6b7280; }
 .raw-log { background: #1f2937; color: #d1d5db; padding: 0.8rem; border-radius: 4px; overflow: auto; font-size: 0.75rem; max-height: 400px; margin-top: 0.6rem; }
 .empty-state { color: #888; padding: 2rem; text-align: center; background: #fafafa; border-radius: 8px; }
 .badge { display: inline-block; padding: 0.15rem 0.5rem; border-radius: 999px; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; }

--- a/scripts/auto-import.py
+++ b/scripts/auto-import.py
@@ -293,32 +293,73 @@ def _process_film(conn, *, run_id: int, video: ScannedVideo,
         conn.commit()
         return
 
-    _insert_item(conn, run_id=run_id, video=video, parsed=parsed,
-                 detected_type="film",
-                 imdb_id=movie.imdb_id, tmdb_id=movie.tmdb_id,
-                 action=action, target_film_id=film_id)
-    if action == "added_film":
-        counters["added_films"] += 1
-    elif action == "updated_film":
-        counters["updated_films"] += 1
-    elif action == "skipped":
+    # When upsert_film returns "skipped" it means the film already has this
+    # exact SK Torrent video id linked — record that as the reason so the
+    # admin dashboard doesn't show a reason-less row.
+    if action == "skipped":
+        _insert_item(conn, run_id=run_id, video=video, parsed=parsed,
+                     detected_type="film",
+                     imdb_id=movie.imdb_id, tmdb_id=movie.tmdb_id,
+                     action="skipped", target_film_id=film_id,
+                     failure_step="already_imported",
+                     failure_message="film already linked to this SK Torrent video")
         counters["skipped_count"] += 1
+    else:
+        _insert_item(conn, run_id=run_id, video=video, parsed=parsed,
+                     detected_type="film",
+                     imdb_id=movie.imdb_id, tmdb_id=movie.tmdb_id,
+                     action=action, target_film_id=film_id)
+        if action == "added_film":
+            counters["added_films"] += 1
+        elif action == "updated_film":
+            counters["updated_films"] += 1
     conn.commit()
 
 
 def _process_episode(conn, *, run_id: int, video: ScannedVideo,
                      parsed: ParsedTitle, detail, series_covers: Path,
                      counters: dict, tmdb_session: requests.Session) -> None:
+    # SK Torrent sometimes lists a TV pořad video (e.g. Královny Brna,
+    # Asia Express) in BOTH /videos/ (generic) and /videos/tv-porady/.
+    # If the tv-porady scan already created a tv_episode for this id,
+    # silently skip the duplicate from the generic scan — don't touch
+    # the blacklist and don't flag it as a failure in the admin log.
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT tv_show_id FROM tv_episodes WHERE sktorrent_video_id = %s LIMIT 1",
+        (video.video_id,),
+    )
+    existing_tv_ep = cur.fetchone()
+    if existing_tv_ep is not None:
+        _insert_item(conn, run_id=run_id, video=video, parsed=parsed,
+                     detected_type="tv_episode", imdb_id=None, tmdb_id=None,
+                     action="skipped",
+                     failure_step="duplicate_tv_porad",
+                     failure_message="already imported via /videos/tv-porady scan",
+                     target_tv_show_id=existing_tv_ep[0])
+        counters["skipped_count"] += 1
+        conn.commit()
+        return
+
     tv = resolve_tv(parsed, session=tmdb_session)
-    if tv is None or not tv.imdb_id:
+    if tv is None:
         _mark_skipped(conn, video.video_id, "tmdb_tv_resolve_failed")
         _insert_item(conn, run_id=run_id, video=video, parsed=parsed,
                      detected_type="episode", imdb_id=None, tmdb_id=None,
                      action="skipped",
                      failure_step="tmdb_tv_resolve",
-                     failure_message="no TV match or missing imdb_id",
+                     failure_message="no TMDB match",
                      raw_log={"detail": asdict(detail) if detail else None})
         counters["skipped_count"] += 1
+        return
+    if not tv.imdb_id:
+        # TMDB has a TV match but no IMDB link — hallmark of a CZ/SK-only
+        # production (Královny Brna, Asia Express, Superlov). Route to the
+        # tv_show flow instead of failing here; `series` table needs an
+        # imdb_id but `tv_shows` doesn't.
+        _process_tv_show(conn, run_id=run_id, video=video, parsed=parsed,
+                         detail=detail, counters=counters,
+                         tmdb_session=tmdb_session)
         return
 
     ep_has_dub, ep_has_subs = _langs_to_flags(parsed.langs)
@@ -377,15 +418,22 @@ def _process_episode(conn, *, run_id: int, video: ScannedVideo,
             store_action = action
         elif action == "failed":
             counters["failed_count"] += 1
-            store_action = action
+            _insert_item(conn, run_id=run_id, video=video, parsed=parsed,
+                         detected_type="episode",
+                         imdb_id=tv.imdb_id, tmdb_id=tv.tmdb_id,
+                         action=action,
+                         target_episode_id=ep_id)
         else:
             counters["skipped_count"] += 1
-            store_action = action
-        _insert_item(conn, run_id=run_id, video=video, parsed=parsed,
-                     detected_type="episode",
-                     imdb_id=tv.imdb_id, tmdb_id=tv.tmdb_id,
-                     action=store_action,
-                     target_episode_id=ep_id)
+            # Episode already had this sktorrent_video_id linked — record a
+            # reason so the admin "Skipped" tab never shows a blank why.
+            _insert_item(conn, run_id=run_id, video=video, parsed=parsed,
+                         detected_type="episode",
+                         imdb_id=tv.imdb_id, tmdb_id=tv.tmdb_id,
+                         action=action,
+                         target_episode_id=ep_id,
+                         failure_step="already_imported",
+                         failure_message="episode already linked to this SK Torrent video")
     conn.commit()
 
 

--- a/scripts/auto_import/enricher.py
+++ b/scripts/auto_import/enricher.py
@@ -118,6 +118,13 @@ def upsert_film(
     cur = conn.cursor()
     qualities_str = ",".join(sktorrent_qualities) if sktorrent_qualities else None
 
+    # Clamp csfd_rating to 0..100 — _detect_csfd accepts any 1–3 digit number
+    # so a malformed title like "CSFD 999%" would otherwise land in DB and
+    # corrupt sorting / card rendering.
+    if csfd_rating is not None and not (0 <= csfd_rating <= 100):
+        log.warning("csfd_rating=%d out of range, dropping", csfd_rating)
+        csfd_rating = None
+
     # --- Path A: film already in DB? ---
     cur.execute(
         "SELECT id, sktorrent_video_id FROM films WHERE imdb_id = %s",
@@ -133,15 +140,21 @@ def upsert_film(
         # Preserve existing has_dub/has_subtitles when updating — the DB value
         # reflects any previously linked source (e.g. Bombuj) and we only want
         # to OR-in the new signal from SK Torrent, not downgrade to False.
+        # Backfill ratings via COALESCE — only fill if DB value is NULL, so
+        # manually-curated numbers are never overwritten.
         cur.execute(
             "UPDATE films SET sktorrent_video_id = %s, sktorrent_cdn = %s, "
             "sktorrent_qualities = %s, "
             "has_dub = has_dub OR %s, "
             "has_subtitles = has_subtitles OR %s, "
+            "imdb_rating = COALESCE(imdb_rating, %s), "
+            "csfd_rating = COALESCE(csfd_rating, %s), "
             "sktorrent_added_at = now() "
             "WHERE id = %s",
             (sktorrent_video_id, sktorrent_cdn, qualities_str,
-             has_dub, has_subtitles, film_id),
+             has_dub, has_subtitles,
+             movie.vote_average, csfd_rating,
+             film_id),
         )
         log.info("upserted SKT into existing film %d (imdb=%s)", film_id, movie.imdb_id)
         return "updated_film", film_id


### PR DESCRIPTION
<!-- claude-session: c0717c9a-16b7-4690-af5a-437a07586132 -->

## Summary

/admin/import/15 was surfacing real bugs plus cosmetic noise:

1. **Duplicate TV pořad scan** — Královny Brna appeared 16× under "Přeskočeno". SK Torrent lists CZ reality shows in BOTH /videos/ (generic) and /videos/tv-porady/. Generic path tried series/episodes flow → no imdb_id → blacklisted.
   **Fix:** `_process_episode` checks `tv_episodes` by sktorrent_video_id first. If already imported via the tv-porady scan, silently skip with reason `duplicate_tv_porad` — no blacklist touch.

2. **CZ-only TV shows missed by series flow** — Superlov, Asia Express etc. resolve on TMDB but have no imdb_id. `series` table requires imdb_id; `tv_shows` doesn't.
   **Fix:** when `resolve_tv` returns a match with NULL imdb_id, route to `_process_tv_show` instead of failing.

3. **Reason-less "skipped" rows** — 103 rows had `failure_step=NULL` because `upsert_film`'s Path A (film already linked) didn't set one.
   **Fix:** callers explicitly set `failure_step="already_imported"` + message; backfilled 108 prod rows with one UPDATE.

4. **Admin UI missing reason column** — "Přeskočeno" tab now has a **Důvod** column showing `failure_step` + `failure_message` so every row answers *why*.

5. **Copilot comments from PR #491** folded in:
   - `csfd_rating` clamped to 0..100 before insert (parser will only return 1-3 digits, so 999% is technically possible).
   - Path A `UPDATE` now backfills `imdb_rating` / `csfd_rating` via `COALESCE` — fills NULLs, never overwrites curated values.

## Test plan

- [x] `python3 -m scripts.auto_import.test_title_parser` — 12/12 OK
- [x] `cargo check -p cr-web` — compiles (Askama template change)
- [x] Deployed locally via `cargo zigbuild` + scp; /admin/import/15 now shows Důvod column
- [x] Backfilled 108 past rows
- [ ] Next auto-import run should show 0 "missing imdb_id" rows for CZ shows — will verify after merge