### PR TITLE
fix(backup): export rclone env from script, not systemd

### DIFF
--- a/deploy/systemd/cr-backup-db.service
+++ b/deploy/systemd/cr-backup-db.service
@@ -11,16 +11,10 @@ StartLimitIntervalSec=600
 Type=oneshot
 User=root
 WorkingDirectory=/opt/cr
-# /opt/cr/.env drží R2_BACKUP_* credentials (viz ~/Dokumenty/přístupy/cloudflare/r2-cr-db-backups.md)
-# a případné další env proměnné projektu.
+# /opt/cr/.env drží R2_BACKUP_* credentials (viz ~/Dokumenty/přístupy/cloudflare/r2-cr-db-backups.md).
+# Skript si sám exportuje RCLONE_CONFIG_CR_R2_BACKUP_* z R2_BACKUP_* — systemd
+# `Environment="...=${FOO}"` neumí shell expansion, takže to nemůže být tady.
 EnvironmentFile=/opt/cr/.env
-# Mapa env proměnných pro rclone — žádný rclone.conf na disku.
-# "cr_r2_backup" musí matchovat R2_REMOTE v scripts/backup-db.sh.
-Environment=RCLONE_CONFIG_CR_R2_BACKUP_TYPE=s3
-Environment=RCLONE_CONFIG_CR_R2_BACKUP_PROVIDER=Cloudflare
-Environment="RCLONE_CONFIG_CR_R2_BACKUP_ACCESS_KEY_ID=${R2_BACKUP_ACCESS_KEY_ID}"
-Environment="RCLONE_CONFIG_CR_R2_BACKUP_SECRET_ACCESS_KEY=${R2_BACKUP_SECRET_ACCESS_KEY}"
-Environment="RCLONE_CONFIG_CR_R2_BACKUP_ENDPOINT=${R2_BACKUP_ENDPOINT}"
 ExecStart=/bin/bash /opt/cr/scripts/backup-db.sh auto
 # Loguj do journald (default), ne do souboru bez rotace. journalctl -u stačí.
 StandardOutput=journal

--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -62,7 +62,7 @@ PGDUMP_ERR="$TMPDIR_BACKUP/pgdump.err"
 RCLONE_ERR="$TMPDIR_BACKUP/rclone.err"
 
 # rclone remote jméno (přes env var — žádný rclone.conf na disku není potřeba).
-# Viz sekci "rclone env mapping" v deploy/systemd/cr-backup-db.service.
+# Export se děje níž v sekci "rclone env mapping" až po preflightu R2_BACKUP_*.
 R2_REMOTE="cr_r2_backup:cr-backups"
 
 log() { echo "[$(date -u +%H:%M:%S)] $*"; }
@@ -75,6 +75,18 @@ command -v rclone >/dev/null || die "rclone not found (apt install rclone)"
 [ -n "${R2_BACKUP_ACCESS_KEY_ID:-}" ] || die "R2_BACKUP_ACCESS_KEY_ID not set"
 [ -n "${R2_BACKUP_SECRET_ACCESS_KEY:-}" ] || die "R2_BACKUP_SECRET_ACCESS_KEY not set"
 [ -n "${R2_BACKUP_ENDPOINT:-}" ] || die "R2_BACKUP_ENDPOINT not set"
+
+# --- rclone env mapping ---
+# rclone čte "cr_r2_backup" remote z těchto RCLONE_CONFIG_* env var místo
+# /root/.config/rclone/rclone.conf. Nastavujeme je tady ze skriptu (ne ze
+# systemd unit souboru), protože `Environment="...=${FOO}"` v systemd neudělá
+# shell expansion — literál `${R2_BACKUP_ENDPOINT}` skončil v rclone a každý
+# auto běh padl na "was not a valid URI" (viz task #97 follow-up).
+export RCLONE_CONFIG_CR_R2_BACKUP_TYPE=s3
+export RCLONE_CONFIG_CR_R2_BACKUP_PROVIDER=Cloudflare
+export RCLONE_CONFIG_CR_R2_BACKUP_ACCESS_KEY_ID="$R2_BACKUP_ACCESS_KEY_ID"
+export RCLONE_CONFIG_CR_R2_BACKUP_SECRET_ACCESS_KEY="$R2_BACKUP_SECRET_ACCESS_KEY"
+export RCLONE_CONFIG_CR_R2_BACKUP_ENDPOINT="$R2_BACKUP_ENDPOINT"
 
 # --- Helpers ---
 psql_exec() {


### PR DESCRIPTION
<!-- claude-session: d3fa5f77-e620-435a-80b9-efdaa45a1cb1 -->

## Summary

Every auto-triggered DB backup failed on 2026-04-18 with `Custom endpoint \`https://${R2_BACKUP_ENDPOINT}\` was not a valid URI`. Root cause: systemd `Environment=\"FOO=${BAR}\"` does **not** do shell expansion — the literal string `${R2_BACKUP_ENDPOINT}` was being passed to rclone.

- Move the `RCLONE_CONFIG_CR_R2_BACKUP_*` exports out of the systemd unit and into `scripts/backup-db.sh` (right after the R2_BACKUP_* preflight check), where bash expands them properly.
- Service keeps only the `EnvironmentFile=/opt/cr/.env`, which already loads R2_BACKUP_*.
- Manual runs (`scripts/backup-db.sh manual` from an operator shell) keep working exactly as before because the operator's shell has R2_BACKUP_* already, and the script now exports the rclone mapping itself.

## Test plan

Already deployed and verified on production before opening this PR:

- [x] `scp` new `backup-db.sh` + `cr-backup-db.service` to the VPS, `systemctl daemon-reload`
- [x] `systemctl start cr-backup-db.service` → exit 0, journal shows `upload done` + `Done: s3://cr-backups/auto/cr_prod_2026-04-18T0823Z.dump.gz (26679131 bytes)`
- [x] `/admin/backups/` banner now reads "✅ Poslední úspěšná záloha před 0 hodinami — vše v pořádku."
- [x] Row #6: status ok, trigger auto, 25.4 MB, filename `auto/cr_prod_2026-04-18T0823Z.dump.gz`