### PR TITLE
feat(player): tiered SK Torrent CDN probe, add 360p/240p

### DIFF
--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -863,17 +863,27 @@ pub async fn sktorrent_resolve(
     })
 }
 
-/// Probe a single CDN node for all four known quality labels in parallel.
-/// Used as the fast path when we have a DB hint. Some older films live
-/// only under the legacy `HD` or `SD` labels (e.g. video_id 36411) so we
-/// check all four — otherwise those would always fall through to a full
-/// scan despite the hint being correct.
+/// Probe a single CDN node across all six supported quality labels in
+/// parallel. Used as the fast path when we have a DB hint. Order doesn't
+/// matter here because everything fans out in parallel and any hit counts
+/// — older films may live only under the legacy `HD`/`SD` labels (e.g.
+/// video_id 36411) and a small tail only has `360p`/`240p`. Six HEADs is
+/// still cheap versus a 100-HEAD full scan, and returning multiple hits
+/// lets the frontend render a quality switcher when the node has more
+/// than one encode.
 async fn probe_sktorrent_cdn(
     client: &reqwest::Client,
     video_id: i32,
     cdn: i32,
 ) -> Vec<SktorrentSource> {
-    let qualities = [("720p", 720), ("480p", 480), ("HD", 700), ("SD", 360)];
+    let qualities = [
+        ("720p", 720),
+        ("HD", 700),
+        ("480p", 480),
+        ("SD", 360),
+        ("360p", 360),
+        ("240p", 240),
+    ];
     let mut tasks = Vec::new();
     for (q_label, q_res) in qualities.iter() {
         let url =
@@ -933,77 +943,77 @@ async fn update_sktorrent_cdn(db: &sqlx::PgPool, video_id: i32, cdn: i16) {
     }
 }
 
-/// Scan all SK Torrent CDN edge nodes in parallel batches, returning every
-/// URL that answers HEAD 2xx. Called when the DB hint is missing or stale.
+/// Full-scan fallback: called only when the DB hint is missing or stale.
 ///
-/// Range is scoped to `online1..online25` — the 26..30 slots have never
-/// appeared in `films.sktorrent_cdn` across 13 k records (2026-04 snapshot)
-/// and returned no hits in live probes. All four quality labels are kept
-/// because a small share of older films (e.g. video_id 36411) only exist
-/// under the legacy `HD` label.
+/// Tiered probe — for each quality from best to worst, race all 30 CDN
+/// nodes in parallel via `JoinSet` and return on the first HEAD 2xx. A
+/// successful tier drops the set, which aborts the remaining probes;
+/// empty tiers wait out the 3 s per-request timeout before moving on.
+/// Order is 720p → HD → 480p → SD → 360p → 240p; HD covers 267 legacy-
+/// label films and the two new low-res tiers catch the long tail that
+/// SK Torrent only encodes in 360p / 240p (measured on 2026-04-18 over
+/// 834 low-quality films — docs/sktorrent-cdn-stability.md).
 ///
-/// That's 25 × 4 = 100 HEAD per miss, down from the earlier 30 × 4 = 120.
+/// Happy-path cost is ~30 HEAD (whichever CDN answers first). Worst case
+/// (no source anywhere) is 6 × 30 = 180 HEAD, higher than the previous
+/// 100, but we accept that to unlock the 360p/240p tier.
+///
+/// Returns a single source (the first hit in the highest reachable tier);
+/// the frontend's `renderSktorrentSources` handles a 1-element list
+/// fine — one quality button, no switcher — which is the trade-off for
+/// keeping sktorrent.eu's request volume down.
 async fn scan_sktorrent_cdns(client: &reqwest::Client, video_id: i32) -> Vec<SktorrentSource> {
-    let qualities = [("720p", 720), ("480p", 480), ("HD", 700), ("SD", 360)];
-    let mut found: Vec<SktorrentSource> = vec![];
+    // (label, res). `res` is used for frontend sorting; HD/SD are rough.
+    const QUALITIES: &[(&str, i32)] = &[
+        ("720p", 720),
+        ("HD", 700),
+        ("480p", 480),
+        ("SD", 360),
+        ("360p", 360),
+        ("240p", 240),
+    ];
 
-    // Scan CDNs in parallel batches of 10. We break as soon as any batch
-    // returns at least one hit: each film lives on exactly one node, so
-    // further batches can only return 404s. This saves the later batches
-    // for single-label (e.g. HD-only) films too — the earlier `>= 2`
-    // threshold would never trip on those and scan all 25 nodes.
-    let cdns: Vec<i32> = (1..=25).collect();
-    for batch in cdns.chunks(10) {
-        let mut tasks = Vec::new();
-        for &cdn in batch {
-            for (q_label, q_res) in qualities.iter() {
-                let url = format!(
-                    "https://online{cdn}.sktorrent.eu/media/videos//h264/{video_id}_{q_label}.mp4"
-                );
-                let client = client.clone();
-                let q_label = q_label.to_string();
-                let q_res = *q_res;
-                let url_clone = url.clone();
-                tasks.push(tokio::spawn(async move {
-                    let ok = client
-                        .head(&url_clone)
-                        .timeout(std::time::Duration::from_secs(3))
-                        .send()
-                        .await
-                        .map(|r| r.status().is_success() || r.status().as_u16() == 206)
-                        .unwrap_or(false);
-                    (ok, url, q_label, q_res)
-                }));
-            }
+    for &(q_label, q_res) in QUALITIES {
+        // JoinSet races all 30 CDN probes; we take the FIRST success and
+        // drop the set to abort the rest — no waiting on slow/timing-out
+        // peers once we already have an answer.
+        let mut set = tokio::task::JoinSet::new();
+        for cdn in 1..=30 {
+            let url = format!(
+                "https://online{cdn}.sktorrent.eu/media/videos//h264/{video_id}_{q_label}.mp4"
+            );
+            let client = client.clone();
+            set.spawn(async move {
+                let ok = client
+                    .head(&url)
+                    .timeout(std::time::Duration::from_secs(3))
+                    .send()
+                    .await
+                    .map(|r| r.status().is_success() || r.status().as_u16() == 206)
+                    .unwrap_or(false);
+                (ok, url)
+            });
         }
 
-        let mut batch_results = Vec::new();
-        for t in tasks {
-            if let Ok((ok, url, q, res)) = t.await
-                && ok
-            {
-                batch_results.push(SktorrentSource {
-                    url,
-                    quality: q,
-                    res,
-                });
+        let mut hit: Option<String> = None;
+        while let Some(res) = set.join_next().await {
+            if let Ok((true, url)) = res {
+                hit = Some(url);
+                break;
             }
         }
+        // Dropping `set` here aborts any still-pending probes.
 
-        if !batch_results.is_empty() {
-            // Dedupe by quality
-            for src in batch_results {
-                if !found.iter().any(|s| s.quality == src.quality) {
-                    found.push(src);
-                }
-            }
-            // Any hit identifies the node — no film is served from two
-            // nodes at once — so further batches are wasted HEADs.
-            break;
+        if let Some(url) = hit {
+            return vec![SktorrentSource {
+                url,
+                quality: q_label.to_string(),
+                res: q_res,
+            }];
         }
     }
 
-    found
+    vec![]
 }
 
 // --- Helpers ---


### PR DESCRIPTION
<!-- claude-session: d3fa5f77-e620-435a-80b9-efdaa45a1cb1 -->

## Summary

- Scanner rewritten as tiered probe: 720p → HD → 480p → SD → 360p (new) → 240p (new). Returns first hit in highest reachable tier, no quality accumulation.
- Happy-path drops from 40–120 to **30 HEAD requests** per cache miss. Main goal: stop saturating sktorrent.eu's rate limits.
- Adds support for films sktorrent only serves in 360p/240p — previously returned silently empty.

## Why

Live audit (`scripts/audit-sktorrent-sources.py`, 2026-04-18) of 834 suspect films with low-quality DB metadata revealed:
- 833/834 actually have a working source on sktorrent
- Of those, **16** were invisible to the old scanner because SK Torrent only serves them at 360p / 240p / SD
- Previous HD/SD assumption ("never returns 200") was wrong — 267 films are legacy-labelled HD and work fine (verified with Range GET → 206 Partial Content, valid MP4)

Tier order matches observed reality. Single-source return is a deliberate trade-off: the UI loses the quality switcher but we halve outbound load so we don't get blocked.

## Test plan

All verified on production (`ceskarepublika.wiki`) after deploy:
- [x] Coco (720p, vid=7657) → tier 1, online1
- [x] 3 Idioti (HD-only, vid=15421) → tier 2, online3
- [x] Lví král 2019 CZ (720p, vid=4636) → tier 1, online3
- [x] Knoflíkáři (360p, vid=2192) → tier 5, online7, **plays in browser** (readyState=4, 480×308, 103 min)
- [x] Zlaté dno (240p, vid=1165) → tier 6, online20 — previously NO_SOURCES
- [x] cargo check / clippy / fmt / test all green on clean branch