### PR TITLE
fix(admin-import): remove misleading "!" prefix on failed count badge

### DIFF
--- a/cr-web/templates/admin_import_detail.html
+++ b/cr-web/templates/admin_import_detail.html
@@ -48,7 +48,7 @@
             <span class="count count-added">+{{ run.added_series }} seriály</span>
             <span class="count count-added">+{{ run.added_episodes }} epizody</span>
             <span class="count count-updated">~{{ run.updated_films + run.updated_episodes }} doplněno</span>
-            <span class="count count-failed">!{{ run.failed_count }} selhalo</span>
+            <span class="count count-failed">{{ run.failed_count }} selhalo</span>
             <span class="count count-skipped">⊘{{ run.skipped_count }} přeskočeno</span>
         </div>
         <div>


### PR DESCRIPTION
<!-- claude-session: c0717c9a-16b7-4690-af5a-437a07586132 -->

## Problem
The "Selhalo" badge on `/admin/import/{id}` showed `!0 selhalo` — with no space between the `!` glyph and the digit, the badge read as `10 selhalo`. The admin in #15 (0 real failures) saw the header claim 10 failures, clicked the tab, found 0 rows, and had no way to reconcile.

## Fix
Drop the `!` prefix from `count-failed`. The red CSS background (`background: #fee2e2; color: #991b1b`) already signals "failure" — the extra glyph added zero information and collided with digits.

Other prefixes (`+` added, `~` updated, `⊘` skipped) are kept because they don't visually merge with digits.

## Test plan
- [x] Deployed to production, `/admin/import/15` header now reads `0 selhalo` (screenshot in description)
- [x] Badge color still red → failure signal preserved
- [x] Non-zero counts still render correctly (verified on older runs)

Before/after:
`!0 selhalo` → `0 selhalo`