### PR TITLE
docs(claude): bound Copilot re-review wait, avoid indefinite stuck sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,9 +90,18 @@ gh api "repos/Olbrasoft/cr/commits/${HEAD}/check-runs" --jq '.check_runs[] | sel
 ```
 - `in_progress`/`queued` → Copilot review still running → WAIT, do NOT merge
 - `completed` → read review comments, fix ALL, push. Then merge.
-- empty (no output) → Copilot not active → merge after CI passes
+- empty (no output) → **bounded wait** (see below).
 
-**NEVER merge before Copilot review finishes.** Copilot almost always finds something to fix (~92%). Read comments, fix them, push. Only then merge.
+**Copilot re-review is NOT automatic.** Copilot reviews each PR ONCE when it first sees actionable content, and then does not re-review follow-up pushes on its own. Do NOT sit waiting for a second review that will never arrive — that hangs the session and burns CI minutes for nothing.
+
+**Bounded-wait rule for the "Agent" check-run:**
+- After a push, wait AT MOST ~60 seconds past the last `check_suite` success for an `Agent` check-run to appear.
+- If it has not appeared in that window → Copilot will not re-review this push. **Merge immediately** (assuming CI is green and you have addressed the previous review's comments).
+- Do NOT rationalize further waiting ("previous push triggered Copilot, so this one must too", "maybe it's just slow") — that is the exact failure mode this rule prevents.
+
+**Requesting a re-review explicitly** — only when the push added *substantial new code* beyond the original review's scope (e.g., a new handler, a new migration, an architectural change). Simply addressing the comments Copilot already made is NOT substantial; don't request re-review for that. To request: leave a `/copilot review` PR comment.
+
+**NEVER merge before the FIRST Copilot review finishes.** Copilot almost always finds something to fix on the initial review (~92%). Read those comments, fix them, push. After that first round, the bounded-wait rule above applies to every subsequent push.
 
 **Progress notifications should say:**
 - After PR: "PR vytvořen, CI běží. Sleduji pipeline." (NOT "Issue hotová")


### PR DESCRIPTION
<!-- claude-session: c0717c9a-16b7-4690-af5a-437a07586132 -->

## Summary
- Sessions keep waiting indefinitely for a Copilot re-review that never arrives, because the current CLAUDE.md rule (`empty output → Copilot not active → merge after CI passes`) is routinely overridden by wishful thinking (\"previous push triggered Copilot, so it should come again\"). PR #495 hung on exactly this pattern until a manual push-notification unblocked it.
- Replace the soft rule with a **bounded wait**: after push, wait at most ~60s past the last `check_suite` success for an `Agent` check-run to appear. If not there → Copilot will not re-review this push; merge. Don't rationalize further waiting.
- Document that Copilot re-reviews are NOT automatic — Copilot reviews each PR once, then only re-reviews on explicit `/copilot review` comment, and that comment should be reserved for substantial new changes, not for addressing existing feedback.

## Test plan
- [x] Rule is additive to existing \"NEVER merge before the FIRST Copilot review\" invariant — no regression risk.
- [x] Docs-only change, no CI/runtime impact.