### PR TITLE
perf(player): DB-hint fast path for sktorrent CDN resolve

### DIFF
--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -25,10 +25,10 @@ struct FilmRow {
     runtime_min: Option<i16>,
     cover_filename: Option<String>,
     sktorrent_video_id: Option<i32>,
-    // SK Torrent CDN assignment rotates, so template no longer reads these —
-    // player calls /api/films/sktorrent-resolve at play time. Kept in SELECT
-    // so the struct matches the legacy DB row shape; remove once we drop the
-    // columns entirely.
+    // `sktorrent_cdn` is used as a first-try hint by `sktorrent_resolve`
+    // (see docs/sktorrent-cdn-stability.md) — ~80 % of films still live on
+    // the node stored here, saving 48 HEAD requests per playback. FilmRow
+    // itself doesn't read it; the resolver queries the column directly.
     #[allow(dead_code)]
     sktorrent_cdn: Option<i16>,
     #[allow(dead_code)]
@@ -760,7 +760,21 @@ pub struct SktorrentResolveResponse {
 // `max_entries=2000, ttl=6h`.
 
 /// GET /api/films/sktorrent-resolve?video_id=99
-/// Fetches current CDN URLs from sktorrent.eu video page.
+///
+/// Resolves the current CDN node that hosts a given SK Torrent video. The
+/// main page `online.sktorrent.eu/video/{id}/` stealth-blocks datacentre
+/// ASNs (HTTP 200, 0 bytes from Hetzner), so we never parse HTML here —
+/// instead we HEAD-probe the edge CDN nodes `online{N}.sktorrent.eu` which
+/// are not blocked.
+///
+/// Strategy (min load → max load):
+///   1. In-memory cache hit (6 h TTL, `AppState.sktorrent_cache`).
+///   2. DB hint: `sktorrent_cdn` stored at import time. Probe that single
+///      node for 720p + 480p (2 HEAD). Per the 2026-04 stability test
+///      (docs/sktorrent-cdn-stability.md) this works for ~80 % of films.
+///   3. Full scan: `online1..online25` × {720p, 480p} = 50 HEAD. Run only
+///      when the hint is missing or stale. On success we self-heal the DB
+///      row so future plays go back to the 2-HEAD fast path.
 pub async fn sktorrent_resolve(
     State(state): State<AppState>,
     axum::extract::Query(params): axum::extract::Query<SktorrentResolveQuery>,
@@ -776,62 +790,39 @@ pub async fn sktorrent_resolve(
         });
     }
 
-    // Fetch sktorrent video page
-    let page_url = format!("https://online.sktorrent.eu/video/{video_id}/");
-    let result = state
-        .http_client
-        .get(&page_url)
-        .header(
-            "User-Agent",
-            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36",
-        )
-        .header("Accept-Encoding", "identity")
-        .timeout(std::time::Duration::from_secs(10))
-        .send()
-        .await;
+    // DB hint — look up the last known CDN node across all three tables
+    // that can carry an SK Torrent video (films / series episodes / tv show
+    // episodes). The same video_id lives in at most one of them.
+    let hint: Option<i16> = sqlx::query_scalar(
+        "SELECT sktorrent_cdn FROM films \
+          WHERE sktorrent_video_id = $1 AND sktorrent_cdn IS NOT NULL \
+         UNION ALL \
+         SELECT sktorrent_cdn FROM series_episodes \
+          WHERE sktorrent_video_id = $1 AND sktorrent_cdn IS NOT NULL \
+         UNION ALL \
+         SELECT sktorrent_cdn FROM tv_episodes \
+          WHERE sktorrent_video_id = $1 AND sktorrent_cdn IS NOT NULL \
+         LIMIT 1",
+    )
+    .bind(video_id)
+    .fetch_optional(&state.db)
+    .await
+    .ok()
+    .flatten();
 
-    let html = match result {
-        Ok(resp) => match resp.text().await {
-            Ok(text) => text,
-            Err(e) => {
-                return axum::Json(SktorrentResolveResponse {
-                    video_id,
-                    sources: vec![],
-                    error: Some(format!("Failed to read response: {e}")),
-                    cached: false,
-                });
-            }
-        },
-        Err(e) => {
-            return axum::Json(SktorrentResolveResponse {
-                video_id,
-                sources: vec![],
-                error: Some(format!("Failed to fetch sktorrent page: {e}")),
-                cached: false,
-            });
-        }
+    let mut sources: Vec<SktorrentSource> = if let Some(cdn) = hint {
+        probe_sktorrent_cdn(&state.http_client, video_id, cdn as i32).await
+    } else {
+        vec![]
     };
 
-    // Extract <source> tags
-    let re = regex::Regex::new(
-        r#"<source\s+src="([^"]+)"\s+type='video/mp4'\s+label='(\d+p)'\s+res='(\d+)'"#,
-    )
-    .expect("const regex literal compiles");
-
-    let mut sources: Vec<SktorrentSource> = re
-        .captures_iter(&html)
-        .filter_map(|cap| {
-            Some(SktorrentSource {
-                url: cap[1].to_string(),
-                quality: cap[2].to_string(),
-                res: cap[3].parse().ok()?,
-            })
-        })
-        .collect();
-
-    // If page didn't return sources (geo-blocked), scan CDN servers with HEAD requests
+    // Fall back to full scan on miss / missing hint. When this finds the
+    // current node, write it back so the next play is cheap again.
     if sources.is_empty() {
         sources = scan_sktorrent_cdns(&state.http_client, video_id).await;
+        if let Some(new_cdn) = infer_cdn_from_sources(&sources) {
+            update_sktorrent_cdn(&state.db, video_id, new_cdn as i16).await;
+        }
     }
 
     if sources.is_empty() {
@@ -856,14 +847,93 @@ pub async fn sktorrent_resolve(
     })
 }
 
-/// Scan sktorrent CDN servers (1..=30) with HEAD request to find working URL.
-/// Used as fallback when page is geo-blocked but CDN URLs work globally.
+/// Probe a single CDN node for all four known quality labels in parallel.
+/// Used as the fast path when we have a DB hint. Some older films live
+/// only under the legacy `HD` or `SD` labels (e.g. video_id 36411) so we
+/// check all four — otherwise those would always fall through to a full
+/// scan despite the hint being correct.
+async fn probe_sktorrent_cdn(
+    client: &reqwest::Client,
+    video_id: i32,
+    cdn: i32,
+) -> Vec<SktorrentSource> {
+    let qualities = [("720p", 720), ("480p", 480), ("HD", 700), ("SD", 360)];
+    let mut tasks = Vec::new();
+    for (q_label, q_res) in qualities.iter() {
+        let url =
+            format!("https://online{cdn}.sktorrent.eu/media/videos//h264/{video_id}_{q_label}.mp4");
+        let client = client.clone();
+        let q_label = q_label.to_string();
+        let q_res = *q_res;
+        let url_clone = url.clone();
+        tasks.push(tokio::spawn(async move {
+            let ok = client
+                .head(&url_clone)
+                .timeout(std::time::Duration::from_secs(3))
+                .send()
+                .await
+                .map(|r| r.status().is_success() || r.status().as_u16() == 206)
+                .unwrap_or(false);
+            (ok, url, q_label, q_res)
+        }));
+    }
+    let mut found = Vec::new();
+    for t in tasks {
+        if let Ok((ok, url, q, res)) = t.await
+            && ok
+        {
+            found.push(SktorrentSource {
+                url,
+                quality: q,
+                res,
+            });
+        }
+    }
+    found
+}
+
+/// Extract the CDN node number from a resolved source URL. URLs look like
+/// `https://online11.sktorrent.eu/media/videos//h264/...` — we just parse
+/// the digits between `online` and the next `.`.
+fn infer_cdn_from_sources(sources: &[SktorrentSource]) -> Option<i32> {
+    let url = sources.first()?.url.as_str();
+    let after = url.strip_prefix("https://online")?;
+    let dot = after.find('.')?;
+    after[..dot].parse::<i32>().ok()
+}
+
+/// Write the freshly-discovered CDN node back to whichever of the three
+/// sktorrent-bearing tables owns this `video_id`. Best-effort — failures
+/// are logged but not surfaced; the playback already has its URL.
+async fn update_sktorrent_cdn(db: &sqlx::PgPool, video_id: i32, cdn: i16) {
+    for sql in [
+        "UPDATE films SET sktorrent_cdn = $1 WHERE sktorrent_video_id = $2",
+        "UPDATE series_episodes SET sktorrent_cdn = $1 WHERE sktorrent_video_id = $2",
+        "UPDATE tv_episodes SET sktorrent_cdn = $1 WHERE sktorrent_video_id = $2",
+    ] {
+        if let Err(e) = sqlx::query(sql).bind(cdn).bind(video_id).execute(db).await {
+            tracing::warn!("sktorrent_cdn self-heal failed ({sql}): {e}");
+        }
+    }
+}
+
+/// Scan all SK Torrent CDN edge nodes in parallel batches, returning every
+/// URL that answers HEAD 2xx. Called when the DB hint is missing or stale.
+///
+/// Range is scoped to `online1..online25` — the 26..30 slots have never
+/// appeared in `films.sktorrent_cdn` across 13 k records (2026-04 snapshot)
+/// and returned no hits in live probes. All four quality labels are kept
+/// because a small share of older films (e.g. video_id 36411) only exist
+/// under the legacy `HD` label.
+///
+/// That's 25 × 4 = 100 HEAD per miss, down from the earlier 30 × 4 = 120.
 async fn scan_sktorrent_cdns(client: &reqwest::Client, video_id: i32) -> Vec<SktorrentSource> {
     let qualities = [("720p", 720), ("480p", 480), ("HD", 700), ("SD", 360)];
     let mut found: Vec<SktorrentSource> = vec![];
 
-    // Scan CDNs in parallel batches of 10
-    let cdns: Vec<i32> = (1..=30).collect();
+    // Scan CDNs in parallel batches of 10 — gives us early exit when
+    // we find both qualities without needing to probe the entire range.
+    let cdns: Vec<i32> = (1..=25).collect();
     for batch in cdns.chunks(10) {
         let mut tasks = Vec::new();
         for &cdn in batch {

--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -27,8 +27,10 @@ struct FilmRow {
     sktorrent_video_id: Option<i32>,
     // `sktorrent_cdn` is used as a first-try hint by `sktorrent_resolve`
     // (see docs/sktorrent-cdn-stability.md) — ~80 % of films still live on
-    // the node stored here, saving 48 HEAD requests per playback. FilmRow
-    // itself doesn't read it; the resolver queries the column directly.
+    // the node stored here, so the fast path usually resolves after probing
+    // 4 labels (720p/480p/HD/SD) instead of falling back to scanning up to
+    // 25 nodes × 4 labels = 100 HEAD requests. FilmRow itself doesn't read
+    // it; the resolver queries the column directly.
     #[allow(dead_code)]
     sktorrent_cdn: Option<i16>,
     #[allow(dead_code)]
@@ -770,11 +772,12 @@ pub struct SktorrentResolveResponse {
 /// Strategy (min load → max load):
 ///   1. In-memory cache hit (6 h TTL, `AppState.sktorrent_cache`).
 ///   2. DB hint: `sktorrent_cdn` stored at import time. Probe that single
-///      node for 720p + 480p (2 HEAD). Per the 2026-04 stability test
-///      (docs/sktorrent-cdn-stability.md) this works for ~80 % of films.
-///   3. Full scan: `online1..online25` × {720p, 480p} = 50 HEAD. Run only
-///      when the hint is missing or stale. On success we self-heal the DB
-///      row so future plays go back to the 2-HEAD fast path.
+///      node for {720p, 480p, HD, SD} (4 HEAD). Per the 2026-04 stability
+///      test (docs/sktorrent-cdn-stability.md) this works for ~80 % of
+///      films.
+///   3. Full scan: `online1..online25` × {720p, 480p, HD, SD} = 100 HEAD.
+///      Run only when the hint is missing or stale. On success we self-heal
+///      the DB row so future plays go back to the 4-HEAD fast path.
 pub async fn sktorrent_resolve(
     State(state): State<AppState>,
     axum::extract::Query(params): axum::extract::Query<SktorrentResolveQuery>,
@@ -792,23 +795,36 @@ pub async fn sktorrent_resolve(
 
     // DB hint — look up the last known CDN node across all three tables
     // that can carry an SK Torrent video (films / series episodes / tv show
-    // episodes). The same video_id lives in at most one of them.
-    let hint: Option<i16> = sqlx::query_scalar(
-        "SELECT sktorrent_cdn FROM films \
-          WHERE sktorrent_video_id = $1 AND sktorrent_cdn IS NOT NULL \
-         UNION ALL \
-         SELECT sktorrent_cdn FROM series_episodes \
-          WHERE sktorrent_video_id = $1 AND sktorrent_cdn IS NOT NULL \
-         UNION ALL \
-         SELECT sktorrent_cdn FROM tv_episodes \
-          WHERE sktorrent_video_id = $1 AND sktorrent_cdn IS NOT NULL \
+    // episodes). If the same video_id ever appeared in more than one table,
+    // the `priority` column fixes a deterministic order: films → series →
+    // tv shows.
+    let hint: Option<i16> = match sqlx::query_scalar(
+        "SELECT sktorrent_cdn FROM ( \
+             SELECT sktorrent_cdn, 1 AS priority FROM films \
+              WHERE sktorrent_video_id = $1 AND sktorrent_cdn IS NOT NULL \
+             UNION ALL \
+             SELECT sktorrent_cdn, 2 AS priority FROM series_episodes \
+              WHERE sktorrent_video_id = $1 AND sktorrent_cdn IS NOT NULL \
+             UNION ALL \
+             SELECT sktorrent_cdn, 3 AS priority FROM tv_episodes \
+              WHERE sktorrent_video_id = $1 AND sktorrent_cdn IS NOT NULL \
+         ) AS cdn_hints \
+         ORDER BY priority \
          LIMIT 1",
     )
     .bind(video_id)
     .fetch_optional(&state.db)
     .await
-    .ok()
-    .flatten();
+    {
+        Ok(v) => v,
+        Err(e) => {
+            // Not fatal — we'll just fall through to the full scan. Logged
+            // so operational issues (connection drops, schema drift) surface
+            // in journalctl instead of silently inflating load.
+            tracing::warn!("sktorrent_resolve hint lookup failed for video_id={video_id}: {e}");
+            None
+        }
+    };
 
     let mut sources: Vec<SktorrentSource> = if let Some(cdn) = hint {
         probe_sktorrent_cdn(&state.http_client, video_id, cdn as i32).await
@@ -931,8 +947,11 @@ async fn scan_sktorrent_cdns(client: &reqwest::Client, video_id: i32) -> Vec<Skt
     let qualities = [("720p", 720), ("480p", 480), ("HD", 700), ("SD", 360)];
     let mut found: Vec<SktorrentSource> = vec![];
 
-    // Scan CDNs in parallel batches of 10 — gives us early exit when
-    // we find both qualities without needing to probe the entire range.
+    // Scan CDNs in parallel batches of 10. We break as soon as any batch
+    // returns at least one hit: each film lives on exactly one node, so
+    // further batches can only return 404s. This saves the later batches
+    // for single-label (e.g. HD-only) films too — the earlier `>= 2`
+    // threshold would never trip on those and scan all 25 nodes.
     let cdns: Vec<i32> = (1..=25).collect();
     for batch in cdns.chunks(10) {
         let mut tasks = Vec::new();
@@ -978,10 +997,9 @@ async fn scan_sktorrent_cdns(client: &reqwest::Client, video_id: i32) -> Vec<Skt
                     found.push(src);
                 }
             }
-            // If we found both qualities, we're done
-            if found.len() >= 2 {
-                break;
-            }
+            // Any hit identifies the node — no film is served from two
+            // nodes at once — so further batches are wasted HEADs.
+            break;
         }
     }
 

--- a/docs/sktorrent-cdn-stability.md
+++ b/docs/sktorrent-cdn-stability.md
@@ -1,0 +1,99 @@
+# SK Torrent CDN edge node stability test
+
+Empirical check of whether `films.sktorrent_cdn` (historical import-time CDN
+assignment) still matches where SK Torrent currently hosts each film. If
+stable enough, we can add a DB-cached single-node hint before the full scan
+in `scan_sktorrent_cdns` (`cr-web/src/handlers/films.rs`).
+
+## Background
+
+- Playback endpoint `/api/films/sktorrent-resolve` brute-forces 30 nodes × 4
+  qualities = 120 HEAD requests per cache miss (in-memory cache has 6h TTL).
+- URL pattern is deterministic on the file side:
+  `https://online{N}.sktorrent.eu/media/videos//h264/{video_id}_{quality}.mp4`
+- Historical data in `films.sktorrent_cdn` spans 13 162 films across 25 nodes
+  (`online1` .. `online25`). The code still scans up to `online30` — the extra
+  5 slots are currently empty but cheap insurance against future expansion.
+- Deterministic hash-sharding hypothesis was tested against the 13 162 pairs
+  (`MOD(vid, 24)+1`, `MOD(vid, 25)+1`, `MOD(vid/100, 25)+1`, etc.). Best hit
+  rate 4.3 % — indistinguishable from random (1/25 = 4 %). **No formula
+  recoverable from `video_id` alone.**
+- The labels `HD` and `SD` are rare but not unused. The 20-film baseline
+  missed them, but re-checking video_id 36411 ("Ukradená bitva") during the
+  first prod verification showed it lives **only** under `HD` on its node.
+  Dropping those labels would silently break playback for that minority —
+  so the fallback scan keeps all four (25 × 4 = 100 HEAD).
+
+## Strategy (shipped 2026-04-18)
+
+If the CDN assignment SK Torrent made at upload time is stable (film stays
+on the same node for years), we can optimise playback resolve to:
+
+1. First try DB-cached `sktorrent_cdn` via `probe_sktorrent_cdn`:
+   4 HEAD requests on that node (720p / 480p / HD / SD).
+2. On success — cache, return.
+3. On miss — fall back to full scan (25 × 4 = 100 HEAD), then write the
+   discovered node back to `films|series_episodes|tv_episodes.sktorrent_cdn`
+   so the next play goes through the 4-HEAD fast path (self-healing).
+
+Expected average load given day 1 results (80 % hit / 20 % miss):
+`0.8 × 4 + 0.2 × (4 + 100) ≈ 24 HEAD per cache miss` — down from 120. −80 %.
+
+Plus the 6-hour in-memory `sktorrent_cache` already amortises repeat plays.
+
+## Day 1 — 2026-04-18 (baseline)
+
+20 random films from `films WHERE sktorrent_cdn IS NOT NULL`. For each,
+`curl -I` (720p + 480p) against the DB-stored CDN node only. No full scan
+issued — we're testing whether the stored hint is enough.
+
+| video_id | db_cdn | 720p | 480p | status |
+|---------:|-------:|:-----|:-----|:-------|
+|    52101 |     23 | 200  | 200  | both_ok |
+|     5409 |      5 | 200  | 200  | both_ok |
+|    33240 |      2 | 200  | 200  | both_ok |
+|    36411 |     11 | 404  | 404  | MOVED |
+|     2491 |     10 | 404  | 200  | 480p_only |
+|    12891 |      7 | 200  | 200  | both_ok |
+|    27643 |      9 | 200  | 200  | both_ok |
+|     5757 |      3 | 200  | 200  | both_ok |
+|     3582 |     21 | 404  | 404  | MOVED |
+|    46755 |     20 | 200  | 200  | both_ok |
+|    33833 |     13 | 200  | 200  | both_ok |
+|     3495 |     21 | 404  | 200  | 480p_only |
+|     2562 |      7 | 404  | 200  | 480p_only |
+|     3841 |     21 | 200  | 200  | both_ok |
+|    15421 |      3 | 404  | 404  | MOVED |
+|    31754 |      9 | 404  | 404  | MOVED |
+|    36858 |     19 | 404  | 200  | 480p_only |
+|     6412 |      2 | 200  | 200  | both_ok |
+|    18921 |     10 | 404  | 404  | MOVED |
+|    20484 |      9 | 200  | 200  | both_ok |
+
+**Summary:**
+- 12 / 20 (60 %) — both qualities still on DB cdn
+- 4 / 20 (20 %) — only 480p survived (720p dropped by SK Torrent)
+- 4 / 20 (20 %) — MOVED: neither quality present; film is now on a different node
+
+## Day 2 — 2026-04-19 (re-test, open)
+
+_Same 20 video_ids, same check. Do NOT drop this task — day 2 data decides
+whether the strategy stays as-is or needs re-tuning._
+
+Goal: distinguish "CDN assignment is long-term stable, the 4 MOVEDs are a
+permanent shuffle" from "CDN rotates daily, every film migrates
+unpredictably".
+
+If day 2 shows the 12 previously-stable films are still stable and only new
+shuffles appear, the shipped strategy is correct: self-heal on miss, no
+further change.
+
+If day 2 shows many new shuffles among previously-stable films, the DB hint
+is weaker than expected and we should consider shortening `sktorrent_cache`
+TTL or writing to the DB more aggressively.
+
+## Decision log
+
+- **2026-04-18**: Shipped strategy "DB hint probe (4 HEAD) → full scan
+  fallback (100 HEAD) → self-heal DB". Known-stable 80 % of films resolve
+  in 4 HEAD. See PR for the perf(player) commit.


### PR DESCRIPTION
<!-- claude-session: d3fa5f77-e620-435a-80b9-efdaa45a1cb1 -->

## Summary
- `/api/films/sktorrent-resolve` now uses a DB hint (stored `sktorrent_cdn`) as the fast path instead of always brute-forcing 30 × 4 = 120 HEAD requests per cache miss.
- Removed the always-empty detail-page fetch against `online.sktorrent.eu/video/{id}/` (Hetzner is stealth-blocked: HTTP 200, 0 bytes) — that request always fell through to the scan anyway.
- Full-scan fallback scoped to `online1..online25` × 4 qualities = 100 HEAD (was 30 × 4 = 120). On success, the new node is self-healed back to `films|series_episodes|tv_episodes.sktorrent_cdn` so the next play goes through the fast path.
- Added `docs/sktorrent-cdn-stability.md` with the baseline measurement (20 films, 80 % DB-hint hit rate, day 2 re-test scheduled).

## Expected impact
Under the measured 80/20 hit/miss split the average cache miss drops from 120 HEAD to ~24 HEAD (−80 %). Cache hits (6 h TTL, unchanged) are still 0 HEAD.

## Test plan
- [x] `cargo check -p cr-web` clean
- [x] `cargo clippy -p cr-web -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p cr-web --lib` (no new tests; existing build green)
- [x] Cross-compiled `aarch64-unknown-linux-musl` + deployed to prod, `/health` returns 200
- [x] API: video 59588 (American High School) — DB hint `cdn=11` matches, returned `online11/59588_480p.mp4` on first call, `cached:true` on second
- [x] API: video 36411 (Ukradená bitva) — DB hint `cdn=11`, HD-only file, returned `online11/36411_HD.mp4` (confirms HD label coverage in fast path)
- [x] Playwright interactive test on https://ceskarepublika.wiki/filmy-online/american-high-school/: video element exists, `readyState=4`, 82 s buffered from `online11.sktorrent.eu`, 0 console errors/warnings, Zdroj/480p buttons click without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)