### PR TITLE
feat(admin): auto DB backups to Cloudflare R2 + /admin/ dashboard

### DIFF
--- a/cr-infra/migrations/20260507_047_backup_runs.sql
+++ b/cr-infra/migrations/20260507_047_backup_runs.sql
@@ -16,7 +16,9 @@ CREATE TABLE IF NOT EXISTS backup_runs (
     trigger         TEXT NOT NULL DEFAULT 'auto',
     -- Velikost výsledného gzip souboru v bajtech. NULL, pokud pg_dump selhal.
     size_bytes      BIGINT,
-    -- Klíč v R2 bucketu, např. 'auto/cr_prod_2026-04-17_0300.dump.gz'.
+    -- Klíč v R2 bucketu, např. 'auto/cr_prod_2026-04-17T0300Z.dump.gz'.
+    -- Skript přidává čas (HHMMZ) do názvu, aby se opakované běhy ve stejný
+    -- den (manual po transientní chybě automatu) nepřepisovaly v R2.
     dump_filename   TEXT,
     -- Krátká diagnostika pokud status='error'. Detail jde do journald.
     error_message   TEXT,

--- a/cr-infra/migrations/20260507_047_backup_runs.sql
+++ b/cr-infra/migrations/20260507_047_backup_runs.sql
@@ -1,0 +1,30 @@
+-- Auto-zálohy produkční PostgreSQL na Cloudflare R2. Každý běh skriptu
+-- scripts/backup-db.sh (spouštěný systemd timerem na prod serveru) zapisuje
+-- jednu řádku sem — start, konec, status, velikost gzip dumpu, filename
+-- v bucketu cr-backups/auto/ a případná chybová hláška.
+--
+-- Admin UI /admin/backups/ čte z téhle tabulky jako /admin/import/ čte z
+-- import_runs — stejný sloupec status, stejné badge.
+
+CREATE TABLE IF NOT EXISTS backup_runs (
+    id              SERIAL PRIMARY KEY,
+    started_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    finished_at     TIMESTAMPTZ,
+    -- 'running' while in progress, 'ok' on success, 'error' on failure.
+    status          TEXT NOT NULL DEFAULT 'running',
+    -- 'auto' = systemd timer, 'manual' = operator spustil ručně.
+    trigger         TEXT NOT NULL DEFAULT 'auto',
+    -- Velikost výsledného gzip souboru v bajtech. NULL, pokud pg_dump selhal.
+    size_bytes      BIGINT,
+    -- Klíč v R2 bucketu, např. 'auto/cr_prod_2026-04-17_0300.dump.gz'.
+    dump_filename   TEXT,
+    -- Krátká diagnostika pokud status='error'. Detail jde do journald.
+    error_message   TEXT,
+
+    CONSTRAINT backup_runs_status_check CHECK (status IN ('running', 'ok', 'error')),
+    CONSTRAINT backup_runs_trigger_check CHECK (trigger IN ('auto', 'manual'))
+);
+
+-- Default dotaz v admin handleru: ORDER BY started_at DESC LIMIT 30.
+CREATE INDEX IF NOT EXISTS backup_runs_started_at_idx
+    ON backup_runs (started_at DESC);

--- a/cr-web/src/handlers/admin_backups.rs
+++ b/cr-web/src/handlers/admin_backups.rs
@@ -123,7 +123,8 @@ pub async fn admin_backups_list(State(state): State<AppState>) -> WebResult<Resp
     .fetch_optional(&state.db)
     .await?;
 
-    let hours_since_last_ok = last_ok_started_at.map(|t| (chrono::Utc::now() - t).num_hours().max(0));
+    let hours_since_last_ok =
+        last_ok_started_at.map(|t| (chrono::Utc::now() - t).num_hours().max(0));
 
     let tmpl = AdminBackupsTemplate {
         img: state.image_base_url.clone(),

--- a/cr-web/src/handlers/admin_backups.rs
+++ b/cr-web/src/handlers/admin_backups.rs
@@ -1,0 +1,134 @@
+//! Admin dashboard for the PostgreSQL auto-backup pipeline.
+//!
+//! Read-only UI listing the last 30 `pg_dump` runs that `scripts/backup-db.sh`
+//! pushed to Cloudflare R2. Mounted under `/admin/backups/` — same auth story
+//! as `/admin/import/` (currently public, see `admin_import.rs`).
+//!
+//! Routes:
+//!   GET /admin/backups/  — last 30 runs (table + freshness banner)
+//!   GET /admin/backups   — same, without trailing slash
+
+use askama::Template;
+use axum::extract::State;
+use axum::response::{Html, IntoResponse, Response};
+
+use crate::error::WebResult;
+use crate::state::AppState;
+
+#[derive(sqlx::FromRow)]
+struct BackupRunRow {
+    id: i32,
+    started_at: chrono::DateTime<chrono::Utc>,
+    finished_at: Option<chrono::DateTime<chrono::Utc>>,
+    status: String,
+    trigger: String,
+    size_bytes: Option<i64>,
+    dump_filename: Option<String>,
+    error_message: Option<String>,
+}
+
+impl BackupRunRow {
+    fn duration_sec(&self) -> i64 {
+        let end = self.finished_at.unwrap_or_else(chrono::Utc::now);
+        (end - self.started_at).num_seconds().max(0)
+    }
+    fn started_at_str(&self) -> String {
+        self.started_at.format("%Y-%m-%d %H:%M").to_string()
+    }
+    fn status_class(&self) -> &'static str {
+        match self.status.as_str() {
+            "ok" => "status-ok",
+            "error" => "status-error",
+            "running" => "status-running",
+            _ => "status-unknown",
+        }
+    }
+    /// Human-friendly size (e.g. "24.3 MB") or "—" when pg_dump failed
+    /// before producing the file.
+    fn size_human(&self) -> String {
+        match self.size_bytes {
+            None => "—".to_string(),
+            Some(b) if b < 1024 => format!("{} B", b),
+            Some(b) if b < 1024 * 1024 => format!("{:.1} KB", b as f64 / 1024.0),
+            Some(b) if b < 1024 * 1024 * 1024 => format!("{:.1} MB", b as f64 / (1024.0 * 1024.0)),
+            Some(b) => format!("{:.2} GB", b as f64 / (1024.0 * 1024.0 * 1024.0)),
+        }
+    }
+}
+
+/// Freshness banner at the top of the page. Daily timer runs at 03:00 UTC, so
+/// anything over ~26h means yesterday's run was skipped/failed.
+struct FreshnessBanner {
+    css_class: &'static str,
+    text: String,
+}
+
+impl FreshnessBanner {
+    fn from_hours(hours: Option<i64>) -> Self {
+        match hours {
+            None => Self {
+                css_class: "banner-error",
+                text: "🚨 Dosud žádná úspěšná záloha — pipeline ještě neběžela nebo každá proběhla s chybou.".to_string(),
+            },
+            Some(h) if h <= 26 => Self {
+                css_class: "banner-ok",
+                text: format!("✅ Poslední úspěšná záloha před {h} hodinami — vše v pořádku."),
+            },
+            Some(h) if h <= 48 => Self {
+                css_class: "banner-warn",
+                text: format!("⚠️ Poslední úspěšná záloha před {h} hodinami — očekáváme denní běh."),
+            },
+            Some(h) => Self {
+                css_class: "banner-error",
+                text: format!("🚨 Poslední úspěšná záloha před {h} hodinami — zkontroluj systemd timer a R2 token."),
+            },
+        }
+    }
+}
+
+#[derive(Template)]
+#[template(path = "admin_backups.html")]
+struct AdminBackupsTemplate {
+    img: String,
+    runs: Vec<BackupRunRow>,
+    banner: FreshnessBanner,
+}
+
+/// Apply X-Robots-Tag noindex — mirror what admin_import does.
+fn noindex(html: String) -> Response {
+    let mut resp = Html(html).into_response();
+    resp.headers_mut().insert(
+        "X-Robots-Tag",
+        axum::http::HeaderValue::from_static("noindex, nofollow"),
+    );
+    resp
+}
+
+/// GET /admin/backups/  — last 30 backup runs.
+pub async fn admin_backups_list(State(state): State<AppState>) -> WebResult<Response> {
+    let runs = sqlx::query_as::<_, BackupRunRow>(
+        "SELECT id, started_at, finished_at, status, trigger, size_bytes, \
+         dump_filename, error_message \
+         FROM backup_runs ORDER BY started_at DESC LIMIT 30",
+    )
+    .fetch_all(&state.db)
+    .await?;
+
+    // Separate query so the banner stays honest even if the last 30 rows are
+    // all failures (a real scenario when R2 credentials rotate).
+    let last_ok_started_at: Option<chrono::DateTime<chrono::Utc>> = sqlx::query_scalar(
+        "SELECT started_at FROM backup_runs WHERE status = 'ok' \
+         ORDER BY started_at DESC LIMIT 1",
+    )
+    .fetch_optional(&state.db)
+    .await?;
+
+    let hours_since_last_ok = last_ok_started_at.map(|t| (chrono::Utc::now() - t).num_hours().max(0));
+
+    let tmpl = AdminBackupsTemplate {
+        img: state.image_base_url.clone(),
+        runs,
+        banner: FreshnessBanner::from_hours(hours_since_last_ok),
+    };
+    Ok(noindex(tmpl.render()?))
+}

--- a/cr-web/src/handlers/admin_dashboard.rs
+++ b/cr-web/src/handlers/admin_dashboard.rs
@@ -82,10 +82,13 @@ async fn fetch_import_tile(state: &AppState) -> LastRunTile {
     {
         Ok(r) => r,
         Err(e) => {
+            // Detail do journaldu, obecná hláška do HTML — /admin/ je zatím
+            // bez auth a je na veřejném vhostu, neleakovat DB hostname /
+            // SQLx driver detaily návštěvníkům.
             tracing::error!("admin dashboard: import_runs query failed: {e}");
             return LastRunTile {
                 status: "error",
-                message: format!("Chyba čtení import_runs: {e}"),
+                message: "Chyba DB (import_runs) — viz journald.".to_string(),
             };
         }
     };
@@ -138,10 +141,11 @@ async fn fetch_backup_tile(state: &AppState) -> LastRunTile {
     {
         Ok(r) => r,
         Err(e) => {
+            // Stejně jako u import_runs — obecná hláška, detaily do journaldu.
             tracing::error!("admin dashboard: backup_runs query failed: {e}");
             return LastRunTile {
                 status: "error",
-                message: format!("Chyba čtení backup_runs: {e}"),
+                message: "Chyba DB (backup_runs) — viz journald.".to_string(),
             };
         }
     };

--- a/cr-web/src/handlers/admin_dashboard.rs
+++ b/cr-web/src/handlers/admin_dashboard.rs
@@ -1,0 +1,170 @@
+//! Admin landing page `/admin/` — rozcestník pro všechny administrační sekce.
+//!
+//! Zobrazuje dlaždice:
+//!   - Auto-import (SK Torrent → films/series/tv_shows)
+//!   - Zálohy DB (pg_dump → Cloudflare R2)
+//!
+//! Každá dlaždice ukazuje stav poslední akce, aby admin ráno věděl, jestli
+//! noční pipeline proběhla v pořádku.
+//!
+//! Routes:
+//!   GET /admin/   — dashboard
+//!   GET /admin    — dashboard (bez lomítka)
+
+use askama::Template;
+use axum::extract::State;
+use axum::response::{Html, IntoResponse, Response};
+
+use crate::error::WebResult;
+use crate::state::AppState;
+
+/// Snapshot jednoho posledního běhu — společný tvar pro import i zálohy.
+struct LastRunTile {
+    /// 'ok', 'error', 'partial', 'running', 'none'
+    status: &'static str,
+    /// Lidsky formátovaná zpráva ("Před 4 hodinami — ok, 47 filmů přidáno").
+    message: String,
+}
+
+impl LastRunTile {
+    fn css_class(&self) -> &'static str {
+        match self.status {
+            "ok" => "tile-ok",
+            "partial" => "tile-warn",
+            "error" => "tile-error",
+            "running" => "tile-running",
+            _ => "tile-unknown",
+        }
+    }
+}
+
+#[derive(Template)]
+#[template(path = "admin_dashboard.html")]
+struct AdminDashboardTemplate {
+    img: String,
+    import_tile: LastRunTile,
+    backup_tile: LastRunTile,
+}
+
+fn noindex(html: String) -> Response {
+    let mut resp = Html(html).into_response();
+    resp.headers_mut().insert(
+        "X-Robots-Tag",
+        axum::http::HeaderValue::from_static("noindex, nofollow"),
+    );
+    resp
+}
+
+fn hours_ago(t: chrono::DateTime<chrono::Utc>) -> i64 {
+    (chrono::Utc::now() - t).num_hours().max(0)
+}
+
+async fn fetch_import_tile(state: &AppState) -> LastRunTile {
+    #[derive(sqlx::FromRow)]
+    struct LastImport {
+        started_at: chrono::DateTime<chrono::Utc>,
+        status: String,
+        added_films: i32,
+        added_series: i32,
+        added_episodes: i32,
+        failed_count: i32,
+    }
+
+    let row = sqlx::query_as::<_, LastImport>(
+        "SELECT started_at, status, added_films, added_series, added_episodes, failed_count \
+         FROM import_runs ORDER BY started_at DESC LIMIT 1",
+    )
+    .fetch_optional(&state.db)
+    .await
+    .unwrap_or_else(|e| {
+        tracing::error!("admin dashboard: import_runs query failed: {e}");
+        None
+    });
+
+    match row {
+        None => LastRunTile {
+            status: "none",
+            message: "Zatím žádný běh — scanner nebyl spuštěn.".to_string(),
+        },
+        Some(r) => {
+            let h = hours_ago(r.started_at);
+            let added = r.added_films + r.added_series + r.added_episodes;
+            let status: &'static str = match r.status.as_str() {
+                "ok" => "ok",
+                "partial" => "partial",
+                "error" => "error",
+                "running" => "running",
+                _ => "none",
+            };
+            let summary = if r.status == "running" {
+                "právě běží".to_string()
+            } else if r.failed_count > 0 {
+                format!("+{added} / ⚠ {} selhalo", r.failed_count)
+            } else {
+                format!("+{added} položek")
+            };
+            LastRunTile {
+                status,
+                message: format!("Před {h}h — {} ({summary})", r.status),
+            }
+        }
+    }
+}
+
+async fn fetch_backup_tile(state: &AppState) -> LastRunTile {
+    #[derive(sqlx::FromRow)]
+    struct LastBackup {
+        started_at: chrono::DateTime<chrono::Utc>,
+        status: String,
+        size_bytes: Option<i64>,
+    }
+
+    let row = sqlx::query_as::<_, LastBackup>(
+        "SELECT started_at, status, size_bytes \
+         FROM backup_runs ORDER BY started_at DESC LIMIT 1",
+    )
+    .fetch_optional(&state.db)
+    .await
+    .unwrap_or_else(|e| {
+        tracing::error!("admin dashboard: backup_runs query failed: {e}");
+        None
+    });
+
+    match row {
+        None => LastRunTile {
+            status: "none",
+            message: "Zatím žádná záloha — pipeline ještě neběžela.".to_string(),
+        },
+        Some(r) => {
+            let h = hours_ago(r.started_at);
+            let status: &'static str = match r.status.as_str() {
+                "ok" => "ok",
+                "error" => "error",
+                "running" => "running",
+                _ => "none",
+            };
+            let size = match r.size_bytes {
+                Some(b) if b >= 1024 * 1024 => format!("{:.1} MB", b as f64 / (1024.0 * 1024.0)),
+                Some(b) => format!("{} B", b),
+                None => "—".to_string(),
+            };
+            LastRunTile {
+                status,
+                message: format!("Před {h}h — {} ({size})", r.status),
+            }
+        }
+    }
+}
+
+/// GET /admin/ — landing page with per-section status tiles.
+pub async fn admin_dashboard(State(state): State<AppState>) -> WebResult<Response> {
+    let (import_tile, backup_tile) =
+        tokio::join!(fetch_import_tile(&state), fetch_backup_tile(&state));
+
+    let tmpl = AdminDashboardTemplate {
+        img: state.image_base_url.clone(),
+        import_tile,
+        backup_tile,
+    };
+    Ok(noindex(tmpl.render()?))
+}

--- a/cr-web/src/handlers/admin_dashboard.rs
+++ b/cr-web/src/handlers/admin_dashboard.rs
@@ -70,16 +70,25 @@ async fn fetch_import_tile(state: &AppState) -> LastRunTile {
         failed_count: i32,
     }
 
-    let row = sqlx::query_as::<_, LastImport>(
+    // Rozlišuj mezi "prázdná tabulka" (= Ok(None)) a "query selhala" (= Err).
+    // Při chybě ukáž červenou dlaždici, ne klidné „zatím žádný běh" — incident
+    // s DB bychom jinak na dashboardu přehlédli.
+    let row = match sqlx::query_as::<_, LastImport>(
         "SELECT started_at, status, added_films, added_series, added_episodes, failed_count \
          FROM import_runs ORDER BY started_at DESC LIMIT 1",
     )
     .fetch_optional(&state.db)
     .await
-    .unwrap_or_else(|e| {
-        tracing::error!("admin dashboard: import_runs query failed: {e}");
-        None
-    });
+    {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!("admin dashboard: import_runs query failed: {e}");
+            return LastRunTile {
+                status: "error",
+                message: format!("Chyba čtení import_runs: {e}"),
+            };
+        }
+    };
 
     match row {
         None => LastRunTile {
@@ -119,16 +128,23 @@ async fn fetch_backup_tile(state: &AppState) -> LastRunTile {
         size_bytes: Option<i64>,
     }
 
-    let row = sqlx::query_as::<_, LastBackup>(
+    // Stejně jako u importu — "query selhala" ≠ "prázdná tabulka".
+    let row = match sqlx::query_as::<_, LastBackup>(
         "SELECT started_at, status, size_bytes \
          FROM backup_runs ORDER BY started_at DESC LIMIT 1",
     )
     .fetch_optional(&state.db)
     .await
-    .unwrap_or_else(|e| {
-        tracing::error!("admin dashboard: backup_runs query failed: {e}");
-        None
-    });
+    {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!("admin dashboard: backup_runs query failed: {e}");
+            return LastRunTile {
+                status: "error",
+                message: format!("Chyba čtení backup_runs: {e}"),
+            };
+        }
+    };
 
     match row {
         None => LastRunTile {

--- a/cr-web/src/handlers/mod.rs
+++ b/cr-web/src/handlers/mod.rs
@@ -9,6 +9,8 @@ use cr_domain::repository::{OrpRepository, PhotoRepository, RegionRepository};
 use crate::error::WebResult;
 use crate::state::AppState;
 
+pub mod admin_backups;
+pub mod admin_dashboard;
 pub mod admin_import;
 mod audiobooks;
 mod download_video;

--- a/cr-web/src/main.rs
+++ b/cr-web/src/main.rs
@@ -240,6 +240,22 @@ async fn main() -> Result<()> {
         .route("/health", axum::routing::get(handlers::health))
         .nest("/api", api_routes)
         .route(
+            "/admin/",
+            axum::routing::get(handlers::admin_dashboard::admin_dashboard),
+        )
+        .route(
+            "/admin",
+            axum::routing::get(handlers::admin_dashboard::admin_dashboard),
+        )
+        .route(
+            "/admin/backups/",
+            axum::routing::get(handlers::admin_backups::admin_backups_list),
+        )
+        .route(
+            "/admin/backups",
+            axum::routing::get(handlers::admin_backups::admin_backups_list),
+        )
+        .route(
             "/admin/import/",
             axum::routing::get(handlers::admin_import::admin_import_list),
         )

--- a/cr-web/templates/admin_backups.html
+++ b/cr-web/templates/admin_backups.html
@@ -73,8 +73,8 @@
         <h3>Jak se zálohuje</h3>
         <ul>
             <li><strong>Kdy:</strong> systemd timer každý den v 03:00 UTC (prod server, port 2222).</li>
-            <li><strong>Jak:</strong> <code>pg_dump -Fc cr | gzip</code> → rclone rcat do <code>cr-backups/auto/</code> na Cloudflare R2.</li>
-            <li><strong>Retence:</strong> 10 dní (lifecycle rule na bucketu cr-backups).</li>
+            <li><strong>Jak:</strong> <code>pg_dump -Fc cr | gzip</code> → <code>rclone copyto --s3-no-check-bucket</code> do <code>cr-backups/auto/</code> na Cloudflare R2.</li>
+            <li><strong>Retence:</strong> 30 dní (lifecycle rule na bucketu cr-backups) — drží se stejné okno jako „posledních 30 běhů" nahoře.</li>
             <li><strong>Formát:</strong> PostgreSQL custom dump (<code>-Fc</code>) — úplný self-contained snapshot, z každé zálohy lze obnovit kompletní DB přes <code>pg_restore</code>.</li>
             <li><strong>Obnova:</strong> viz <code>~/Dokumenty/přístupy/cloudflare/r2-cr-db-backups.md</code>.</li>
         </ul>

--- a/cr-web/templates/admin_backups.html
+++ b/cr-web/templates/admin_backups.html
@@ -1,0 +1,110 @@
+{% extends "base.html" %}
+
+{% block title %}Zálohy DB — admin{% endblock %}
+{% block meta_description %}Přehled auto-záloh produkční PostgreSQL databáze na Cloudflare R2.{% endblock %}
+
+{% block og_title %}Zálohy DB — admin{% endblock %}
+{% block og_description %}Přehled auto-záloh produkční PostgreSQL databáze na Cloudflare R2.{% endblock %}
+
+{# noindex is enforced via X-Robots-Tag response header from the handler. #}
+
+{% block header_left %}
+<div class="logo-group">
+    <h1>Zálohy DB — běhy</h1>
+</div>
+{% endblock %}
+
+{% block content %}
+<main class="admin-backups-page">
+    <nav class="breadcrumb">
+        <a href="/" title="Domů">Česká republika</a>
+        <span>›</span> <a href="/admin/" title="Admin rozcestník">Admin</a>
+        <span>›</span> <span>Zálohy DB</span>
+    </nav>
+
+    <div class="status-banner {{ banner.css_class }}">{{ banner.text }}</div>
+
+    <h2>Posledních 30 běhů zálohování</h2>
+
+    {% if runs.is_empty() %}
+    <p class="empty-state">Zatím žádný běh — auto-zálohy ještě neběžely.</p>
+    {% else %}
+    <table class="runs-table">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Začátek</th>
+                <th>Trvání</th>
+                <th>Stav</th>
+                <th>Trigger</th>
+                <th>Velikost</th>
+                <th>Soubor v R2</th>
+                <th>Poznámka</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for r in runs %}
+            <tr class="{{ r.status_class() }}">
+                <td>#{{ r.id }}</td>
+                <td>{{ r.started_at_str() }}</td>
+                <td>{{ r.duration_sec() }}s</td>
+                <td><span class="badge badge-{{ r.status }}" title="{{ r.status }}">{{ r.status }}</span></td>
+                <td>{{ r.trigger }}</td>
+                <td>{{ r.size_human() }}</td>
+                <td class="mono">
+                    {% match r.dump_filename %}
+                        {% when Some with (f) %}{{ f }}
+                        {% when None %}—
+                    {% endmatch %}
+                </td>
+                <td class="{% if r.status == "error" %}error-cell{% endif %}">
+                    {% match r.error_message %}
+                        {% when Some with (e) %}{{ e }}
+                        {% when None %}—
+                    {% endmatch %}
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% endif %}
+
+    <section class="info-box">
+        <h3>Jak se zálohuje</h3>
+        <ul>
+            <li><strong>Kdy:</strong> systemd timer každý den v 03:00 UTC (prod server, port 2222).</li>
+            <li><strong>Jak:</strong> <code>pg_dump -Fc cr | gzip</code> → rclone rcat do <code>cr-backups/auto/</code> na Cloudflare R2.</li>
+            <li><strong>Retence:</strong> 10 dní (lifecycle rule na bucketu cr-backups).</li>
+            <li><strong>Formát:</strong> PostgreSQL custom dump (<code>-Fc</code>) — úplný self-contained snapshot, z každé zálohy lze obnovit kompletní DB přes <code>pg_restore</code>.</li>
+            <li><strong>Obnova:</strong> viz <code>~/Dokumenty/přístupy/cloudflare/r2-cr-db-backups.md</code>.</li>
+        </ul>
+    </section>
+</main>
+
+<style>
+.admin-backups-page { max-width: 1280px; margin: 0 auto; padding: 1rem; }
+.admin-backups-page h2 { font-size: 1.4rem; margin: 1rem 0 1.2rem; }
+.admin-backups-page h3 { font-size: 1.1rem; margin: 0 0 0.6rem; }
+.runs-table { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
+.runs-table th, .runs-table td { padding: 0.5rem 0.6rem; border-bottom: 1px solid #eee; text-align: left; }
+.runs-table th { background: #f8fafc; font-weight: 600; color: #555; }
+.runs-table tbody tr:hover { background: #f9fafb; }
+.runs-table .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.78rem; color: #334155; }
+.error-cell { color: #b91c1c; font-weight: 600; }
+.badge { display: inline-block; padding: 0.15rem 0.5rem; border-radius: 999px; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; }
+.badge-ok { background: #d1fae5; color: #065f46; }
+.badge-error { background: #fee2e2; color: #991b1b; }
+.badge-running { background: #dbeafe; color: #1e40af; }
+.empty-state { color: #888; padding: 2rem; text-align: center; background: #fafafa; border-radius: 8px; }
+.breadcrumb { font-size: 0.85rem; color: #888; margin-bottom: 1.2rem; }
+.breadcrumb a { color: #11457E; text-decoration: none; }
+.status-banner { padding: 0.8rem 1rem; border-radius: 8px; margin-bottom: 1.2rem; font-weight: 600; }
+.banner-ok { background: #d1fae5; color: #065f46; border: 1px solid #6ee7b7; }
+.banner-warn { background: #fef3c7; color: #92400e; border: 1px solid #fde68a; }
+.banner-error { background: #fee2e2; color: #991b1b; border: 1px solid #fca5a5; }
+.info-box { margin-top: 2rem; padding: 1rem 1.2rem; background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 8px; }
+.info-box ul { margin: 0; padding-left: 1.2rem; font-size: 0.9rem; color: #475569; }
+.info-box li { margin-bottom: 0.35rem; }
+.info-box code { background: #e2e8f0; padding: 0.1rem 0.35rem; border-radius: 3px; font-size: 0.82rem; }
+</style>
+{% endblock %}

--- a/cr-web/templates/admin_dashboard.html
+++ b/cr-web/templates/admin_dashboard.html
@@ -35,7 +35,7 @@
         <a href="/admin/backups/" class="tile {{ backup_tile.css_class() }}" title="Auto-zálohy DB na Cloudflare R2">
             <div class="tile-icon">💾</div>
             <h3>Zálohy DB</h3>
-            <p class="tile-sub">pg_dump → Cloudflare R2 (10 dní retence)</p>
+            <p class="tile-sub">pg_dump → Cloudflare R2 (30 dní retence)</p>
             <p class="tile-status">{{ backup_tile.message }}</p>
         </a>
     </div>

--- a/cr-web/templates/admin_dashboard.html
+++ b/cr-web/templates/admin_dashboard.html
@@ -1,0 +1,79 @@
+{% extends "base.html" %}
+
+{% block title %}Admin — Česká republika{% endblock %}
+{% block meta_description %}Administrační rozcestník — auto-import, zálohy databáze.{% endblock %}
+
+{% block og_title %}Admin — Česká republika{% endblock %}
+{% block og_description %}Administrační rozcestník — auto-import, zálohy databáze.{% endblock %}
+
+{# noindex is enforced via X-Robots-Tag response header from the handler. #}
+
+{% block header_left %}
+<div class="logo-group">
+    <h1>Admin</h1>
+</div>
+{% endblock %}
+
+{% block content %}
+<main class="admin-dashboard">
+    <nav class="breadcrumb">
+        <a href="/" title="Domů">Česká republika</a>
+        <span>›</span> <span>Admin</span>
+    </nav>
+
+    <h2>Rozcestník administrace</h2>
+    <p class="dashboard-intro">Přehled nočních pipeline a vstup do jednotlivých sekcí. Ráno tu zkontroluj, že všechno proběhlo v pořádku.</p>
+
+    <div class="tiles">
+        <a href="/admin/import/" class="tile {{ import_tile.css_class() }}" title="Auto-import ze SK Torrent — detail">
+            <div class="tile-icon">🎬</div>
+            <h3>Auto-import</h3>
+            <p class="tile-sub">SK Torrent → films / series / tv_shows</p>
+            <p class="tile-status">{{ import_tile.message }}</p>
+        </a>
+
+        <a href="/admin/backups/" class="tile {{ backup_tile.css_class() }}" title="Auto-zálohy DB na Cloudflare R2">
+            <div class="tile-icon">💾</div>
+            <h3>Zálohy DB</h3>
+            <p class="tile-sub">pg_dump → Cloudflare R2 (10 dní retence)</p>
+            <p class="tile-status">{{ backup_tile.message }}</p>
+        </a>
+    </div>
+</main>
+
+<style>
+.admin-dashboard { max-width: 1100px; margin: 0 auto; padding: 1rem; }
+.admin-dashboard h2 { font-size: 1.5rem; margin: 1rem 0 0.6rem; }
+.admin-dashboard .dashboard-intro { color: #64748b; margin: 0 0 1.8rem; }
+.breadcrumb { font-size: 0.85rem; color: #888; margin-bottom: 1.2rem; }
+.breadcrumb a { color: #11457E; text-decoration: none; }
+
+.tiles { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1.2rem; }
+.tile {
+    display: block;
+    padding: 1.4rem 1.5rem;
+    border-radius: 12px;
+    border: 1px solid #e2e8f0;
+    background: #fff;
+    color: inherit;
+    text-decoration: none;
+    transition: transform 0.15s, box-shadow 0.15s, border-color 0.15s;
+}
+.tile:hover { transform: translateY(-2px); box-shadow: 0 6px 18px rgba(0,0,0,0.08); border-color: #cbd5e1; }
+.tile h3 { font-size: 1.25rem; margin: 0.4rem 0 0.2rem; color: #11457E; }
+.tile .tile-icon { font-size: 2rem; line-height: 1; }
+.tile .tile-sub { color: #64748b; font-size: 0.85rem; margin: 0 0 0.8rem; }
+.tile .tile-status { margin: 0; font-weight: 600; font-size: 0.95rem; }
+
+.tile-ok { border-left: 4px solid #10b981; }
+.tile-ok .tile-status { color: #065f46; }
+.tile-warn { border-left: 4px solid #f59e0b; }
+.tile-warn .tile-status { color: #92400e; }
+.tile-error { border-left: 4px solid #ef4444; background: #fef2f2; }
+.tile-error .tile-status { color: #991b1b; }
+.tile-running { border-left: 4px solid #3b82f6; }
+.tile-running .tile-status { color: #1e40af; }
+.tile-unknown { border-left: 4px solid #94a3b8; }
+.tile-unknown .tile-status { color: #64748b; }
+</style>
+{% endblock %}

--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -5,7 +5,7 @@ Dvě nezávislé noční úlohy:
 | Unit | Čas | Účel | Admin přehled |
 |------|-----|------|---------------|
 | `cr-auto-import.timer` | 05:00 UTC | SK Torrent → films/series/tv_shows | `/admin/import/` |
-| `cr-backup-db.timer`   | 03:00 UTC | `pg_dump` celé DB → Cloudflare R2 (10 dní retence) | `/admin/backups/` |
+| `cr-backup-db.timer`   | 03:00 UTC | `pg_dump` celé DB → Cloudflare R2 (30 dní retence) | `/admin/backups/` |
 
 ## Auto-import (issue #423)
 
@@ -74,8 +74,9 @@ Every run writes a row to `import_runs` visible at
 
 Denní `pg_dump` celé produkční DB → Cloudflare R2 bucket `cr-backups`.
 Každá záloha je self-contained (custom format `-Fc` + gzip) — z jediné
-zálohy lze obnovit celou DB přes `pg_restore`. Retenci 10 dní řeší
-R2 lifecycle rule (bucket-level, mimo skript).
+zálohy lze obnovit celou DB přes `pg_restore`. Retenci 30 dní řeší
+R2 lifecycle rule (bucket-level, mimo skript) — stejné okno jako
+„posledních 30 běhů" v `/admin/backups/` UI.
 
 ### Instalace / enable na VPS
 
@@ -111,9 +112,11 @@ ssh -p "$VPS_PORT" "root@$VPS_HOST" "/opt/cr/scripts/backup-db.sh manual"
 
 ### Logy
 
+Skript loguje do journald (ne do souboru — žádná log-rotate config potřeba).
+
 ```bash
-ssh -p "$VPS_PORT" "root@$VPS_HOST" "tail -200 /var/log/cr-backup-db.log"
 ssh -p "$VPS_PORT" "root@$VPS_HOST" "journalctl -u cr-backup-db.service --since today"
+ssh -p "$VPS_PORT" "root@$VPS_HOST" "journalctl -u cr-backup-db.service -n 200"
 ```
 
 ### Dashboard
@@ -125,4 +128,4 @@ Každý běh zapíše row do `backup_runs` viditelnou na
 
 Mimo skript — nastavit jednou v R2 dashboardu na bucketu `cr-backups`:
 - Prefix: `auto/`
-- Expire objects: 10 days after upload
+- Expire objects: 30 days after upload

--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -1,4 +1,13 @@
-# Auto-import systemd unit
+# Systemd units (produkční VPS)
+
+Dvě nezávislé noční úlohy:
+
+| Unit | Čas | Účel | Admin přehled |
+|------|-----|------|---------------|
+| `cr-auto-import.timer` | 05:00 UTC | SK Torrent → films/series/tv_shows | `/admin/import/` |
+| `cr-backup-db.timer`   | 03:00 UTC | `pg_dump` celé DB → Cloudflare R2 (10 dní retence) | `/admin/backups/` |
+
+## Auto-import (issue #423)
 
 Daily cron for SK Torrent scanner. See issue #423.
 
@@ -58,3 +67,62 @@ ssh -p "$VPS_PORT" "root@$VPS_HOST" "journalctl -u cr-auto-import.service --sinc
 
 Every run writes a row to `import_runs` visible at
 <https://ceskarepublika.wiki/admin/import/>.
+
+---
+
+## Auto-zálohy DB (task #97)
+
+Denní `pg_dump` celé produkční DB → Cloudflare R2 bucket `cr-backups`.
+Každá záloha je self-contained (custom format `-Fc` + gzip) — z jediné
+zálohy lze obnovit celou DB přes `pg_restore`. Retenci 10 dní řeší
+R2 lifecycle rule (bucket-level, mimo skript).
+
+### Instalace / enable na VPS
+
+```bash
+# 1. Instaluj rclone (jednou)
+ssh -p "$VPS_PORT" "root@$VPS_HOST" "apt-get install -y rclone"
+
+# 2. Doplň /opt/cr/.env (jednou — credentials viz ~/Dokumenty/přístupy/cloudflare/r2-cr-db-backups.md):
+#   R2_BACKUP_ACCESS_KEY_ID=...
+#   R2_BACKUP_SECRET_ACCESS_KEY=...
+#   R2_BACKUP_ENDPOINT=https://<account-id>.r2.cloudflarestorage.com
+
+# 3. Zkopíruj skript + unit files
+scp -P "$VPS_PORT" scripts/backup-db.sh "root@$VPS_HOST:/opt/cr/scripts/"
+scp -P "$VPS_PORT" deploy/systemd/cr-backup-db.{service,timer} \
+    "root@$VPS_HOST:/etc/systemd/system/"
+ssh -p "$VPS_PORT" "root@$VPS_HOST" "chmod +x /opt/cr/scripts/backup-db.sh"
+
+# 4. Enable + start timer
+ssh -p "$VPS_PORT" "root@$VPS_HOST" \
+    "systemctl daemon-reload && \
+     systemctl enable --now cr-backup-db.timer && \
+     systemctl list-timers cr-backup-db.timer"
+```
+
+### Ruční spuštění (test / mimořádná záloha)
+
+```bash
+ssh -p "$VPS_PORT" "root@$VPS_HOST" "systemctl start cr-backup-db.service"
+# nebo skript rovnou (zapíše do backup_runs s trigger='manual'):
+ssh -p "$VPS_PORT" "root@$VPS_HOST" "/opt/cr/scripts/backup-db.sh manual"
+```
+
+### Logy
+
+```bash
+ssh -p "$VPS_PORT" "root@$VPS_HOST" "tail -200 /var/log/cr-backup-db.log"
+ssh -p "$VPS_PORT" "root@$VPS_HOST" "journalctl -u cr-backup-db.service --since today"
+```
+
+### Dashboard
+
+Každý běh zapíše row do `backup_runs` viditelnou na
+<https://ceskarepublika.wiki/admin/backups/>.
+
+### Retention (Cloudflare R2 lifecycle)
+
+Mimo skript — nastavit jednou v R2 dashboardu na bucketu `cr-backups`:
+- Prefix: `auto/`
+- Expire objects: 10 days after upload

--- a/deploy/systemd/cr-backup-db.service
+++ b/deploy/systemd/cr-backup-db.service
@@ -1,0 +1,33 @@
+[Unit]
+Description=CR — Denní záloha produkční PostgreSQL databáze na Cloudflare R2
+Documentation=https://github.com/Olbrasoft/cr (task #97)
+# Wait for docker — skript mluví s kontejnerem `cr-db-1` přes `docker compose exec`.
+After=docker.service network-online.target
+Wants=network-online.target
+StartLimitBurst=2
+StartLimitIntervalSec=600
+
+[Service]
+Type=oneshot
+User=root
+WorkingDirectory=/opt/cr
+# /opt/cr/.env drží R2_BACKUP_* credentials (viz ~/Dokumenty/přístupy/cloudflare/r2-cr-db-backups.md)
+# a případné další env proměnné projektu.
+EnvironmentFile=/opt/cr/.env
+# Mapa env proměnných pro rclone — žádný rclone.conf na disku.
+# "cr_r2_backup" musí matchovat R2_REMOTE v scripts/backup-db.sh.
+Environment=RCLONE_CONFIG_CR_R2_BACKUP_TYPE=s3
+Environment=RCLONE_CONFIG_CR_R2_BACKUP_PROVIDER=Cloudflare
+Environment="RCLONE_CONFIG_CR_R2_BACKUP_ACCESS_KEY_ID=${R2_BACKUP_ACCESS_KEY_ID}"
+Environment="RCLONE_CONFIG_CR_R2_BACKUP_SECRET_ACCESS_KEY=${R2_BACKUP_SECRET_ACCESS_KEY}"
+Environment="RCLONE_CONFIG_CR_R2_BACKUP_ENDPOINT=${R2_BACKUP_ENDPOINT}"
+ExecStart=/bin/bash /opt/cr/scripts/backup-db.sh auto
+StandardOutput=append:/var/log/cr-backup-db.log
+StandardError=append:/var/log/cr-backup-db.log
+# Pokud transientně selže (Cloudflare 502, DB v restartu), zkus ještě jednou.
+# Pokud padne i podruhé, nech to být — admin banner upozorní ráno.
+Restart=on-failure
+RestartSec=120
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/cr-backup-db.service
+++ b/deploy/systemd/cr-backup-db.service
@@ -22,8 +22,12 @@ Environment="RCLONE_CONFIG_CR_R2_BACKUP_ACCESS_KEY_ID=${R2_BACKUP_ACCESS_KEY_ID}
 Environment="RCLONE_CONFIG_CR_R2_BACKUP_SECRET_ACCESS_KEY=${R2_BACKUP_SECRET_ACCESS_KEY}"
 Environment="RCLONE_CONFIG_CR_R2_BACKUP_ENDPOINT=${R2_BACKUP_ENDPOINT}"
 ExecStart=/bin/bash /opt/cr/scripts/backup-db.sh auto
-StandardOutput=append:/var/log/cr-backup-db.log
-StandardError=append:/var/log/cr-backup-db.log
+# Loguj do journald (default), ne do souboru bez rotace. journalctl -u stačí.
+StandardOutput=journal
+StandardError=journal
+# Drop škrábané logy (i když 1 log/s ze skriptu by neměl nikdy být problém).
+LogRateLimitIntervalSec=10s
+LogRateLimitBurst=200
 # Pokud transientně selže (Cloudflare 502, DB v restartu), zkus ještě jednou.
 # Pokud padne i podruhé, nech to být — admin banner upozorní ráno.
 Restart=on-failure

--- a/deploy/systemd/cr-backup-db.timer
+++ b/deploy/systemd/cr-backup-db.timer
@@ -1,0 +1,15 @@
+[Unit]
+Description=CR — Auto-záloha DB denně ve 03:00 UTC
+Documentation=https://github.com/Olbrasoft/cr (task #97)
+
+[Timer]
+OnCalendar=*-*-* 03:00:00 UTC
+# Pokud VPS byl v plánovaném čase rebootovaný, spusť při startu (doženeme).
+Persistent=true
+# Malé rozptýlení proti thundering herd (auto-import běží v 05:00 UTC, takže
+# 03:00 tady je klidné okno, ale nechme si to kvůli Cloudflare side-wide timerům).
+RandomizedDelaySec=5min
+Unit=cr-backup-db.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# ------------------------------------------------------------
+# backup-db.sh — denní full backup produkční PostgreSQL DB na Cloudflare R2
+#
+# Spouští se systemd timerem cr-backup-db.timer každý den v 03:00 UTC.
+# Ruční běh: `scripts/backup-db.sh manual`
+#
+# Krok za krokem:
+#   1. INSERT row do backup_runs se status='running'
+#   2. docker exec db pg_dump -Fc cr | gzip > /tmp/…
+#   3. rclone copyto /tmp/… cr-r2-backup:cr-backups/auto/cr_prod_YYYY-MM-DD.dump.gz
+#   4. UPDATE backup_runs SET status='ok', size, filename, finished_at
+#   5. Cleanup tmp souboru
+#
+# Retence starších záloh řeší R2 lifecycle rule (10 dní na prefix auto/)
+# — tento skript pouze uploaduje, nikdy neřízeně nemaže.
+#
+# Při jakékoli chybě uprostřed pipeline (pg_dump selže, rclone selže,
+# ztráta sítě) se row v backup_runs označí jako status='error' s err. hláškou
+# a skript skončí s non-zero exit kódem. Systemd pak pošle alert dle potřeby.
+#
+# Vyžaduje:
+#   - docker compose s běžícím kontejnerem `db` (postgres:16)
+#   - rclone (apt install rclone)
+#   - env proměnné v /opt/cr/.env:
+#       R2_BACKUP_ACCESS_KEY_ID
+#       R2_BACKUP_SECRET_ACCESS_KEY
+#       R2_BACKUP_ENDPOINT  (https://<account>.r2.cloudflarestorage.com)
+# ------------------------------------------------------------
+
+set -euo pipefail
+
+# --- Config ---
+COMPOSE_FILE="${COMPOSE_FILE:-/opt/cr/docker-compose.yml}"
+TRIGGER="${1:-auto}"   # 'auto' (timer) nebo 'manual' (operator)
+TODAY=$(date -u +%F)
+FILENAME="cr_prod_${TODAY}.dump.gz"
+R2_KEY="auto/${FILENAME}"
+TMP="/tmp/cr_backup_$$.dump.gz"
+
+# rclone remote jméno (přes env var — žádný rclone.conf na disku není potřeba).
+# Viz sekci "rclone env mapping" v deploy/systemd/cr-backup-db.service.
+R2_REMOTE="cr_r2_backup:cr-backups"
+
+log() { echo "[$(date -u +%H:%M:%S)] $*"; }
+die() { echo "[FAIL $(date -u +%H:%M:%S)] $*" >&2; exit 1; }
+
+# --- Preflight ---
+command -v docker >/dev/null || die "docker not found"
+command -v rclone >/dev/null || die "rclone not found (apt install rclone)"
+[ -f "$COMPOSE_FILE" ] || die "compose file $COMPOSE_FILE missing"
+[ -n "${R2_BACKUP_ACCESS_KEY_ID:-}" ] || die "R2_BACKUP_ACCESS_KEY_ID not set"
+[ -n "${R2_BACKUP_SECRET_ACCESS_KEY:-}" ] || die "R2_BACKUP_SECRET_ACCESS_KEY not set"
+[ -n "${R2_BACKUP_ENDPOINT:-}" ] || die "R2_BACKUP_ENDPOINT not set"
+
+# --- Helpers ---
+psql_exec() {
+    # Runs a single SQL statement inside the db container. Stdin can carry
+    # multi-line SQL. Uses -v ON_ERROR_STOP=1 so any SQL error exits non-zero.
+    docker compose -f "$COMPOSE_FILE" exec -T db \
+        psql -U cr -d cr -v ON_ERROR_STOP=1 -q -t -A "$@"
+}
+
+cleanup() {
+    rm -f "$TMP"
+}
+trap cleanup EXIT
+
+# --- 1. Create running row, capture ID ---
+RUN_ID=$(psql_exec -c "INSERT INTO backup_runs (trigger) VALUES ('$TRIGGER') RETURNING id;" | tr -d '[:space:]')
+[ -n "$RUN_ID" ] || die "failed to INSERT into backup_runs"
+log "backup_runs #$RUN_ID created (trigger=$TRIGGER)"
+
+# From here on, on any error, mark the row as failed before bailing out.
+mark_failed() {
+    local msg="$1"
+    local escaped
+    escaped=$(printf '%s' "$msg" | sed "s/'/''/g")
+    # Best-effort — if even this fails (DB down), the row stays 'running'
+    # forever, which the admin banner will surface as alarm.
+    psql_exec -c "UPDATE backup_runs SET status='error', finished_at=NOW(), error_message='$escaped' WHERE id=$RUN_ID;" || true
+}
+
+# --- 2. pg_dump + gzip ---
+log "pg_dump starting..."
+if ! docker compose -f "$COMPOSE_FILE" exec -T db \
+        pg_dump -Fc -U cr cr 2>/tmp/cr_backup_pgdump_err.$$ | gzip > "$TMP"; then
+    ERR=$(head -c 500 "/tmp/cr_backup_pgdump_err.$$" 2>/dev/null || echo "pg_dump pipeline failed")
+    rm -f "/tmp/cr_backup_pgdump_err.$$"
+    mark_failed "pg_dump failed: $ERR"
+    die "$ERR"
+fi
+rm -f "/tmp/cr_backup_pgdump_err.$$"
+
+SIZE=$(stat -c %s "$TMP")
+[ "$SIZE" -gt 1024 ] || { mark_failed "pg_dump produced only $SIZE bytes"; die "dump suspiciously small: $SIZE bytes"; }
+log "pg_dump done — $SIZE bytes"
+
+# --- 3. Upload to R2 ---
+# --s3-no-check-bucket: R2 token je scoped jen na bucket `cr-backups` a nemá
+# ListBuckets/CreateBucket právo. Bez tohoto flagu rclone volá HeadBucket nebo
+# CreateBucket před uploadem a dostane 403 AccessDenied. Náš bucket existuje,
+# takže sanity check prostě přeskočíme.
+log "uploading to R2 ($R2_REMOTE/$R2_KEY)..."
+if ! rclone copyto --s3-no-check-bucket "$TMP" "$R2_REMOTE/$R2_KEY" 2>/tmp/cr_backup_rclone_err.$$; then
+    ERR=$(head -c 500 "/tmp/cr_backup_rclone_err.$$" 2>/dev/null || echo "rclone copyto failed")
+    rm -f "/tmp/cr_backup_rclone_err.$$"
+    mark_failed "rclone upload failed: $ERR"
+    die "$ERR"
+fi
+rm -f "/tmp/cr_backup_rclone_err.$$"
+log "upload done"
+
+# --- 4. Mark as ok ---
+psql_exec -c "UPDATE backup_runs SET status='ok', finished_at=NOW(), size_bytes=$SIZE, dump_filename='$R2_KEY' WHERE id=$RUN_ID;" >/dev/null
+log "backup_runs #$RUN_ID marked ok"
+log "Done: s3://cr-backups/$R2_KEY ($SIZE bytes)"

--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -7,13 +7,16 @@
 #
 # Krok za krokem:
 #   1. INSERT row do backup_runs se status='running'
-#   2. docker exec db pg_dump -Fc cr | gzip > /tmp/…
-#   3. rclone copyto /tmp/… cr-r2-backup:cr-backups/auto/cr_prod_YYYY-MM-DD.dump.gz
+#   2. docker exec db pg_dump -Fc cr | gzip > $(mktemp)
+#   3. rclone copyto --s3-no-check-bucket ... cr-r2-backup:cr-backups/auto/
+#         cr_prod_YYYY-MM-DDTHHMMZ.dump.gz  (čas v názvu kvůli opakovaným
+#         běhům v jeden den — nechceme tiché přepisování v R2)
 #   4. UPDATE backup_runs SET status='ok', size, filename, finished_at
-#   5. Cleanup tmp souboru
+#   5. Cleanup tmp souboru (trap EXIT)
 #
-# Retence starších záloh řeší R2 lifecycle rule (10 dní na prefix auto/)
-# — tento skript pouze uploaduje, nikdy neřízeně nemaže.
+# Retence starších záloh řeší R2 lifecycle rule (30 dní na prefix auto/,
+# stejné okno jako „posledních 30 běhů" v /admin/backups/) — tento skript
+# pouze uploaduje, nikdy neřízeně nemaže.
 #
 # Při jakékoli chybě uprostřed pipeline (pg_dump selže, rclone selže,
 # ztráta sítě) se row v backup_runs označí jako status='error' s err. hláškou
@@ -33,10 +36,30 @@ set -euo pipefail
 # --- Config ---
 COMPOSE_FILE="${COMPOSE_FILE:-/opt/cr/docker-compose.yml}"
 TRIGGER="${1:-auto}"   # 'auto' (timer) nebo 'manual' (operator)
-TODAY=$(date -u +%F)
-FILENAME="cr_prod_${TODAY}.dump.gz"
+
+# Validace vstupu proti whitelistu — TRIGGER se interpoluje do SQL INSERTu
+# (viz dole), takže libovolný string by byl injekce. Skript spouští root
+# přes systemd, ale ruční `backup-db.sh $PAYLOAD` by jinak dokázal cokoli.
+case "$TRIGGER" in
+    auto|manual) ;;
+    *) echo "FAIL: invalid TRIGGER '$TRIGGER' (expected auto|manual)" >&2; exit 2 ;;
+esac
+
+# Unikátní název souboru: datum + čas (HHMMZ). Opakovaný běh ve stejný den
+# (systemd restart po transientní chybě nebo ruční retry po selhání) zapíše
+# do R2 JINÝ objekt — žádné tiché přepisování dřívějšího běhu.
+STAMP=$(date -u +%Y-%m-%dT%H%MZ)
+FILENAME="cr_prod_${STAMP}.dump.gz"
 R2_KEY="auto/${FILENAME}"
-TMP="/tmp/cr_backup_$$.dump.gz"
+
+# Temp soubory přes mktemp v adresáři s mode 0700, aby se zabránilo symlink
+# race attackům v /tmp (skript běží jako root). mktemp respektuje $TMPDIR
+# a default je /tmp. Soubory sám vytvoří s mode 0600.
+TMPDIR_BACKUP=$(mktemp -d -t cr_backup.XXXXXXXX)
+chmod 700 "$TMPDIR_BACKUP"
+TMP="$TMPDIR_BACKUP/dump.gz"
+PGDUMP_ERR="$TMPDIR_BACKUP/pgdump.err"
+RCLONE_ERR="$TMPDIR_BACKUP/rclone.err"
 
 # rclone remote jméno (přes env var — žádný rclone.conf na disku není potřeba).
 # Viz sekci "rclone env mapping" v deploy/systemd/cr-backup-db.service.
@@ -55,25 +78,30 @@ command -v rclone >/dev/null || die "rclone not found (apt install rclone)"
 
 # --- Helpers ---
 psql_exec() {
-    # Runs a single SQL statement inside the db container. Stdin can carry
-    # multi-line SQL. Uses -v ON_ERROR_STOP=1 so any SQL error exits non-zero.
+    # Runs SQL inside the db container. -X ignores ~/.psqlrc (would otherwise
+    # inject \timing / \pset etc. and break parsing of RUN_ID). -q -t -A keep
+    # output minimal. ON_ERROR_STOP=1 makes any SQL error exit non-zero.
     docker compose -f "$COMPOSE_FILE" exec -T db \
-        psql -U cr -d cr -v ON_ERROR_STOP=1 -q -t -A "$@"
+        psql -X -U cr -d cr -v ON_ERROR_STOP=1 -q -t -A "$@"
 }
 
 cleanup() {
-    rm -f "$TMP"
+    # Smaže celý mktemp adresář včetně obsahu.
+    rm -rf "$TMPDIR_BACKUP"
 }
 trap cleanup EXIT
 
 # --- 1. Create running row, capture ID ---
+# TRIGGER je validovaný proti whitelistu výš, takže interpolace je bezpečná.
 RUN_ID=$(psql_exec -c "INSERT INTO backup_runs (trigger) VALUES ('$TRIGGER') RETURNING id;" | tr -d '[:space:]')
 [ -n "$RUN_ID" ] || die "failed to INSERT into backup_runs"
 log "backup_runs #$RUN_ID created (trigger=$TRIGGER)"
 
 # From here on, on any error, mark the row as failed before bailing out.
 mark_failed() {
-    local msg="$1"
+    local msg="${1:-unknown error}"
+    # Fallback text pokud je msg prázdný (head -c může úspět a nic nevrátit)
+    [ -n "$msg" ] || msg="unknown error (empty diagnostic)"
     local escaped
     escaped=$(printf '%s' "$msg" | sed "s/'/''/g")
     # Best-effort — if even this fails (DB down), the row stays 'running'
@@ -81,16 +109,19 @@ mark_failed() {
     psql_exec -c "UPDATE backup_runs SET status='error', finished_at=NOW(), error_message='$escaped' WHERE id=$RUN_ID;" || true
 }
 
+# Chyba kdekoli v pg_dump/rclone → mark failed + echo err. Používáme explicitní
+# if-then, ale pro jistotu i trap ERR kdyby unikla netriviální chyba.
+trap 'mark_failed "unexpected script error at line $LINENO"' ERR
+
 # --- 2. pg_dump + gzip ---
 log "pg_dump starting..."
 if ! docker compose -f "$COMPOSE_FILE" exec -T db \
-        pg_dump -Fc -U cr cr 2>/tmp/cr_backup_pgdump_err.$$ | gzip > "$TMP"; then
-    ERR=$(head -c 500 "/tmp/cr_backup_pgdump_err.$$" 2>/dev/null || echo "pg_dump pipeline failed")
-    rm -f "/tmp/cr_backup_pgdump_err.$$"
+        pg_dump -Fc -U cr cr 2>"$PGDUMP_ERR" | gzip > "$TMP"; then
+    ERR=$(head -c 500 "$PGDUMP_ERR" 2>/dev/null)
+    [ -n "$ERR" ] || ERR="pg_dump pipeline failed (no stderr captured)"
     mark_failed "pg_dump failed: $ERR"
     die "$ERR"
 fi
-rm -f "/tmp/cr_backup_pgdump_err.$$"
 
 SIZE=$(stat -c %s "$TMP")
 [ "$SIZE" -gt 1024 ] || { mark_failed "pg_dump produced only $SIZE bytes"; die "dump suspiciously small: $SIZE bytes"; }
@@ -102,16 +133,18 @@ log "pg_dump done — $SIZE bytes"
 # CreateBucket před uploadem a dostane 403 AccessDenied. Náš bucket existuje,
 # takže sanity check prostě přeskočíme.
 log "uploading to R2 ($R2_REMOTE/$R2_KEY)..."
-if ! rclone copyto --s3-no-check-bucket "$TMP" "$R2_REMOTE/$R2_KEY" 2>/tmp/cr_backup_rclone_err.$$; then
-    ERR=$(head -c 500 "/tmp/cr_backup_rclone_err.$$" 2>/dev/null || echo "rclone copyto failed")
-    rm -f "/tmp/cr_backup_rclone_err.$$"
+if ! rclone copyto --s3-no-check-bucket "$TMP" "$R2_REMOTE/$R2_KEY" 2>"$RCLONE_ERR"; then
+    ERR=$(head -c 500 "$RCLONE_ERR" 2>/dev/null)
+    [ -n "$ERR" ] || ERR="rclone copyto failed (no stderr captured)"
     mark_failed "rclone upload failed: $ERR"
     die "$ERR"
 fi
-rm -f "/tmp/cr_backup_rclone_err.$$"
 log "upload done"
 
 # --- 4. Mark as ok ---
+# Disable ERR trap pro finální UPDATE — kdyby selhal, mark_failed by
+# přepsal už existující ok status na error (false alarm).
+trap - ERR
 psql_exec -c "UPDATE backup_runs SET status='ok', finished_at=NOW(), size_bytes=$SIZE, dump_filename='$R2_KEY' WHERE id=$RUN_ID;" >/dev/null
 log "backup_runs #$RUN_ID marked ok"
 log "Done: s3://cr-backups/$R2_KEY ($SIZE bytes)"


### PR DESCRIPTION
<!-- claude-session: c0717c9a-16b7-4690-af5a-437a07586132 -->

## Summary
- Daily `pg_dump -Fc | gzip` → rclone → Cloudflare R2 bucket `cr-backups/auto/` (separate CF account, isolated from cr-images)
- 10-day retention via R2 lifecycle rule (already applied on bucket)
- New `/admin/` dashboard rozcestník with status tiles (Auto-import + Zálohy DB) so morning status check is one page
- New `/admin/backups/` page — last 30 runs with freshness banner
- systemd timer `cr-backup-db.timer` fires 03:00 UTC daily on VPS

## Architecture
- Migration `20260507_047_backup_runs.sql` — tracks each run (started_at, finished_at, status, trigger, size_bytes, dump_filename, error_message)
- Rust handlers in `cr-web` (read-only, noindex via X-Robots-Tag)
- Bash script `scripts/backup-db.sh` — pipes `docker exec db pg_dump` through gzip → `rclone copyto --s3-no-check-bucket` (flag required because R2 token is scoped to one bucket and can't CreateBucket)
- R2 credentials in `/opt/cr/.env` as `R2_BACKUP_*` env vars; rclone config embedded via `RCLONE_CONFIG_CR_R2_BACKUP_*`

## Verified on production
- [x] First manual backup successful — 25.5 MB, `cr_prod_2026-04-17.dump.gz` in R2
- [x] Row in `backup_runs` table with status='ok', all metadata
- [x] `/admin/` tile shows green "Před 0h — ok (25.5 MB)"
- [x] `/admin/backups/` freshness banner green, table shows the run
- [x] Zero console errors on both admin pages
- [x] R2 lifecycle rule "Auto-backup 10-day retention" on prefix `auto/` — Enabled
- [x] systemd timer enabled, next run 2026-04-18 03:02 UTC

## Test plan
- [x] Local cargo check clean
- [x] Cross-compile + deploy (cr-web binary + templates)
- [x] Manual backup run on prod — verified in DB + R2
- [x] Playwright interactive E2E on prod /admin/, /admin/backups/
- [x] /admin/import/ still works (no regression)
- [ ] CI: Check & Clippy, Format, Test
- [ ] Copilot code review

🤖 Generated with [Claude Code](https://claude.com/claude-code)