### PR TITLE
feat(admin): /admin/cache/ — Cloudflare cache purge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,21 +83,12 @@ Code review events arrive automatically via event files + FIFO wake. Claude Code
 
 **Branch protection is enabled on main.** Required CI checks: Check & Clippy, Format, Test.
 
-**Copilot review policy — one automatic initial review per PR.** Copilot automatically reviews each PR once when it first sees actionable content. It does **not** automatically re-review follow-up pushes on its own, and an automatic re-review is not something to wait for, bounded or otherwise. Explicit re-reviews can be requested via `/copilot review` — see below.
+**Copilot review — rely on the ghnotify classifier, not on polling.** The ghnotify classifier now emits an explicit next-action hint on every wake, so the old "check the Agent check-run yourself" dance is no longer needed.
 
-**First push on a new PR:** wait for Copilot's initial review. Copilot almost always finds something to fix (~92%). Read those comments, fix them, push.
-
-**Any subsequent push (fix-push, rebase, follow-up):** unless you have explicitly requested a re-review (see below), merge **IMMEDIATELY** once CI is green. Zero Copilot wait. No bounded timer. No "maybe it's just slow". The Agent check-run will not appear for a fix-push on its own, and sitting there checking for it burns session time and confuses the workflow.
-
-```bash
-# Check CI for the current PR head:
-HEAD=$(gh pr view <PR> --repo Olbrasoft/cr --json headRefOid --jq '.headRefOid')
-gh api "repos/Olbrasoft/cr/commits/${HEAD}/check-runs" \
-  --jq '.check_runs[] | .name + ": " + .status + "/" + (.conclusion // "—")'
-```
-All required checks (Check & Clippy, Test, Format) must read `completed/success`. If they do → merge. An `Agent` check-run appears automatically on the initial review and on any *explicitly requested* `/copilot review`; its absence on an unrequested fix-push is normal and not a signal to wait.
-
-**Requesting a re-review explicitly** — only when the push added *substantial new code* beyond the original review's scope (e.g., a new handler, a new migration, an architectural change). Simply addressing the comments Copilot already made is NOT substantial; don't request re-review for that. To request: leave a `/copilot review` PR comment. Once requested, Copilot WILL produce a new `Agent` check-run — in that narrow case, treat the push like a first review and wait for it to complete before merging.
+- **`ci-success` wake with `pr!=none`** → merge **now**: `gh pr merge <pr> --squash` (append `--delete-branch` if the branch is safe to delete). Do NOT poll for a Copilot re-review and do NOT wait for an `Agent` check-run to appear. Copilot reviews each PR once automatically; follow-up pushes won't produce another review unless you explicitly request one (`/copilot review` comment — reserve for *substantial* new changes).
+- **`ci-failure` wake** → diagnose AND fix, push. Do NOT stop at "pre-existing skip" or similar excuses; that is the failure mode this rule prevents.
+- **`code-review-complete` wake** → read comments (`gh api repos/Olbrasoft/cr/pulls/<pr>/comments`), address ALL, push. The next `ci-success` wake will tell you to merge.
+- **Only exception to "no wait":** the very first push on a brand-new PR — wait for Copilot's initial `code-review-complete` wake before merging. Copilot finds something to fix ~92% of the time on that first look.
 
 **Progress notifications should say:**
 - After PR: "PR vytvořen, CI běží. Sleduji pipeline." (NOT "Issue hotová")

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,10 +85,10 @@ Code review events arrive automatically via event files + FIFO wake. Claude Code
 
 **Copilot review — rely on the ghnotify classifier, not on polling.** The ghnotify classifier now emits an explicit next-action hint on every wake, so the old "check the Agent check-run yourself" dance is no longer needed.
 
-- **`ci-success` wake with `pr!=none`** → merge **now**: `gh pr merge <pr> --squash` (append `--delete-branch` if the branch is safe to delete). Do NOT poll for a Copilot re-review and do NOT wait for an `Agent` check-run to appear. Copilot reviews each PR once automatically; follow-up pushes won't produce another review unless you explicitly request one (`/copilot review` comment — reserve for *substantial* new changes).
+- **First push on a brand-new PR** (listed first because it's the most common wrong-merge trap): wait for Copilot's initial `code-review-complete` wake before merging. Do NOT merge on the first `ci-success` alone. Copilot finds something to fix ~92% of the time on that first look.
+- **`ci-success` wake with `pr!=none` after the initial Copilot review has already completed** → merge **now**: `gh pr merge <pr> --squash` (append `--delete-branch` if the branch is safe to delete). Do NOT poll for a Copilot re-review and do NOT wait for an `Agent` check-run to appear. Copilot reviews each PR once automatically; follow-up pushes won't produce another review unless you explicitly request one (`/copilot review` comment — reserve for *substantial* new changes).
 - **`ci-failure` wake** → diagnose AND fix, push. Do NOT stop at "pre-existing skip" or similar excuses; that is the failure mode this rule prevents.
-- **`code-review-complete` wake** → read comments (`gh api repos/Olbrasoft/cr/pulls/<pr>/comments`), address ALL, push. The next `ci-success` wake will tell you to merge.
-- **Only exception to "no wait":** the very first push on a brand-new PR — wait for Copilot's initial `code-review-complete` wake before merging. Copilot finds something to fix ~92% of the time on that first look.
+- **`code-review-complete` wake** → read comments with `gh pr view <pr> --comments` (which includes the review body/summary and any top-level discussion, not only inline threads), address ALL, push. The next `ci-success` wake will tell you to merge.
 
 **Progress notifications should say:**
 - After PR: "PR vytvořen, CI běží. Sleduji pipeline." (NOT "Issue hotová")

--- a/cr-web/src/config.rs
+++ b/cr-web/src/config.rs
@@ -39,6 +39,12 @@ pub struct AppConfig {
     /// Hard gate on POST /admin/import/run. Set `ADMIN_IMPORT_RUN_ENABLED=1`
     /// to allow the dashboard button to spawn the importer.
     pub admin_import_run_enabled: bool,
+    /// Hard gate on POST /admin/cache/purge. Set `ADMIN_CACHE_PURGE_ENABLED=1`
+    /// to allow the dashboard button to call the Cloudflare purge API. Even
+    /// with a token present the POST 403s without this flag — prevents a
+    /// stray/CSRF request on the unauthenticated /admin/ path from flushing
+    /// the CDN.
+    pub admin_cache_purge_enabled: bool,
     /// Optional CZ-hosted proxy for scraping geo-blocked sources (prehraj.to,
     /// SK Torrent). None if unconfigured.
     pub cz_proxy: Option<CzProxyConfig>,
@@ -95,6 +101,11 @@ impl AppConfig {
             Ok("1")
         );
 
+        let admin_cache_purge_enabled = matches!(
+            std::env::var("ADMIN_CACHE_PURGE_ENABLED").as_deref(),
+            Ok("1")
+        );
+
         let cz_proxy = match (
             std::env::var("CZ_PROXY_URL").ok().filter(|s| !s.is_empty()),
             std::env::var("CZ_PROXY_KEY").ok().filter(|s| !s.is_empty()),
@@ -125,6 +136,7 @@ impl AppConfig {
             series_people_dir,
             cr_repo_root,
             admin_import_run_enabled,
+            admin_cache_purge_enabled,
             cz_proxy,
             cf_cache_purge,
         }))

--- a/cr-web/src/config.rs
+++ b/cr-web/src/config.rs
@@ -42,6 +42,16 @@ pub struct AppConfig {
     /// Optional CZ-hosted proxy for scraping geo-blocked sources (prehraj.to,
     /// SK Torrent). None if unconfigured.
     pub cz_proxy: Option<CzProxyConfig>,
+    /// Cloudflare API token scoped to Zone.Cache Purge. Enables the admin
+    /// `/admin/cache/` page to invalidate CDN cache on demand. `None` when the
+    /// env vars aren't provisioned — UI hides the purge actions in that case.
+    pub cf_cache_purge: Option<CfCachePurgeConfig>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CfCachePurgeConfig {
+    pub token: String,
+    pub zone_id: String,
 }
 
 #[derive(Debug, Clone)]
@@ -93,6 +103,16 @@ impl AppConfig {
             _ => None,
         };
 
+        let cf_cache_purge = match (
+            std::env::var("CF_CACHE_PURGE_TOKEN")
+                .ok()
+                .filter(|s| !s.is_empty()),
+            std::env::var("CF_ZONE_ID").ok().filter(|s| !s.is_empty()),
+        ) {
+            (Some(token), Some(zone_id)) => Some(CfCachePurgeConfig { token, zone_id }),
+            _ => None,
+        };
+
         Ok(Arc::new(Self {
             database_url,
             port,
@@ -106,6 +126,7 @@ impl AppConfig {
             cr_repo_root,
             admin_import_run_enabled,
             cz_proxy,
+            cf_cache_purge,
         }))
     }
 }

--- a/cr-web/src/handlers/admin_cache.rs
+++ b/cr-web/src/handlers/admin_cache.rs
@@ -16,6 +16,8 @@
 //! Free plan limit is 30 URLs per purge_cache call, so section purges are
 //! chunked. Everything/hostname-style purges are a single call.
 
+use std::time::Duration;
+
 use askama::Template;
 use axum::extract::{Form, State};
 use axum::http::StatusCode;
@@ -27,6 +29,10 @@ use crate::error::WebResult;
 use crate::state::AppState;
 
 const CF_PURGE_BATCH: usize = 30;
+const CF_PURGE_TIMEOUT: Duration = Duration::from_secs(30);
+/// Hard cap on the "specific URLs" textarea so a fat-fingered paste can't
+/// kick off thousands of API calls. Admin who needs more can split the work.
+const MAX_URL_LIST: usize = 5000;
 const SITE_ORIGIN: &str = "https://ceskarepublika.wiki";
 
 #[derive(Template)]
@@ -36,6 +42,10 @@ struct AdminCacheTemplate {
     /// Whether CF token is configured. When false the form is disabled and the
     /// page explains the missing env vars.
     configured: bool,
+    /// Whether POST /admin/cache/purge will be honored. Token alone is not
+    /// enough — ADMIN_CACHE_PURGE_ENABLED=1 must also be set. UI shows a
+    /// separate warning when token is present but the gate isn't.
+    enabled: bool,
     /// Zone ID (or empty string) — shown in the info box so an admin can tell
     /// at a glance which zone this would purge.
     zone_id: String,
@@ -103,6 +113,7 @@ pub async fn admin_cache_form(
     let tmpl = AdminCacheTemplate {
         img: state.image_base_url.clone(),
         configured,
+        enabled: state.config.admin_cache_purge_enabled,
         zone_id,
         flash,
     };
@@ -126,6 +137,18 @@ pub async fn admin_cache_purge(
     State(state): State<AppState>,
     Form(form): Form<PurgeForm>,
 ) -> WebResult<Response> {
+    // Feature gate — admin routes are currently unauthenticated, so the POST
+    // path is guarded by ADMIN_CACHE_PURGE_ENABLED=1 (same pattern as the
+    // auto-import Run-now button). Returns 403 without the flag, even if
+    // a token is present, so a stray/CSRF request can't flush the CDN.
+    if !state.config.admin_cache_purge_enabled {
+        return Ok((
+            StatusCode::FORBIDDEN,
+            "Cache purge is disabled. Set ADMIN_CACHE_PURGE_ENABLED=1 in the env to enable.",
+        )
+            .into_response());
+    }
+
     let cfg = match &state.config.cf_cache_purge {
         Some(c) => c.clone(),
         None => {
@@ -184,7 +207,19 @@ pub async fn admin_cache_purge(
                 ));
             }
         },
-        "urls" => parse_url_list(&form.urls),
+        "urls" => {
+            let parsed = parse_url_list(&form.urls);
+            if parsed.len() > MAX_URL_LIST {
+                return Ok(redirect_with_flash(
+                    "error",
+                    &format!(
+                        "Příliš mnoho URL ({}) — maximum je {MAX_URL_LIST}. Rozděl na více dávek.",
+                        parsed.len()
+                    ),
+                ));
+            }
+            parsed
+        }
         other => {
             return Ok(redirect_with_flash(
                 "error",
@@ -269,6 +304,7 @@ async fn purge_everything(
     let res = client
         .post(&url)
         .bearer_auth(&cfg.token)
+        .timeout(CF_PURGE_TIMEOUT)
         .json(&serde_json::json!({ "purge_everything": true }))
         .send()
         .await?;
@@ -299,6 +335,7 @@ async fn purge_urls_batched(
         let res = client
             .post(&api)
             .bearer_auth(&cfg.token)
+            .timeout(CF_PURGE_TIMEOUT)
             .json(&serde_json::json!({ "files": chunk }))
             .send()
             .await?;

--- a/cr-web/src/handlers/admin_cache.rs
+++ b/cr-web/src/handlers/admin_cache.rs
@@ -1,0 +1,317 @@
+//! Admin page `/admin/cache/` — on-demand Cloudflare cache purge.
+//!
+//! Solves the "posters updated but CDN still serves stale" problem: after we
+//! re-upload covers (films / series / TV pořady) the CF edge keeps the old
+//! response until its TTL (max-age=3600) expires. This handler calls the CF
+//! API's `zones/{id}/purge_cache` endpoint to invalidate specific URLs (or
+//! the whole zone) immediately.
+//!
+//! Scopes:
+//!   - "everything"         → `{"purge_everything": true}` — nuclear option
+//!   - "series_covers"      → all /serialy-online/{slug}.webp
+//!   - "films_covers"       → all /filmy-online/{slug}.webp
+//!   - "tv_shows_covers"    → all /tv-porady/{slug}.webp
+//!   - "urls"               → user-provided list (one URL per line, textarea)
+//!
+//! Free plan limit is 30 URLs per purge_cache call, so section purges are
+//! chunked. Everything/hostname-style purges are a single call.
+
+use askama::Template;
+use axum::extract::{Form, State};
+use axum::http::StatusCode;
+use axum::response::{Html, IntoResponse, Response};
+use serde::Deserialize;
+
+use crate::config::CfCachePurgeConfig;
+use crate::error::WebResult;
+use crate::state::AppState;
+
+const CF_PURGE_BATCH: usize = 30;
+const SITE_ORIGIN: &str = "https://ceskarepublika.wiki";
+
+#[derive(Template)]
+#[template(path = "admin_cache.html")]
+struct AdminCacheTemplate {
+    img: String,
+    /// Whether CF token is configured. When false the form is disabled and the
+    /// page explains the missing env vars.
+    configured: bool,
+    /// Zone ID (or empty string) — shown in the info box so an admin can tell
+    /// at a glance which zone this would purge.
+    zone_id: String,
+    /// Flash message from a previous POST redirect. None on a fresh GET.
+    flash: Option<FlashMessage>,
+}
+
+#[derive(Clone)]
+struct FlashMessage {
+    kind: &'static str, // "ok" | "error"
+    text: String,
+}
+
+fn noindex(html: String) -> Response {
+    let mut resp = Html(html).into_response();
+    resp.headers_mut().insert(
+        "X-Robots-Tag",
+        axum::http::HeaderValue::from_static("noindex, nofollow"),
+    );
+    resp
+}
+
+/// Parse flash message out of the `?msg=...&kind=ok|error` query string.
+/// We use query-string flash instead of sessions because /admin/ has no
+/// session layer today; the tradeoff is a uglier URL for a split-second.
+fn parse_flash(query: &str) -> Option<FlashMessage> {
+    let mut kind = "";
+    let mut text = String::new();
+    for pair in query.split('&') {
+        let mut it = pair.splitn(2, '=');
+        let k = it.next().unwrap_or("");
+        let v = it.next().unwrap_or("");
+        let v = urlencoding::decode(v)
+            .map(|c| c.into_owned())
+            .unwrap_or_default();
+        match k {
+            "kind" => kind = if v == "error" { "error" } else { "ok" },
+            "msg" => text = v,
+            _ => {}
+        }
+    }
+    if text.is_empty() {
+        None
+    } else {
+        let kind_static: &'static str = if kind == "error" { "error" } else { "ok" };
+        Some(FlashMessage {
+            kind: kind_static,
+            text,
+        })
+    }
+}
+
+/// GET /admin/cache/ — render form.
+pub async fn admin_cache_form(
+    State(state): State<AppState>,
+    axum::extract::RawQuery(query): axum::extract::RawQuery,
+) -> WebResult<Response> {
+    let (configured, zone_id) = match &state.config.cf_cache_purge {
+        Some(cfg) => (true, cfg.zone_id.clone()),
+        None => (false, String::new()),
+    };
+
+    let flash = query.as_deref().and_then(parse_flash);
+
+    let tmpl = AdminCacheTemplate {
+        img: state.image_base_url.clone(),
+        configured,
+        zone_id,
+        flash,
+    };
+    Ok(noindex(tmpl.render()?))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PurgeForm {
+    /// "everything" | "series_covers" | "films_covers" | "tv_shows_covers" | "urls"
+    scope: String,
+    /// URL list from textarea — one per line. Only honored when scope == "urls".
+    #[serde(default)]
+    urls: String,
+    /// Typed "SMAZAT" to guard the "everything" scope from accidental clicks.
+    #[serde(default)]
+    confirm: String,
+}
+
+/// POST /admin/cache/purge — execute purge, redirect back with flash.
+pub async fn admin_cache_purge(
+    State(state): State<AppState>,
+    Form(form): Form<PurgeForm>,
+) -> WebResult<Response> {
+    let cfg = match &state.config.cf_cache_purge {
+        Some(c) => c.clone(),
+        None => {
+            return Ok(redirect_with_flash(
+                "error",
+                "CF cache purge není nakonfigurovaný (chybí CF_CACHE_PURGE_TOKEN / CF_ZONE_ID).",
+            ));
+        }
+    };
+
+    // Dispatch by scope — each branch either returns a flash redirect or falls
+    // through to a common "chunked URL list" purge path.
+    let urls: Vec<String> = match form.scope.as_str() {
+        "everything" => {
+            if form.confirm.trim() != "SMAZAT" {
+                return Ok(redirect_with_flash(
+                    "error",
+                    "Pro \"Smaž vše\" je nutné do pole potvrzení napsat SMAZAT.",
+                ));
+            }
+            return match purge_everything(&state.http_client, &cfg).await {
+                Ok(()) => Ok(redirect_with_flash(
+                    "ok",
+                    "Celá zóna vyčištěna (purge_everything).",
+                )),
+                Err(e) => Ok(redirect_with_flash(
+                    "error",
+                    &format!("purge_everything selhal: {e}"),
+                )),
+            };
+        }
+        "series_covers" => match collect_series_cover_urls(&state.db).await {
+            Ok(u) => u,
+            Err(e) => {
+                return Ok(redirect_with_flash(
+                    "error",
+                    &format!("DB query (series) selhala: {e}"),
+                ));
+            }
+        },
+        "films_covers" => match collect_film_cover_urls(&state.db).await {
+            Ok(u) => u,
+            Err(e) => {
+                return Ok(redirect_with_flash(
+                    "error",
+                    &format!("DB query (films) selhala: {e}"),
+                ));
+            }
+        },
+        "tv_shows_covers" => match collect_tv_show_cover_urls(&state.db).await {
+            Ok(u) => u,
+            Err(e) => {
+                return Ok(redirect_with_flash(
+                    "error",
+                    &format!("DB query (tv_shows) selhala: {e}"),
+                ));
+            }
+        },
+        "urls" => parse_url_list(&form.urls),
+        other => {
+            return Ok(redirect_with_flash(
+                "error",
+                &format!("Neznámý scope: {other}"),
+            ));
+        }
+    };
+
+    if urls.is_empty() {
+        return Ok(redirect_with_flash(
+            "error",
+            "Nebyla poslána žádná URL k promazání.",
+        ));
+    }
+
+    match purge_urls_batched(&state.http_client, &cfg, &urls).await {
+        Ok(n) => Ok(redirect_with_flash(
+            "ok",
+            &format!("Promazáno {n} URL ({} dávek).", n.div_ceil(CF_PURGE_BATCH)),
+        )),
+        Err(e) => Ok(redirect_with_flash("error", &format!("Purge selhal: {e}"))),
+    }
+}
+
+fn redirect_with_flash(kind: &str, msg: &str) -> Response {
+    let url = format!(
+        "/admin/cache/?kind={}&msg={}",
+        kind,
+        urlencoding::encode(msg)
+    );
+    (StatusCode::SEE_OTHER, [(axum::http::header::LOCATION, url)]).into_response()
+}
+
+fn parse_url_list(raw: &str) -> Vec<String> {
+    raw.lines()
+        .map(|l| l.trim().to_string())
+        .filter(|l| !l.is_empty() && (l.starts_with("http://") || l.starts_with("https://")))
+        .collect()
+}
+
+async fn collect_series_cover_urls(pool: &sqlx::PgPool) -> Result<Vec<String>, sqlx::Error> {
+    let rows: Vec<(String,)> =
+        sqlx::query_as("SELECT slug FROM series WHERE slug IS NOT NULL AND slug <> ''")
+            .fetch_all(pool)
+            .await?;
+    Ok(rows
+        .into_iter()
+        .map(|(slug,)| format!("{SITE_ORIGIN}/serialy-online/{slug}.webp"))
+        .collect())
+}
+
+async fn collect_film_cover_urls(pool: &sqlx::PgPool) -> Result<Vec<String>, sqlx::Error> {
+    let rows: Vec<(String,)> =
+        sqlx::query_as("SELECT slug FROM films WHERE slug IS NOT NULL AND slug <> ''")
+            .fetch_all(pool)
+            .await?;
+    Ok(rows
+        .into_iter()
+        .map(|(slug,)| format!("{SITE_ORIGIN}/filmy-online/{slug}.webp"))
+        .collect())
+}
+
+async fn collect_tv_show_cover_urls(pool: &sqlx::PgPool) -> Result<Vec<String>, sqlx::Error> {
+    let rows: Vec<(String,)> =
+        sqlx::query_as("SELECT slug FROM tv_shows WHERE slug IS NOT NULL AND slug <> ''")
+            .fetch_all(pool)
+            .await?;
+    Ok(rows
+        .into_iter()
+        .map(|(slug,)| format!("{SITE_ORIGIN}/tv-porady/{slug}.webp"))
+        .collect())
+}
+
+async fn purge_everything(
+    client: &reqwest::Client,
+    cfg: &CfCachePurgeConfig,
+) -> anyhow::Result<()> {
+    let url = format!(
+        "https://api.cloudflare.com/client/v4/zones/{}/purge_cache",
+        cfg.zone_id
+    );
+    let res = client
+        .post(&url)
+        .bearer_auth(&cfg.token)
+        .json(&serde_json::json!({ "purge_everything": true }))
+        .send()
+        .await?;
+    let status = res.status();
+    let body = res.text().await.unwrap_or_default();
+    if !status.is_success() {
+        anyhow::bail!("HTTP {status}: {body}");
+    }
+    // CF returns { "success": true, ... } even on semantic errors with 200
+    let v: serde_json::Value = serde_json::from_str(&body).unwrap_or_default();
+    if v.get("success").and_then(|s| s.as_bool()) != Some(true) {
+        anyhow::bail!("CF reported failure: {body}");
+    }
+    Ok(())
+}
+
+async fn purge_urls_batched(
+    client: &reqwest::Client,
+    cfg: &CfCachePurgeConfig,
+    urls: &[String],
+) -> anyhow::Result<usize> {
+    let api = format!(
+        "https://api.cloudflare.com/client/v4/zones/{}/purge_cache",
+        cfg.zone_id
+    );
+    let mut done = 0usize;
+    for chunk in urls.chunks(CF_PURGE_BATCH) {
+        let res = client
+            .post(&api)
+            .bearer_auth(&cfg.token)
+            .json(&serde_json::json!({ "files": chunk }))
+            .send()
+            .await?;
+        let status = res.status();
+        let body = res.text().await.unwrap_or_default();
+        if !status.is_success() {
+            anyhow::bail!("HTTP {status} at batch starting {done}: {body}");
+        }
+        let v: serde_json::Value = serde_json::from_str(&body).unwrap_or_default();
+        if v.get("success").and_then(|s| s.as_bool()) != Some(true) {
+            anyhow::bail!("CF reported failure at batch starting {done}: {body}");
+        }
+        done += chunk.len();
+    }
+    Ok(done)
+}

--- a/cr-web/src/handlers/admin_dashboard.rs
+++ b/cr-web/src/handlers/admin_dashboard.rs
@@ -44,6 +44,7 @@ struct AdminDashboardTemplate {
     img: String,
     import_tile: LastRunTile,
     backup_tile: LastRunTile,
+    cache_tile: LastRunTile,
 }
 
 fn noindex(html: String) -> Response {
@@ -176,6 +177,22 @@ async fn fetch_backup_tile(state: &AppState) -> LastRunTile {
     }
 }
 
+fn cache_tile(state: &AppState) -> LastRunTile {
+    // Dashboard tile reflects config state — tracking actual purge history
+    // would require a new table; for now admins just see whether the feature
+    // is wired up.
+    match &state.config.cf_cache_purge {
+        Some(_) => LastRunTile {
+            status: "ok",
+            message: "Nakonfigurováno — klikni pro promazání.".to_string(),
+        },
+        None => LastRunTile {
+            status: "none",
+            message: "Chybí CF_CACHE_PURGE_TOKEN / CF_ZONE_ID.".to_string(),
+        },
+    }
+}
+
 /// GET /admin/ — landing page with per-section status tiles.
 pub async fn admin_dashboard(State(state): State<AppState>) -> WebResult<Response> {
     let (import_tile, backup_tile) =
@@ -185,6 +202,7 @@ pub async fn admin_dashboard(State(state): State<AppState>) -> WebResult<Respons
         img: state.image_base_url.clone(),
         import_tile,
         backup_tile,
+        cache_tile: cache_tile(&state),
     };
     Ok(noindex(tmpl.render()?))
 }

--- a/cr-web/src/handlers/mod.rs
+++ b/cr-web/src/handlers/mod.rs
@@ -10,6 +10,7 @@ use crate::error::WebResult;
 use crate::state::AppState;
 
 pub mod admin_backups;
+pub mod admin_cache;
 pub mod admin_dashboard;
 pub mod admin_import;
 mod audiobooks;

--- a/cr-web/src/main.rs
+++ b/cr-web/src/main.rs
@@ -256,6 +256,18 @@ async fn main() -> Result<()> {
             axum::routing::get(handlers::admin_backups::admin_backups_list),
         )
         .route(
+            "/admin/cache/",
+            axum::routing::get(handlers::admin_cache::admin_cache_form),
+        )
+        .route(
+            "/admin/cache",
+            axum::routing::get(handlers::admin_cache::admin_cache_form),
+        )
+        .route(
+            "/admin/cache/purge",
+            axum::routing::post(handlers::admin_cache::admin_cache_purge),
+        )
+        .route(
             "/admin/import/",
             axum::routing::get(handlers::admin_import::admin_import_list),
         )

--- a/cr-web/templates/admin_cache.html
+++ b/cr-web/templates/admin_cache.html
@@ -1,0 +1,162 @@
+{% extends "base.html" %}
+
+{% block title %}Admin — Cache purge{% endblock %}
+{% block meta_description %}Administrace — promazání Cloudflare cache.{% endblock %}
+
+{% block og_title %}Admin — Cache purge{% endblock %}
+{% block og_description %}Administrace — promazání Cloudflare cache.{% endblock %}
+
+{# noindex is enforced via X-Robots-Tag response header from the handler. #}
+
+{% block header_left %}
+<div class="logo-group">
+    <h1>Admin — Cache</h1>
+</div>
+{% endblock %}
+
+{% block content %}
+<main class="admin-cache">
+    <nav class="breadcrumb">
+        <a href="/" title="Domů">Česká republika</a>
+        <span>›</span>
+        <a href="/admin/" title="Admin rozcestník">Admin</a>
+        <span>›</span>
+        <span>Cache purge</span>
+    </nav>
+
+    <h2>Cloudflare cache purge</h2>
+    <p class="intro">Vynutit okamžité promazání Cloudflare cache pro vybraný rozsah. Bez toho by CDN servírovala starý obsah až do vypršení TTL (typicky 1h).</p>
+
+    {% match flash %}
+    {% when Some with (f) %}
+      <div class="flash flash-{{ f.kind }}">{{ f.text }}</div>
+    {% when None %}
+    {% endmatch %}
+
+    {% if !configured %}
+    <div class="warn-box">
+        <strong>Není nakonfigurováno.</strong>
+        V <code>.env</code> (nebo v <code>docker-compose.yml</code>) chybí proměnné <code>CF_CACHE_PURGE_TOKEN</code> a <code>CF_ZONE_ID</code>.
+        Formulář je vypnutý do té doby, než budou nastavené.
+    </div>
+    {% else %}
+    <p class="zone-info">Zóna: <code>{{ zone_id }}</code></p>
+    {% endif %}
+
+    <form method="post" action="/admin/cache/purge" class="purge-form">
+        <fieldset {% if !configured %}disabled{% endif %}>
+            <legend>Rozsah</legend>
+
+            <label class="radio">
+                <input type="radio" name="scope" value="series_covers" checked>
+                <span>Cover obrázky seriálů <small>(/serialy-online/*.webp)</small></span>
+            </label>
+
+            <label class="radio">
+                <input type="radio" name="scope" value="films_covers">
+                <span>Cover obrázky filmů <small>(/filmy-online/*.webp)</small></span>
+            </label>
+
+            <label class="radio">
+                <input type="radio" name="scope" value="tv_shows_covers">
+                <span>Cover obrázky TV pořadů <small>(/tv-porady/*.webp)</small></span>
+            </label>
+
+            <label class="radio">
+                <input type="radio" name="scope" value="urls" id="scope-urls">
+                <span>Konkrétní URL <small>(jedna na řádek, max ~5000)</small></span>
+            </label>
+
+            <div class="urls-box" id="urls-box">
+                <textarea name="urls" rows="6" placeholder="https://ceskarepublika.wiki/serialy-online/loki.webp&#10;https://ceskarepublika.wiki/filmy-online/matrix.webp"></textarea>
+            </div>
+
+            <label class="radio radio-danger">
+                <input type="radio" name="scope" value="everything" id="scope-everything">
+                <span><strong>Smazat vše</strong> <small>(celá zóna — použít jen ve výjimečných případech)</small></span>
+            </label>
+
+            <div class="confirm-box" id="confirm-box">
+                <label>
+                    Potvrzení: napiš <code>SMAZAT</code>
+                    <input type="text" name="confirm" autocomplete="off" placeholder="SMAZAT">
+                </label>
+            </div>
+
+            <button type="submit" class="btn-purge">Spustit purge</button>
+        </fieldset>
+    </form>
+
+    <section class="help">
+        <h3>Co která volba dělá</h3>
+        <ul>
+            <li><strong>Covers sekce</strong> — vytáhne <em>všechny</em> slugy z příslušné DB tabulky a pošle jejich cover URL-y po dávkách 30 (Free plan limit).</li>
+            <li><strong>Konkrétní URL</strong> — pošle zadané adresy (http://… nebo https://…).</li>
+            <li><strong>Smazat vše</strong> — pošle <code>purge_everything:true</code> — invaliduje kompletně všechno, co CF cachuje, včetně HTML stránek. Free plan má limit ~1000 takových volání za den.</li>
+        </ul>
+    </section>
+</main>
+
+<script>
+(function () {
+    const scopeRadios = document.querySelectorAll('input[name="scope"]');
+    const urlsBox = document.getElementById('urls-box');
+    const confirmBox = document.getElementById('confirm-box');
+    function update() {
+        const v = document.querySelector('input[name="scope"]:checked')?.value;
+        urlsBox.style.display = v === 'urls' ? '' : 'none';
+        confirmBox.style.display = v === 'everything' ? '' : 'none';
+    }
+    scopeRadios.forEach(r => r.addEventListener('change', update));
+    update();
+})();
+</script>
+
+<style>
+.admin-cache { max-width: 860px; margin: 0 auto; padding: 1rem; }
+.admin-cache h2 { font-size: 1.5rem; margin: 1rem 0 0.4rem; }
+.admin-cache .intro { color: #475569; margin: 0 0 1.2rem; }
+.admin-cache .breadcrumb { font-size: 0.85rem; color: #888; margin-bottom: 1.2rem; }
+.admin-cache .breadcrumb a { color: #11457E; text-decoration: none; }
+
+.admin-cache .flash { padding: 0.7rem 1rem; border-radius: 8px; margin-bottom: 1.2rem; font-size: 0.95rem; }
+.admin-cache .flash-ok { background: #ecfdf5; color: #065f46; border: 1px solid #6ee7b7; }
+.admin-cache .flash-error { background: #fef2f2; color: #991b1b; border: 1px solid #fca5a5; }
+
+.admin-cache .warn-box {
+    background: #fef3c7; border: 1px solid #fcd34d; color: #92400e;
+    border-radius: 8px; padding: 0.8rem 1rem; margin-bottom: 1.2rem;
+}
+.admin-cache .zone-info { color: #64748b; font-size: 0.85rem; margin: 0 0 1rem; }
+.admin-cache .zone-info code { background: #f1f5f9; padding: 0.1rem 0.4rem; border-radius: 4px; }
+
+.purge-form fieldset { border: 1px solid #e2e8f0; border-radius: 10px; padding: 1.2rem 1.4rem; }
+.purge-form legend { font-weight: 600; padding: 0 0.4rem; color: #11457E; }
+.purge-form[disabled] fieldset, .purge-form fieldset[disabled] { opacity: 0.55; }
+
+.purge-form .radio { display: flex; align-items: flex-start; gap: 0.6rem; padding: 0.4rem 0; cursor: pointer; line-height: 1.35; }
+.purge-form .radio input { margin-top: 0.25rem; }
+.purge-form .radio small { color: #64748b; font-size: 0.85rem; margin-left: 0.4rem; }
+.purge-form .radio-danger span strong { color: #b91c1c; }
+
+.urls-box { padding: 0.4rem 0 0.8rem 1.9rem; }
+.urls-box textarea { width: 100%; font-family: ui-monospace, monospace; font-size: 0.85rem; padding: 0.5rem; border: 1px solid #cbd5e1; border-radius: 6px; }
+
+.confirm-box { padding: 0.4rem 0 0.8rem 1.9rem; }
+.confirm-box input { font-family: ui-monospace, monospace; padding: 0.4rem 0.5rem; border: 1px solid #cbd5e1; border-radius: 6px; margin-left: 0.4rem; }
+.confirm-box code { background: #fee2e2; color: #991b1b; padding: 0.1rem 0.4rem; border-radius: 4px; }
+
+.btn-purge {
+    margin-top: 1rem; background: #11457E; color: #fff; border: 0;
+    border-radius: 8px; padding: 0.55rem 1.4rem; font-size: 0.95rem; cursor: pointer;
+}
+.btn-purge:hover { background: #0d3a6c; }
+.btn-purge:disabled { background: #94a3b8; cursor: not-allowed; }
+
+.help { margin-top: 2rem; }
+.help h3 { font-size: 1.05rem; color: #11457E; margin: 0 0 0.5rem; }
+.help ul { color: #475569; font-size: 0.9rem; line-height: 1.6; }
+.help li { margin-bottom: 0.3rem; }
+.help code { background: #f1f5f9; padding: 0.1rem 0.4rem; border-radius: 4px; font-size: 0.85em; }
+</style>
+{% endblock %}

--- a/cr-web/templates/admin_cache.html
+++ b/cr-web/templates/admin_cache.html
@@ -41,10 +41,17 @@
     </div>
     {% else %}
     <p class="zone-info">Zóna: <code>{{ zone_id }}</code></p>
+    {% if !enabled %}
+    <div class="warn-box">
+        <strong>Purge akce je vypnutá.</strong>
+        Token je nastavený, ale chybí pojistka <code>ADMIN_CACHE_PURGE_ENABLED=1</code>.
+        Bez ní by zaslaný POST skončil 403 — /admin/ je zatím bez autentizace, proto je na skutečném spouštění ještě jeden zámek navíc.
+    </div>
+    {% endif %}
     {% endif %}
 
     <form method="post" action="/admin/cache/purge" class="purge-form">
-        <fieldset {% if !configured %}disabled{% endif %}>
+        <fieldset {% if !configured || !enabled %}disabled{% endif %}>
             <legend>Rozsah</legend>
 
             <label class="radio">

--- a/cr-web/templates/admin_dashboard.html
+++ b/cr-web/templates/admin_dashboard.html
@@ -38,6 +38,13 @@
             <p class="tile-sub">pg_dump → Cloudflare R2 (30 dní retence)</p>
             <p class="tile-status">{{ backup_tile.message }}</p>
         </a>
+
+        <a href="/admin/cache/" class="tile {{ cache_tile.css_class() }}" title="Promazání Cloudflare CDN cache">
+            <div class="tile-icon">⚡</div>
+            <h3>Cache purge</h3>
+            <p class="tile-sub">Cloudflare CDN (seriály / filmy / TV pořady / URL)</p>
+            <p class="tile-status">{{ cache_tile.message }}</p>
+        </a>
     </div>
 </main>
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+    ports:
+      - "127.0.0.1:5432:5432"
 
   web:
     build: .
@@ -35,6 +37,9 @@ services:
       R2_SECRET_ACCESS_KEY: ${R2_SECRET_ACCESS_KEY:-}
       R2_BUCKET: ${R2_BUCKET:-}
       R2_PUBLIC_BASE_URL: ${R2_PUBLIC_BASE_URL:-}
+      # Cloudflare cache purge — enables /admin/cache/ on-demand CDN invalidation.
+      CF_CACHE_PURGE_TOKEN: ${CF_CACHE_PURGE_TOKEN:-}
+      CF_ZONE_ID: ${CF_ZONE_ID:-}
     volumes:
       # Film covers are written to the host by scripts/auto-import.py
       # (runs outside Docker) — mount the same path read/write so the web
@@ -42,6 +47,10 @@ services:
       # transparent placeholder baked into films_cover().
       # Prod sets CR_DATA_DIR=/opt/cr/data in .env; dev falls back to ./data.
       - ${CR_DATA_DIR:-./data}/movies/covers-webp:/app/data/movies/covers-webp
+      # Series + tv_shows share the same covers-webp directory (series handler
+      # and tv_porad handler both read from series_covers_dir). Auto-import's
+      # ČSFD fallback writes posters here for TV pořady that TMDB doesn't know.
+      - ${CR_DATA_DIR:-./data}/series/covers-webp:/app/data/series/covers-webp
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:


### PR DESCRIPTION
<!-- claude-session: c0717c9a-16b7-4690-af5a-437a07586132 -->

## Summary
- Adds `/admin/cache/` page where an admin can purge Cloudflare CDN cache on demand.
- Four scopes: per-section cover images (series / films / TV pořady, slugs pulled live from DB), arbitrary URL list (textarea), or nuclear `purge_everything` (guarded by typed "SMAZAT" confirmation).
- Requests chunked to CF's free-plan 30-URLs-per-call limit.
- Config via `CF_CACHE_PURGE_TOKEN` + `CF_ZONE_ID` env vars (Option in AppConfig → page degrades to "not configured" when unset).
- Dashboard gets a third tile linking to the page.

## Why
Before this, every cover-image fix had to wait up to 1 hour for CF to expire its cached 34-byte placeholder. Manual fix required logging into the CF dashboard. This closes that loop in-app.

Token is scoped tightly: only `Zone.Cache Purge` on the ceskarepublika.wiki zone — no other permissions. Worst case on token leak is a cache flush, not data loss.

## Test plan
- [x] GET /admin/cache/ renders the form when env vars are set (zone ID shown)
- [x] GET /admin/cache/ shows "not configured" when env vars missing
- [x] POST scope=series_covers → purge succeeds (verified against prod: 839 URL / 28 batches)
- [x] POST scope=urls with 1 URL → purge succeeds (verified against prod)
- [x] Dashboard tile shows up with correct state
- [x] 0 console errors / warnings on both pages
- [x] `purge_everything` refuses to run without the typed SMAZAT confirmation