### PR TITLE
fix(player): resolve SK Torrent CDN live on every playback (#496)

### DIFF
--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -25,9 +25,13 @@ struct FilmRow {
     runtime_min: Option<i16>,
     cover_filename: Option<String>,
     sktorrent_video_id: Option<i32>,
-    // Used by Askama template (film_detail.html) for JS player initialization
+    // SK Torrent CDN assignment rotates, so template no longer reads these —
+    // player calls /api/films/sktorrent-resolve at play time. Kept in SELECT
+    // so the struct matches the legacy DB row shape; remove once we drop the
+    // columns entirely.
+    #[allow(dead_code)]
     sktorrent_cdn: Option<i16>,
-    // Used by Askama template (film_detail.html) for JS player initialization
+    #[allow(dead_code)]
     sktorrent_qualities: Option<String>,
     #[allow(dead_code)] // Needed in SELECT for ORDER BY; not rendered in templates
     added_at: Option<chrono::DateTime<chrono::Utc>>,

--- a/cr-web/templates/episode_detail.html
+++ b/cr-web/templates/episode_detail.html
@@ -206,8 +206,9 @@ var seriesTitle = "{{ series.title }}";
 var initialSeason = {{ episode.season }};
 var initialEpisode = {{ episode.episode }};
 var initialVideoId = {{ episode.sktorrent_video_id.unwrap_or(0) }};
-var initialCdn = {{ episode.sktorrent_cdn.unwrap_or(0) }};
-var initialQualities = "{% match episode.sktorrent_qualities %}{% when Some with (q) %}{{ q }}{% when None %}480p{% endmatch %}".split(",").filter(function(q) { return q.match(/^\d+p$/); });
+/* SK Torrent CDN + qualities are resolved live via /api/films/sktorrent-resolve —
+   SK Torrent rotates videos across online{N} servers, so any stored value goes
+   stale. Do not pass CDN or qualities from the DB. */
 // Cached Přehraj.to URL for this episode (stable across searches).
 // Used as primary Zdroj 1 when SK Torrent is not available.
 var prehrajtoUrl = {% match episode.prehrajto_url %}{% when Some with (u) %}"{{ u }}"{% when None %}null{% endmatch %};
@@ -222,23 +223,30 @@ var _subPoll = null;
 
 function initPlayer() {
     if (initialVideoId) {
-        // Primary: SK Torrent (has quality options)
-        var qualities = initialQualities.length ? initialQualities : ['480p'];
-        var sources = qualities.map(function(q) {
-            return {
-                url: 'https://online' + initialCdn + '.sktorrent.eu/media/videos//h264/' + initialVideoId + '_' + q + '.mp4',
-                quality: q,
-                res: parseInt(q, 10),
-            };
-        });
-        sources.sort(function(a, b) { return b.res - a.res; });
-        state.source1 = {
-            episode: { season: initialSeason, episode: initialEpisode },
-            sources: sources,
-            currentIndex: 0,
-            videoId: initialVideoId,
-        };
-        switchToSource1();
+        // Primary: SK Torrent. Live-resolve current CDN + qualities.
+        document.getElementById('source-status').textContent = 'Načítám zdroj...';
+        fetch('/api/films/sktorrent-resolve?video_id=' + initialVideoId)
+            .then(function(r) { return r.json(); })
+            .then(function(data) {
+                if (!data.sources || !data.sources.length) {
+                    document.getElementById('source-status').textContent = 'Zdroj nedostupný';
+                    return;
+                }
+                var sources = data.sources.map(function(s) {
+                    return { url: s.url, quality: s.quality, res: s.res };
+                });
+                sources.sort(function(a, b) { return b.res - a.res; });
+                state.source1 = {
+                    episode: { season: initialSeason, episode: initialEpisode },
+                    sources: sources,
+                    currentIndex: 0,
+                    videoId: initialVideoId,
+                };
+                switchToSource1();
+            })
+            .catch(function() {
+                document.getElementById('source-status').textContent = 'Chyba obnovy zdroje';
+            });
     } else if (prehrajtoUrl) {
         // Fallback: cached Přehraj.to URL. Resolve on the fly, then play.
         document.getElementById('source-status').textContent = 'Načítání Přehraj.to...';
@@ -326,34 +334,12 @@ function playQuality1(index, doPlay) {
     });
     document.getElementById('source-status').textContent = 'S' + state.source1.episode.season + 'E' + state.source1.episode.episode;
     if (doPlay) {
-        player.play().catch(function() {
-            // Browser blocked autoplay with sound on fresh page load — fall back
-            // to muted autoplay, then unmute on the very next user interaction
-            // (click anywhere, keypress, etc.) so the viewer gets sound as soon
-            // as they touch the page instead of hunting for the volume icon.
-            player.muted = true;
-            player.play().catch(function() {});
-            unmuteOnFirstInteraction(player);
-        });
+        // If the browser blocks autoplay-with-sound, leave the player paused —
+        // the viewer hits play and gets sound via that user gesture. Never
+        // fall back to muted autoplay, which surprises the viewer with a
+        // silent video and a hidden unmute dance.
+        player.play().catch(function() {});
     }
-}
-
-function unmuteOnFirstInteraction(player) {
-    if (player._unmuteArmed) return;
-    player._unmuteArmed = true;
-    var handler = function() {
-        if (player.muted) {
-            player.muted = false;
-            if (player.volume === 0) player.volume = 1;
-        }
-        document.removeEventListener('click', handler, true);
-        document.removeEventListener('keydown', handler, true);
-        document.removeEventListener('touchstart', handler, true);
-        player._unmuteArmed = false;
-    };
-    document.addEventListener('click', handler, true);
-    document.addEventListener('keydown', handler, true);
-    document.addEventListener('touchstart', handler, true);
 }
 
 function switchToSource2() {

--- a/cr-web/templates/film_detail.html
+++ b/cr-web/templates/film_detail.html
@@ -112,13 +112,14 @@
             </div>
         </div>
 
-        {# Pass sktorrent data to JS — use static CDN URLs (sktorrent page is geo-blocked from non-CZ IPs) #}
+        {# SK Torrent video id only — CDN + qualities are resolved live via
+           /api/films/sktorrent-resolve at play time, because SK Torrent rotates
+           videos across online{N}.sktorrent.eu CDN servers and any stored CDN
+           value goes stale. #}
         {% match film.sktorrent_video_id %}
         {% when Some with (vid) %}
         <script>
         var sktorrentVideoId = {{ vid }};
-        var sktorrentCdn = {% match film.sktorrent_cdn %}{% when Some with (cdn) %}{{ cdn }}{% when None %}0{% endmatch %};
-        var sktorrentQualities = "{% match film.sktorrent_qualities %}{% when Some with (q) %}{{ q }}{% when None %}480p{% endmatch %}".split(",").filter(function(q) { return q.match(/^\d+p$/); });
         </script>
         {% when None %}
         {% endmatch %}
@@ -388,7 +389,7 @@ function showSktorrent(btn) {
 /* --- Cached Přehraj.to URL: primary source when SK Torrent is absent --- */
 var cachedPrehrajtoPlayed = false;
 (function() {
-    var hasSktorrent = typeof sktorrentVideoId !== 'undefined' && sktorrentCdn;
+    var hasSktorrent = typeof sktorrentVideoId !== 'undefined';
     if (hasSktorrent) return;                      // SK Torrent owns primary
     if (!cachedPrehrajtoUrl) return;               // Nothing to play
     var player = document.getElementById('film-player');
@@ -423,7 +424,7 @@ var cachedPrehrajtoPlayed = false;
     var filmTitle = "{{ film.title }}";
     var section = document.getElementById('prehrajto-section');
     var container = document.getElementById('prehrajto-results');
-    var hasSktorrent = typeof sktorrentVideoId !== 'undefined' && sktorrentCdn;
+    var hasSktorrent = typeof sktorrentVideoId !== 'undefined';
     if (!section || !container || !filmTitle) return;
 
     fetch('/api/movies/search?q=' + encodeURIComponent(filmTitle))
@@ -762,45 +763,66 @@ function setSubSize(px) {
     style.textContent = 'video::cue { font-size: ' + px + 'px !important; }';
 }
 
-/* --- Initialize sktorrent player from static CDN URLs --- */
+/* --- Initialize sktorrent player via live resolver --- */
+/* SK Torrent rotates videos across online{N}.sktorrent.eu CDN servers, so we
+   never trust a stored CDN value — every page load (and every mid-play error)
+   calls /api/films/sktorrent-resolve to find out where the video lives RIGHT
+   NOW. Backend caches resolver results in BoundedTtlCache (6h TTL), so this
+   adds at most one sktorrent fetch per video per 6 hours. */
 var sktorrentSources = [];
 
-(function() {
-    if (typeof sktorrentVideoId === 'undefined' || !sktorrentCdn || !sktorrentQualities.length) return;
-    var player = document.getElementById('film-player');
-    var qualDiv = document.getElementById('sktorrent-quality');
-    if (!player || !qualDiv) return;
-
-    // Build sources from DB data — CDN URLs work globally (no geo-block)
-    sktorrentQualities.forEach(function(q) {
-        var res = parseInt(q);
-        sktorrentSources.push({
-            url: 'https://online' + sktorrentCdn + '.sktorrent.eu/media/videos//h264/' + sktorrentVideoId + '_' + q + '.mp4',
-            quality: q,
-            res: res
-        });
+function renderSktorrentSources(data) {
+    var status = document.getElementById('source-status');
+    if (!data || !data.sources || !data.sources.length) {
+        if (status) status.textContent = 'Zdroj nedostupný';
+        return false;
+    }
+    sktorrentSources = data.sources.map(function(s) {
+        return { url: s.url, quality: s.quality, res: s.res };
     });
-
-    // Sort by resolution desc — prefer highest
     sktorrentSources.sort(function(a, b) { return b.res - a.res; });
 
-    // Build quality buttons
-    sktorrentSources.forEach(function(s, i) {
-        var btn = document.createElement('button');
-        btn.className = 'quality-btn' + (i === 0 ? ' active' : '');
-        btn.textContent = s.quality;
-        btn.onclick = function() { playSktorrent(i, btn); };
-        qualDiv.appendChild(btn);
-    });
+    var qualDiv = document.getElementById('sktorrent-quality');
+    if (qualDiv) {
+        qualDiv.innerHTML = '';
+        sktorrentSources.forEach(function(s, i) {
+            var btn = document.createElement('button');
+            btn.className = 'quality-btn' + (i === 0 ? ' active' : '');
+            btn.textContent = s.quality;
+            btn.onclick = function() { playSktorrent(i, btn); };
+            qualDiv.appendChild(btn);
+        });
+    }
+    return true;
+}
 
-    // Play best quality immediately
-    playSktorrent(0, qualDiv.querySelector('.quality-btn'));
+function resolveAndPlaySktorrent(onStatus) {
+    var status = document.getElementById('source-status');
+    if (status && onStatus) status.textContent = onStatus;
+    return fetch('/api/films/sktorrent-resolve?video_id=' + sktorrentVideoId)
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+            if (!renderSktorrentSources(data)) return;
+            var qualDiv = document.getElementById('sktorrent-quality');
+            playSktorrent(0, qualDiv ? qualDiv.querySelector('.quality-btn') : null);
+        })
+        .catch(function() {
+            if (status) status.textContent = 'Chyba obnovy zdroje';
+        });
+}
+
+(function() {
+    if (typeof sktorrentVideoId === 'undefined') return;
+    var player = document.getElementById('film-player');
+    if (!player) return;
+    resolveAndPlaySktorrent('Načítám zdroj...');
 })();
 
 function playSktorrent(index, btn) {
     var player = document.getElementById('film-player');
     if (window._hls) { window._hls.destroy(); window._hls = null; }
     var source = sktorrentSources[index];
+    if (!source) return;
     player.src = source.url;
     player.dataset.sktorrentSrc = source.url;
     player.dataset.sktorrentQuality = source.quality;
@@ -809,51 +831,18 @@ function playSktorrent(index, btn) {
     document.getElementById('source-status').textContent = '';
 }
 
-/* Fallback: if static CDN URL fails, fetch fresh URL from sktorrent */
+/* Defence against mid-play CDN rotation: if the SK Torrent URL fails after
+   we already had a working resolver response, try resolving once more. */
 (function() {
     var player = document.getElementById('film-player');
     if (!player || typeof sktorrentVideoId === 'undefined') return;
 
     var fallbackTried = false;
-    player.addEventListener('error', function(e) {
+    player.addEventListener('error', function() {
         if (fallbackTried) return;
-        var status = document.getElementById('source-status');
-        // Only fallback for sktorrent URLs
         if (!player.src || player.src.indexOf('sktorrent.eu') === -1) return;
         fallbackTried = true;
-        if (status) status.textContent = 'Obnovuji zdroj...';
-
-        fetch('/api/films/sktorrent-resolve?video_id=' + sktorrentVideoId)
-            .then(function(r) { return r.json(); })
-            .then(function(data) {
-                if (!data.sources || !data.sources.length) {
-                    if (status) status.textContent = 'Zdroj nedostupný';
-                    return;
-                }
-                // Rebuild sktorrentSources with fresh URLs
-                sktorrentSources = data.sources.map(function(s) {
-                    return { url: s.url, quality: s.quality, res: s.res };
-                });
-                sktorrentSources.sort(function(a, b) { return b.res - a.res; });
-                // Rebuild quality buttons
-                var qualDiv = document.getElementById('sktorrent-quality');
-                if (qualDiv) {
-                    qualDiv.innerHTML = '';
-                    sktorrentSources.forEach(function(s, i) {
-                        var btn = document.createElement('button');
-                        btn.className = 'quality-btn' + (i === 0 ? ' active' : '');
-                        btn.textContent = s.quality;
-                        btn.onclick = function() { playSktorrent(i, btn); };
-                        qualDiv.appendChild(btn);
-                    });
-                }
-                // Play best quality from fresh URLs
-                playSktorrent(0, qualDiv ? qualDiv.querySelector('.quality-btn') : null);
-                if (status) status.textContent = 'Obnoveno';
-            })
-            .catch(function() {
-                if (status) status.textContent = 'Zdroj nedostupný';
-            });
+        resolveAndPlaySktorrent('Obnovuji zdroj...');
     }, true);
 })();
 

--- a/cr-web/templates/tv_epizoda_detail.html
+++ b/cr-web/templates/tv_epizoda_detail.html
@@ -180,8 +180,9 @@ var showTitle = "{{ show.title }}";
 var initialSeason = {{ episode.season }};
 var initialEpisode = {{ episode.episode }};
 var initialVideoId = {{ episode.sktorrent_video_id.unwrap_or(0) }};
-var initialCdn = {{ episode.sktorrent_cdn.unwrap_or(0) }};
-var initialQualities = "{% match episode.sktorrent_qualities %}{% when Some with (q) %}{{ q }}{% when None %}480p{% endmatch %}".split(",").filter(function(q) { return q.match(/^\d+p$/); });
+/* SK Torrent CDN + qualities are resolved live via /api/films/sktorrent-resolve —
+   SK Torrent rotates videos across online{N} servers, so any stored value goes
+   stale. Do not pass CDN or qualities from the DB. */
 // Cached Přehraj.to URL for this episode (stable across searches).
 // Used as primary Zdroj 1 when SK Torrent is not available.
 var prehrajtoUrl = {% match episode.prehrajto_url %}{% when Some with (u) %}"{{ u }}"{% when None %}null{% endmatch %};
@@ -196,23 +197,30 @@ var _subPoll = null;
 
 function initPlayer() {
     if (initialVideoId) {
-        // Primary: SK Torrent (has quality options)
-        var qualities = initialQualities.length ? initialQualities : ['480p'];
-        var sources = qualities.map(function(q) {
-            return {
-                url: 'https://online' + initialCdn + '.sktorrent.eu/media/videos//h264/' + initialVideoId + '_' + q + '.mp4',
-                quality: q,
-                res: parseInt(q, 10),
-            };
-        });
-        sources.sort(function(a, b) { return b.res - a.res; });
-        state.source1 = {
-            episode: { season: initialSeason, episode: initialEpisode },
-            sources: sources,
-            currentIndex: 0,
-            videoId: initialVideoId,
-        };
-        switchToSource1();
+        // Primary: SK Torrent. Live-resolve current CDN + qualities.
+        document.getElementById('source-status').textContent = 'Načítám zdroj...';
+        fetch('/api/films/sktorrent-resolve?video_id=' + initialVideoId)
+            .then(function(r) { return r.json(); })
+            .then(function(data) {
+                if (!data.sources || !data.sources.length) {
+                    document.getElementById('source-status').textContent = 'Zdroj nedostupný';
+                    return;
+                }
+                var sources = data.sources.map(function(s) {
+                    return { url: s.url, quality: s.quality, res: s.res };
+                });
+                sources.sort(function(a, b) { return b.res - a.res; });
+                state.source1 = {
+                    episode: { season: initialSeason, episode: initialEpisode },
+                    sources: sources,
+                    currentIndex: 0,
+                    videoId: initialVideoId,
+                };
+                switchToSource1();
+            })
+            .catch(function() {
+                document.getElementById('source-status').textContent = 'Chyba obnovy zdroje';
+            });
     } else if (prehrajtoUrl) {
         // Fallback: cached Přehraj.to URL. Resolve on the fly, then play.
         document.getElementById('source-status').textContent = 'Načítání Přehraj.to...';
@@ -300,34 +308,12 @@ function playQuality1(index, doPlay) {
     });
     document.getElementById('source-status').textContent = 'S' + state.source1.episode.season + 'E' + state.source1.episode.episode;
     if (doPlay) {
-        player.play().catch(function() {
-            // Browser blocked autoplay with sound on fresh page load — fall back
-            // to muted autoplay, then unmute on the very next user interaction
-            // (click anywhere, keypress, etc.) so the viewer gets sound as soon
-            // as they touch the page instead of hunting for the volume icon.
-            player.muted = true;
-            player.play().catch(function() {});
-            unmuteOnFirstInteraction(player);
-        });
+        // If the browser blocks autoplay-with-sound, leave the player paused —
+        // the viewer hits play and gets sound via that user gesture. Never
+        // fall back to muted autoplay, which surprises the viewer with a
+        // silent video and a hidden unmute dance.
+        player.play().catch(function() {});
     }
-}
-
-function unmuteOnFirstInteraction(player) {
-    if (player._unmuteArmed) return;
-    player._unmuteArmed = true;
-    var handler = function() {
-        if (player.muted) {
-            player.muted = false;
-            if (player.volume === 0) player.volume = 1;
-        }
-        document.removeEventListener('click', handler, true);
-        document.removeEventListener('keydown', handler, true);
-        document.removeEventListener('touchstart', handler, true);
-        player._unmuteArmed = false;
-    };
-    document.addEventListener('click', handler, true);
-    document.addEventListener('keydown', handler, true);
-    document.addEventListener('touchstart', handler, true);
 }
 
 function switchToSource2() {


### PR DESCRIPTION
<!-- claude-session: c0717c9a-16b7-4690-af5a-437a07586132 -->

Closes #496

## Summary
- SK Torrent rotates videos across online{N}.sktorrent.eu servers, so the stored `sktorrent_cdn` / `sktorrent_qualities` values go stale. Player detail pages now call `/api/films/sktorrent-resolve` on init (not just on error) to get the current CDN + qualities and render the play URL + quality buttons from the response.
- Fixes 674 films that had `sktorrent_cdn IS NULL` in the DB (e.g. `/filmy-online/axel-a-tajemstvi-planety-kepler-2017/`) — the old init IIFE short-circuited on `!sktorrentCdn` before setting a src, so the `player.error` fallback never triggered either.
- Mid-play CDN rotation still recovers via the existing error handler.
- Existing backend resolver endpoint (with 6h `BoundedTtlCache`) is unchanged; only the frontend wiring flipped from "error fallback" to "primary path".

## Test plan
- [x] `/filmy-online/axel-a-tajemstvi-planety-kepler-2017/` — DB `sktorrent_cdn=NULL` → resolved live to `online22.sktorrent.eu/38040_720p.mp4`, 720p+480p buttons rendered, `readyState=4`. (Before this PR: silent fail on `online0`.)
- [x] `/serialy-online/polabi/2x28/` — `online15.sktorrent.eu/59516_720p.mp4`, playing (currentTime ~10s).
- [x] `/tv-porady/asia-express/s01e16/` — `online20.sktorrent.eu/59521_720p.mp4`, playing (currentTime ~10s).
- [x] Zero console errors on all three pages.
- [x] `cargo check`, `cargo fmt --check` clean.