### PR TITLE
feat(tv-porady): search autocomplete on /tv-porady/ list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,22 @@
 
 Instructions for Claude Code when working in this repository.
 
+## CRITICAL — Change Workflow Order (MANDATORY)
+
+Every code change in this repo goes through FOUR stages, in this exact order. Never skip, never reorder.
+
+1. **Local implementation** — edit code on the feature branch.
+2. **Local verification** — build + run locally (`cargo check`, `cargo test`, `cargo run -p cr-web`, unit tests for Python scripts). The change MUST work end-to-end on the dev environment before moving on.
+3. **Production deploy + verification** — cross-compile, scp binary (or rsync Python), restart the web container, then **open Playwright against `https://ceskarepublika.wiki` from the local PC** and exercise the feature as a real user (see "Playwright Testing Rules" below). Fix any issues locally, redeploy, re-verify until prod is green.
+4. **PR + code review + merge** — ONLY after step 3 is green: `git push`, `gh pr create`, wait for CI + Copilot review, address comments, merge.
+
+**Why this order matters:** Opening a PR before prod verification means Copilot reviews code that will likely need more fixes once it's been tested on production — triggering a PR-fix-review-fix cycle. Testing on prod first means Copilot reviews the final working version **once**. It also prevents "issue hotová" messages after a merged PR when the actual feature is still broken on the live site.
+
+**Concrete don'ts:**
+- Do NOT `gh pr create` before you have paste-ready "deployed + Playwright-verified" evidence for the PR body's Test plan.
+- Do NOT merge a PR just because CI is green — CI only tests code correctness, not feature correctness.
+- `curl` smoke tests are helpful but do NOT replace Playwright interaction for UI changes.
+
 ## CRITICAL — Issue Completion Rules (MANDATORY)
 
 **An issue is NOT done after creating a PR.** An issue is done ONLY after ALL of these:

--- a/cr-web/src/handlers/mod.rs
+++ b/cr-web/src/handlers/mod.rs
@@ -37,7 +37,7 @@ pub use series::{
     episode_detail, series_episode_still, series_list, series_person_image, series_resolve,
     series_search,
 };
-pub use tv_porady::{tv_epizoda_detail, tv_porad_detail, tv_porady_list};
+pub use tv_porady::{tv_epizoda_detail, tv_porad_detail, tv_porady_list, tv_porady_search};
 pub use video_api::{
     library_delete, library_file, library_list, library_play, library_stream, video_cleanup,
     video_file, video_file_part, video_info, video_prepare, video_recent, video_status,

--- a/cr-web/src/handlers/tv_porady.rs
+++ b/cr-web/src/handlers/tv_porady.rs
@@ -272,6 +272,66 @@ async fn fetch_latest_episode_cards(
     Ok(rows)
 }
 
+#[derive(Serialize)]
+struct TvPoradSearchResult {
+    slug: String,
+    title: String,
+    year: Option<i16>,
+    imdb_rating: Option<f32>,
+    cover: bool,
+}
+
+#[derive(FromRow)]
+struct TvPoradSearchRow {
+    slug: String,
+    title: String,
+    first_air_year: Option<i16>,
+    imdb_rating: Option<f32>,
+    cover_filename: Option<String>,
+}
+
+/// GET /api/tv-porady/search?q=...
+pub async fn tv_porady_search(
+    State(state): State<AppState>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
+) -> WebResult<Response> {
+    let q = params.get("q").map(|s| s.trim()).unwrap_or("");
+    if q.len() < 2 {
+        return Ok(axum::Json(Vec::<TvPoradSearchResult>::new()).into_response());
+    }
+    let pattern = format!("%{q}%");
+    let starts_pattern = format!("{q}%");
+    let rows = sqlx::query_as::<_, TvPoradSearchRow>(
+        "SELECT slug, title, first_air_year, imdb_rating, cover_filename \
+         FROM tv_shows \
+         WHERE title ILIKE $1 OR original_title ILIKE $1 \
+         ORDER BY \
+           CASE WHEN title ILIKE $2 THEN 0 \
+                WHEN title ILIKE $1 THEN 1 \
+                WHEN original_title ILIKE $2 THEN 2 \
+                ELSE 3 END, \
+           imdb_rating DESC NULLS LAST \
+         LIMIT 10",
+    )
+    .bind(&pattern)
+    .bind(&starts_pattern)
+    .fetch_all(&state.db)
+    .await?;
+
+    let results: Vec<TvPoradSearchResult> = rows
+        .into_iter()
+        .map(|r| TvPoradSearchResult {
+            slug: r.slug,
+            title: r.title,
+            year: r.first_air_year,
+            imdb_rating: r.imdb_rating,
+            cover: r.cover_filename.is_some(),
+        })
+        .collect();
+
+    Ok(axum::Json(results).into_response())
+}
+
 /// GET /tv-porady/{slug}/ — TV pořad detail with episode list.
 pub async fn tv_porad_detail(
     State(state): State<AppState>,

--- a/cr-web/src/main.rs
+++ b/cr-web/src/main.rs
@@ -226,6 +226,10 @@ async fn main() -> Result<()> {
             axum::routing::get(handlers::series_search),
         )
         .route(
+            "/tv-porady/search",
+            axum::routing::get(handlers::tv_porady_search),
+        )
+        .route(
             "/films/sktorrent-resolve",
             axum::routing::get(handlers::sktorrent_resolve),
         )

--- a/cr-web/templates/tv_porady_list.html
+++ b/cr-web/templates/tv_porady_list.html
@@ -34,6 +34,7 @@
 <div class="search-container" id="header-search-box">
     <input type="text" id="tv-search" class="search-input" placeholder="Hledat TV pořad..." autocomplete="off" {% match search_query %}{% when Some with (q) %}value="{{ q }}"{% when None %}{% endmatch %}>
     <button class="search-btn" onclick="doSearch()">Hledat</button>
+    <div id="search-results" class="search-dropdown"></div>
 </div>
 {% endblock %}
 
@@ -218,6 +219,19 @@
 .page-link:hover { background: #11457E; color: white; }
 .page-link.current { background: #C5A059; color: white; cursor: default; }
 .page-dots { padding: 0.4rem 0.2rem; color: #888; }
+
+/* Search autocomplete dropdown */
+#header-search-box { position: relative; overflow: visible !important; }
+.search-dropdown { display: none; position: absolute; top: calc(100% + 4px); left: 0; right: 0; background: white; border: 1px solid #ddd; border-radius: 12px; box-shadow: 0 8px 24px rgba(0,0,0,0.18); z-index: 200; max-height: 420px; overflow-y: auto; }
+.search-dropdown.open { display: block; }
+.search-item { display: flex; align-items: center; gap: 0.7rem; padding: 0.5rem 0.8rem; text-decoration: none; color: inherit; border-bottom: 1px solid #f0f0f0; transition: background 0.15s; }
+.search-item:last-child { border-bottom: none; }
+.search-item:hover { background: #f5f5f5; }
+.search-item img { width: 40px; height: 60px; object-fit: cover; border-radius: 4px; flex-shrink: 0; }
+.search-item .si-placeholder { width: 40px; height: 60px; background: #eee; border-radius: 4px; flex-shrink: 0; }
+.search-item .si-info { flex: 1; min-width: 0; }
+.search-item .si-title { font-weight: 500; display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.search-item .si-meta { font-size: 0.8rem; color: #888; }
 </style>
 
 <script>
@@ -270,9 +284,45 @@ function applySortCombined(v) {
     }
 })();
 
+/* Autocomplete — mirrors series_list.html, hits /api/tv-porady/search */
 (function() {
     var input = document.getElementById('tv-search');
-    if (!input) return;
+    var dd = document.getElementById('search-results');
+    var timer = null;
+    if (!input || !dd) return;
+
+    input.addEventListener('input', function() {
+        clearTimeout(timer);
+        var q = this.value.trim();
+        if (q.length < 2) { dd.classList.remove('open'); return; }
+        timer = setTimeout(function() {
+            fetch('/api/tv-porady/search?q=' + encodeURIComponent(q))
+                .then(function(r) { return r.json(); })
+                .then(function(results) {
+                    if (!results.length) {
+                        dd.innerHTML = '<div style="padding:0.8rem;color:#888;text-align:center">Nic nenalezeno</div>';
+                    } else {
+                        dd.innerHTML = results.map(function(r) {
+                            var cover = r.cover
+                                ? '<img src="/tv-porady/' + r.slug + '.webp" alt="' + r.title + '" title="' + r.title + '">'
+                                : '<div class="si-placeholder"></div>';
+                            var yr = r.year ? ' (' + r.year + ')' : '';
+                            var rat = r.imdb_rating ? ' — IMDB ' + r.imdb_rating : '';
+                            return '<a href="/tv-porady/' + r.slug + '/" class="search-item" title="' + r.title + '">'
+                                + cover + '<div class="si-info"><span class="si-title">' + r.title + yr + '</span>'
+                                + '<span class="si-meta">' + rat + '</span></div></a>';
+                        }).join('');
+                    }
+                    dd.classList.add('open');
+                })
+                .catch(function() { dd.classList.remove('open'); });
+        }, 200);
+    });
+
+    document.addEventListener('click', function(e) {
+        if (!e.target.closest('#header-search-box')) dd.classList.remove('open');
+    });
+
     input.addEventListener('keydown', function(e) {
         if (e.key === 'Enter') { e.preventDefault(); doSearch(); }
     });

--- a/cr-web/templates/tv_porady_list.html
+++ b/cr-web/templates/tv_porady_list.html
@@ -284,38 +284,84 @@ function applySortCombined(v) {
     }
 })();
 
-/* Autocomplete — mirrors series_list.html, hits /api/tv-porady/search */
+/* Autocomplete — hits /api/tv-porady/search. Uses DOM APIs + AbortController
+   to avoid XSS from untrusted titles and stale responses overwriting fresh
+   results (both flagged by Copilot on PR #493). */
 (function() {
     var input = document.getElementById('tv-search');
     var dd = document.getElementById('search-results');
     var timer = null;
+    var currentCtrl = null;
     if (!input || !dd) return;
+
+    function renderResults(results) {
+        dd.textContent = '';
+        if (!results.length) {
+            var empty = document.createElement('div');
+            empty.style.padding = '0.8rem';
+            empty.style.color = '#888';
+            empty.style.textAlign = 'center';
+            empty.textContent = 'Nic nenalezeno';
+            dd.appendChild(empty);
+            return;
+        }
+        results.forEach(function(r) {
+            var item = document.createElement('a');
+            item.href = '/tv-porady/' + r.slug + '/';
+            item.className = 'search-item';
+            item.title = r.title;
+
+            if (r.cover) {
+                var img = document.createElement('img');
+                img.src = '/tv-porady/' + r.slug + '.webp';
+                img.alt = r.title;
+                img.title = r.title;
+                item.appendChild(img);
+            } else {
+                var placeholder = document.createElement('div');
+                placeholder.className = 'si-placeholder';
+                item.appendChild(placeholder);
+            }
+
+            var info = document.createElement('div');
+            info.className = 'si-info';
+            var title = document.createElement('span');
+            title.className = 'si-title';
+            title.textContent = r.title + (r.year ? ' (' + r.year + ')' : '');
+            var meta = document.createElement('span');
+            meta.className = 'si-meta';
+            meta.textContent = r.imdb_rating ? ' — IMDB ' + r.imdb_rating : '';
+            info.appendChild(title);
+            info.appendChild(meta);
+            item.appendChild(info);
+            dd.appendChild(item);
+        });
+    }
 
     input.addEventListener('input', function() {
         clearTimeout(timer);
         var q = this.value.trim();
-        if (q.length < 2) { dd.classList.remove('open'); return; }
+        if (q.length < 2) {
+            if (currentCtrl) { currentCtrl.abort(); currentCtrl = null; }
+            dd.classList.remove('open');
+            return;
+        }
         timer = setTimeout(function() {
-            fetch('/api/tv-porady/search?q=' + encodeURIComponent(q))
+            if (currentCtrl) currentCtrl.abort();
+            currentCtrl = new AbortController();
+            var myCtrl = currentCtrl;
+            fetch('/api/tv-porady/search?q=' + encodeURIComponent(q),
+                  { signal: myCtrl.signal })
                 .then(function(r) { return r.json(); })
                 .then(function(results) {
-                    if (!results.length) {
-                        dd.innerHTML = '<div style="padding:0.8rem;color:#888;text-align:center">Nic nenalezeno</div>';
-                    } else {
-                        dd.innerHTML = results.map(function(r) {
-                            var cover = r.cover
-                                ? '<img src="/tv-porady/' + r.slug + '.webp" alt="' + r.title + '" title="' + r.title + '">'
-                                : '<div class="si-placeholder"></div>';
-                            var yr = r.year ? ' (' + r.year + ')' : '';
-                            var rat = r.imdb_rating ? ' — IMDB ' + r.imdb_rating : '';
-                            return '<a href="/tv-porady/' + r.slug + '/" class="search-item" title="' + r.title + '">'
-                                + cover + '<div class="si-info"><span class="si-title">' + r.title + yr + '</span>'
-                                + '<span class="si-meta">' + rat + '</span></div></a>';
-                        }).join('');
-                    }
+                    if (myCtrl !== currentCtrl) return; // stale
+                    renderResults(results);
                     dd.classList.add('open');
                 })
-                .catch(function() { dd.classList.remove('open'); });
+                .catch(function(err) {
+                    if (err.name === 'AbortError') return;
+                    dd.classList.remove('open');
+                });
         }, 200);
     });
 


### PR DESCRIPTION
<!-- claude-session: c0717c9a-16b7-4690-af5a-437a07586132 -->

## Summary

/tv-porady/ header had a search box with no suggestions — just form-submit. This wires up the autocomplete flow to match /serialy-online/.

## Changes

- **handlers/tv_porady.rs:** new `tv_porady_search` handler, SQL mirrors `series_search` but hits `tv_shows` instead of `series`. Returns `[{slug, title, year, imdb_rating, cover}]`.
- **handlers/mod.rs + main.rs:** export + route `/api/tv-porady/search`.
- **templates/tv_porady_list.html:** add dropdown div, CSS, and fetch JS (200ms debounce, min 2 chars, hits the new endpoint).

## Test plan

- [x] `cargo check -p cr-web` passes
- [ ] After deploy: type 2+ chars into /tv-porady/ header, see suggestions with covers + ratings