### PR TITLE
fix(covers): placeholder uses Cache-Control: no-store

### DIFF
--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -613,7 +613,9 @@ pub async fn films_cover(
         }
     }
 
-    // Placeholder: 1x1 transparent WebP
+    // Placeholder: 1x1 transparent WebP. `no-store` — a missing cover is a
+    // transient state (import will fill it shortly); caching the placeholder
+    // pins an empty card in the browser for hours after the real WebP lands.
     static PLACEHOLDER: &[u8] = &[
         0x52, 0x49, 0x46, 0x46, 0x1a, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50, 0x56, 0x50, 0x38,
         0x4c, 0x0d, 0x00, 0x00, 0x00, 0x2f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -623,7 +625,7 @@ pub async fn films_cover(
         StatusCode::OK,
         [
             (header::CONTENT_TYPE, "image/webp"),
-            (header::CACHE_CONTROL, "public, max-age=3600"),
+            (header::CACHE_CONTROL, "no-store"),
         ],
         PLACEHOLDER.to_vec(),
     )

--- a/cr-web/src/handlers/series.rs
+++ b/cr-web/src/handlers/series.rs
@@ -869,7 +869,10 @@ pub async fn series_cover(
         }
     }
 
-    // Placeholder (1x1 WebP)
+    // Placeholder (1x1 WebP). `no-store` is deliberate — browsers that
+    // fetched a placeholder while the real cover was still being imported
+    // would otherwise keep the 1x1 for the full max-age, making the next
+    // pageview still show an empty card even after the WebP lands on disk.
     static PLACEHOLDER: &[u8] = &[
         0x52, 0x49, 0x46, 0x46, 0x1a, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50, 0x56, 0x50, 0x38,
         0x4c, 0x0d, 0x00, 0x00, 0x00, 0x2f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -879,7 +882,7 @@ pub async fn series_cover(
         StatusCode::OK,
         [
             (header::CONTENT_TYPE, "image/webp"),
-            (header::CACHE_CONTROL, "public, max-age=3600"),
+            (header::CACHE_CONTROL, "no-store"),
         ],
         PLACEHOLDER.to_vec(),
     )
@@ -1000,7 +1003,9 @@ pub async fn series_cover_large(
                 .into_response());
         }
     }
-    // Tiny empty WebP placeholder
+    // Tiny empty WebP placeholder. `no-store` — same reasoning as the
+    // series_cover fallback above: don't let a transient miss get pinned
+    // in the browser cache for hours after the real file appears.
     static PLACEHOLDER: &[u8] = &[
         0x52, 0x49, 0x46, 0x46, 0x1a, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50, 0x56, 0x50, 0x38,
         0x4c, 0x0d, 0x00, 0x00, 0x00, 0x2f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -1010,7 +1015,7 @@ pub async fn series_cover_large(
         StatusCode::OK,
         [
             (header::CONTENT_TYPE, "image/webp"),
-            (header::CACHE_CONTROL, "public, max-age=3600"),
+            (header::CACHE_CONTROL, "no-store"),
         ],
         PLACEHOLDER.to_vec(),
     )

--- a/cr-web/src/handlers/tv_porady.rs
+++ b/cr-web/src/handlers/tv_porady.rs
@@ -670,6 +670,9 @@ pub async fn tv_porad_cover(
         }
     }
 
+    // `no-store` — missing TV pořad cover is a transient state; a cached
+    // placeholder would pin an empty card for hours after the real WebP
+    // arrives on disk.
     static PLACEHOLDER: &[u8] = &[
         0x52, 0x49, 0x46, 0x46, 0x1a, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50, 0x56, 0x50, 0x38,
         0x4c, 0x0d, 0x00, 0x00, 0x00, 0x2f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -679,7 +682,7 @@ pub async fn tv_porad_cover(
         StatusCode::OK,
         [
             (header::CONTENT_TYPE, "image/webp"),
-            (header::CACHE_CONTROL, "public, max-age=3600"),
+            (header::CACHE_CONTROL, "no-store"),
         ],
         PLACEHOLDER.to_vec(),
     )
@@ -779,6 +782,8 @@ pub async fn tv_porad_cover_large(
         }
     }
 
+    // Same rationale as the small-cover fallback — don't let a transient
+    // miss on the large variant pin an empty poster in the browser cache.
     static PLACEHOLDER: &[u8] = &[
         0x52, 0x49, 0x46, 0x46, 0x1a, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50, 0x56, 0x50, 0x38,
         0x4c, 0x0d, 0x00, 0x00, 0x00, 0x2f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -788,7 +793,7 @@ pub async fn tv_porad_cover_large(
         StatusCode::OK,
         [
             (header::CONTENT_TYPE, "image/webp"),
-            (header::CACHE_CONTROL, "public, max-age=3600"),
+            (header::CACHE_CONTROL, "no-store"),
         ],
         PLACEHOLDER.to_vec(),
     )


### PR DESCRIPTION
<!-- claude-session: c0717c9a-16b7-4690-af5a-437a07586132 -->

## Summary
- Cover-missing placeholder (1x1 WebP, 34B) was served with `Cache-Control: public, max-age=3600`. On the CDN with Browser Cache TTL override the effective header was 14400s.
- Users who visited `/serialy-online/` while a cover was still being imported got the placeholder pinned in their browser for hours. Even after the real WebP landed on disk (and CF origin started serving it), the user's browser kept showing black posters until the local HTTP cache expired.
- Switches placeholder responses in `series_cover`, `series_cover_large`, `films_cover`, `tv_porad_cover`, `tv_porad_cover_large` to `Cache-Control: no-store`. Real covers still get `max-age=31536000` as before.

## Why now
User reported that 14/24 sci-fi series on the list still showed as black cards even after a full cover download + 2× CF purge. Root cause was client-side HTTP cache holding the old placeholder — measured via Playwright: `naturalWidth == 1` for 14 cards; forcing a cache-bust query param made all 24 render correctly.

## Test plan
- [ ] Deploy to prod
- [ ] Curl `/serialy-online/nonexistent.webp` → expect `Cache-Control: no-store`
- [ ] Curl `/serialy-online/loki.webp` → expect `Cache-Control: public, max-age=31536000`
- [ ] Playwright: visit /serialy-online/sci-fi/ with a fresh browser context, expect all poster `naturalWidth > 1`