### PR TITLE
feat(films,series): SEO H1, pretty_plural, series filters + mobile

### DIFF
--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -233,9 +233,7 @@ impl FilmsListTemplate {
         self.current_genre.is_some() || !self.selected_genre_slugs.is_empty()
     }
     fn is_current_genre(&self, g: &GenreRow) -> bool {
-        self.current_genre
-            .as_ref()
-            .is_some_and(|cg| cg.id == g.id)
+        self.current_genre.as_ref().is_some_and(|cg| cg.id == g.id)
     }
     fn film_genres(&self, film_id: &i32) -> &[FilmGenreNameRow] {
         static EMPTY: Vec<FilmGenreNameRow> = Vec::new();
@@ -474,7 +472,7 @@ pub async fn films_detail(
             .get(axum::http::header::REFERER)
             .and_then(|h| h.to_str().ok())
             .map(|r| {
-                if let Some(path) = r.splitn(2, "://").nth(1).and_then(|s| s.split_once('/')) {
+                if let Some(path) = r.split_once("://").and_then(|(_, s)| s.split_once('/')) {
                     let p = format!("/{}", path.1);
                     let clean = p.split('?').next().unwrap_or(&p);
                     clean == "/filmy-online/" || clean == "/filmy-online"
@@ -1142,7 +1140,6 @@ async fn scan_sktorrent_cdns(client: &reqwest::Client, video_id: i32) -> Vec<Skt
 
     vec![]
 }
-
 
 // --- Helpers ---
 

--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -172,28 +172,25 @@ impl FilmsQuery {
         self.razeni.as_deref().unwrap_or("pridano")
     }
 
+    fn parse_genre_slugs(input: Option<&String>) -> Vec<String> {
+        // Dedup to keep AND-mode `HAVING COUNT(DISTINCT g.slug) = slugs.len()` correct.
+        let mut slugs: Vec<String> = Vec::new();
+        if let Some(input) = input {
+            for s in input.split(',').map(|g| g.trim()).filter(|g| !g.is_empty()) {
+                if !slugs.iter().any(|x| x == s) {
+                    slugs.push(s.to_string());
+                }
+            }
+        }
+        slugs
+    }
+
     fn include_genres(&self) -> Vec<String> {
-        self.zanry
-            .as_ref()
-            .map(|s| {
-                s.split(',')
-                    .map(|g| g.trim().to_string())
-                    .filter(|g| !g.is_empty())
-                    .collect()
-            })
-            .unwrap_or_default()
+        Self::parse_genre_slugs(self.zanry.as_ref())
     }
 
     fn exclude_genres(&self) -> Vec<String> {
-        self.bez
-            .as_ref()
-            .map(|s| {
-                s.split(',')
-                    .map(|g| g.trim().to_string())
-                    .filter(|g| !g.is_empty())
-                    .collect()
-            })
-            .unwrap_or_default()
+        Self::parse_genre_slugs(self.bez.as_ref())
     }
 
     fn year_filter(&self) -> Option<i16> {
@@ -235,6 +232,9 @@ impl FilmsListTemplate {
     fn is_current_genre(&self, g: &GenreRow) -> bool {
         self.current_genre.as_ref().is_some_and(|cg| cg.id == g.id)
     }
+    // NOTE: Askama auto-refs arguments in template method calls — `{{ self.film_genres(f.id) }}`
+    // generates a call with `&f.id`. Keep the signature as `&i32` to match; Copilot's
+    // "accept i32 by value" suggestion would break Askama codegen here.
     fn film_genres(&self, film_id: &i32) -> &[FilmGenreNameRow] {
         static EMPTY: Vec<FilmGenreNameRow> = Vec::new();
         self.film_genres_map

--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -51,6 +51,39 @@ struct GenreRow {
     name_cs: String,
 }
 
+impl GenreRow {
+    /// Pretty Czech plural title for headings and SEO (e.g. "Horory", "Dramata", "Televizní filmy").
+    fn pretty_plural(&self) -> String {
+        let known: &str = match self.slug.as_str() {
+            "akcni" => "Akční filmy",
+            "animovany" => "Animované filmy",
+            "dobrodruzny" => "Dobrodružné filmy",
+            "dokumentarni" => "Dokumentární filmy",
+            "drama" => "Dramata",
+            "fantasy" => "Fantasy filmy",
+            "historicky" => "Historické filmy",
+            "horor" => "Horory",
+            "hudebni" => "Hudební filmy",
+            "komedie" => "Komedie",
+            "krimi" => "Kriminální filmy",
+            "mysteriozni" => "Mysteriózní filmy",
+            "rodinny" => "Rodinné filmy",
+            "romanticky" => "Romantické filmy",
+            "sci-fi" => "Sci-Fi filmy",
+            "thriller" => "Thrillery",
+            "tv-film" => "Televizní filmy",
+            "valecny" => "Válečné filmy",
+            "western" => "Westerny",
+            _ => "",
+        };
+        if known.is_empty() {
+            format!("{} filmy", self.name_cs)
+        } else {
+            known.to_string()
+        }
+    }
+}
+
 #[derive(sqlx::FromRow)]
 struct FilmGenreNameRow {
     name_cs: String,
@@ -97,13 +130,9 @@ impl FilmsQuery {
     }
 
     fn audio_filter(&self) -> Option<&'static str> {
-        // Default: no jazyk param → filter to dubbed only
-        let val = self.jazyk.as_deref().map(|s| s.trim()).unwrap_or("dub");
-        if val == "vse" {
+        let val = self.jazyk.as_deref().map(|s| s.trim()).unwrap_or("");
+        if val.is_empty() || val == "vse" {
             return None;
-        }
-        if val.is_empty() {
-            return Some("f.has_dub = true");
         }
         let parts: Vec<&str> = val.split(',').map(|s| s.trim()).collect();
         let has_dub = parts.contains(&"dub") || parts.contains(&"cz") || parts.contains(&"sk");
@@ -188,6 +217,33 @@ struct FilmsListTemplate {
     sort_key: String,
     query_string: String,
     search_query: Option<String>,
+    open_filter: bool,
+    /// Genre slugs the user is filtering by right now (from `?zanry=` on main page).
+    /// Empty on a category sub-page — that info is already in `current_genre`.
+    selected_genre_slugs: Vec<String>,
+    /// Genres per film, keyed by film id — rendered as chips in desktop list view.
+    film_genres_map: std::collections::HashMap<i32, Vec<FilmGenreNameRow>>,
+}
+
+impl FilmsListTemplate {
+    fn is_selected(&self, slug: &str) -> bool {
+        self.selected_genre_slugs.iter().any(|s| s == slug)
+    }
+    fn is_multi_filter_mode(&self) -> bool {
+        self.current_genre.is_some() || !self.selected_genre_slugs.is_empty()
+    }
+    fn is_current_genre(&self, g: &GenreRow) -> bool {
+        self.current_genre
+            .as_ref()
+            .is_some_and(|cg| cg.id == g.id)
+    }
+    fn film_genres(&self, film_id: &i32) -> &[FilmGenreNameRow] {
+        static EMPTY: Vec<FilmGenreNameRow> = Vec::new();
+        self.film_genres_map
+            .get(film_id)
+            .map(|v| v.as_slice())
+            .unwrap_or(EMPTY.as_slice())
+    }
 }
 
 #[derive(Template)]
@@ -360,6 +416,19 @@ pub async fn films_list(
         }
     });
 
+    let selected_genre_slugs: Vec<String> = params
+        .zanry
+        .as_deref()
+        .map(|s| {
+            s.split(',')
+                .map(|t| t.trim().to_string())
+                .filter(|t| !t.is_empty())
+                .collect()
+        })
+        .unwrap_or_default();
+    let open_filter = !selected_genre_slugs.is_empty();
+    let film_genres_map = load_film_genres_map(&state.db, &films).await?;
+
     let tmpl = FilmsListTemplate {
         img: state.image_base_url.clone(),
         films,
@@ -371,6 +440,9 @@ pub async fn films_list(
         sort_key: params.sort_key().to_string(),
         query_string,
         search_query,
+        open_filter,
+        selected_genre_slugs,
+        film_genres_map,
     };
     Ok(Html(tmpl.render()?).into_response())
 }
@@ -380,6 +452,7 @@ pub async fn films_detail(
     State(state): State<AppState>,
     Path(slug): Path<String>,
     axum::extract::Query(params): axum::extract::Query<FilmsQuery>,
+    headers: axum::http::HeaderMap,
 ) -> WebResult<Response> {
     // WebP cover request: /filmy-online/some-film.webp (small) or -large.webp
     if slug.ends_with("-large.webp") {
@@ -397,7 +470,20 @@ pub async fn films_detail(
             .await?;
 
     if let Some(genre) = genre {
-        return films_by_genre(state, genre, params).await;
+        let from_films_home = headers
+            .get(axum::http::header::REFERER)
+            .and_then(|h| h.to_str().ok())
+            .map(|r| {
+                if let Some(path) = r.splitn(2, "://").nth(1).and_then(|s| s.split_once('/')) {
+                    let p = format!("/{}", path.1);
+                    let clean = p.split('?').next().unwrap_or(&p);
+                    clean == "/filmy-online/" || clean == "/filmy-online"
+                } else {
+                    false
+                }
+            })
+            .unwrap_or(false);
+        return films_by_genre(state, genre, params, from_films_home).await;
     }
 
     // Otherwise: film detail
@@ -445,16 +531,49 @@ async fn films_by_genre(
     state: AppState,
     genre: GenreRow,
     params: FilmsQuery,
+    open_filter: bool,
 ) -> WebResult<Response> {
     let page = params.page();
     let offset = (page - 1) * FILMS_PER_PAGE;
     let order = params.order_clause();
     let exclude = params.exclude_genres();
     let year_f = params.year_filter();
+    let zanry_extras = params.include_genres();
 
-    // Build WHERE clauses for exclude genres and year
-    let mut where_parts: Vec<String> = vec!["fg.genre_id = $1".to_string()];
-    let mut bind_idx = 2;
+    // Merge path genre with extras from ?zanry= into one include list
+    let mut include_slugs: Vec<String> = vec![genre.slug.clone()];
+    for s in zanry_extras.iter() {
+        if !include_slugs.contains(s) {
+            include_slugs.push(s.clone());
+        }
+    }
+    let multi_include = include_slugs.len() > 1;
+
+    // Build WHERE clauses
+    let mut where_parts: Vec<String> = vec![];
+    let mut bind_idx = 1;
+    if !multi_include {
+        where_parts.push(format!(
+            "f.id IN (SELECT fg.film_id FROM film_genres fg WHERE fg.genre_id = ${bind_idx})"
+        ));
+        bind_idx += 1;
+    } else if params.genre_mode_and() {
+        where_parts.push(format!(
+            "f.id IN (SELECT fg.film_id FROM film_genres fg \
+             JOIN genres g ON g.id = fg.genre_id \
+             WHERE g.slug = ANY(${bind_idx}) \
+             GROUP BY fg.film_id HAVING COUNT(DISTINCT g.slug) = {})",
+            include_slugs.len()
+        ));
+        bind_idx += 1;
+    } else {
+        where_parts.push(format!(
+            "f.id IN (SELECT fg.film_id FROM film_genres fg \
+             JOIN genres g ON g.id = fg.genre_id \
+             WHERE g.slug = ANY(${bind_idx}))"
+        ));
+        bind_idx += 1;
+    }
     if !exclude.is_empty() {
         where_parts.push(format!(
             "f.id NOT IN (SELECT fg2.film_id FROM film_genres fg2 \
@@ -473,12 +592,13 @@ async fn films_by_genre(
     let where_clause = where_parts.join(" AND ");
 
     // Count
-    let count_query = format!(
-        "SELECT count(DISTINCT f.id) as count FROM films f \
-         JOIN film_genres fg ON f.id = fg.film_id \
-         WHERE {where_clause}"
-    );
-    let mut count_q = sqlx::query_as::<_, CountRow>(&count_query).bind(genre.id);
+    let count_query = format!("SELECT count(*) as count FROM films f WHERE {where_clause}");
+    let mut count_q = sqlx::query_as::<_, CountRow>(&count_query);
+    if multi_include {
+        count_q = count_q.bind(include_slugs.clone());
+    } else {
+        count_q = count_q.bind(genre.id);
+    }
     if !exclude.is_empty() {
         count_q = count_q.bind(exclude.clone());
     }
@@ -491,16 +611,19 @@ async fn films_by_genre(
 
     // Films
     let films_query = format!(
-        "SELECT DISTINCT {FILM_COLUMNS} \
-         FROM films f \
-         JOIN film_genres fg ON f.id = fg.film_id \
+        "SELECT {FILM_COLUMNS} FROM films f \
          WHERE {where_clause} \
          ORDER BY {order} \
          LIMIT ${limit_idx} OFFSET ${offset_idx}",
         limit_idx = bind_idx,
         offset_idx = bind_idx + 1
     );
-    let mut q = sqlx::query_as::<_, FilmRow>(&films_query).bind(genre.id);
+    let mut q = sqlx::query_as::<_, FilmRow>(&films_query);
+    if multi_include {
+        q = q.bind(include_slugs.clone());
+    } else {
+        q = q.bind(genre.id);
+    }
     if !exclude.is_empty() {
         q = q.bind(exclude.clone());
     }
@@ -517,6 +640,7 @@ async fn films_by_genre(
 
     let query_string = build_films_query_string(&params);
 
+    let film_genres_map = load_film_genres_map(&state.db, &films).await?;
     let tmpl = FilmsListTemplate {
         img: state.image_base_url.clone(),
         films,
@@ -528,6 +652,9 @@ async fn films_by_genre(
         sort_key: params.sort_key().to_string(),
         query_string,
         search_query: None,
+        open_filter: open_filter || !zanry_extras.is_empty(),
+        selected_genre_slugs: zanry_extras.clone(),
+        film_genres_map,
     };
     Ok(Html(tmpl.render()?).into_response())
 }
@@ -1016,6 +1143,7 @@ async fn scan_sktorrent_cdns(client: &reqwest::Client, video_id: i32) -> Vec<Skt
     vec![]
 }
 
+
 // --- Helpers ---
 
 async fn load_genres(db: &sqlx::PgPool) -> Result<Vec<GenreRow>, sqlx::Error> {
@@ -1028,6 +1156,41 @@ async fn load_genres(db: &sqlx::PgPool) -> Result<Vec<GenreRow>, sqlx::Error> {
     )
     .fetch_all(db)
     .await
+}
+
+#[derive(sqlx::FromRow)]
+struct FilmGenreJoinRow {
+    film_id: i32,
+    name_cs: String,
+    slug: String,
+}
+
+async fn load_film_genres_map(
+    db: &sqlx::PgPool,
+    films: &[FilmRow],
+) -> Result<std::collections::HashMap<i32, Vec<FilmGenreNameRow>>, sqlx::Error> {
+    if films.is_empty() {
+        return Ok(std::collections::HashMap::new());
+    }
+    let ids: Vec<i32> = films.iter().map(|f| f.id).collect();
+    let rows = sqlx::query_as::<_, FilmGenreJoinRow>(
+        "SELECT fg.film_id, g.name_cs, g.slug \
+         FROM film_genres fg JOIN genres g ON g.id = fg.genre_id \
+         WHERE fg.film_id = ANY($1) \
+         ORDER BY fg.film_id, g.name_cs",
+    )
+    .bind(ids)
+    .fetch_all(db)
+    .await?;
+    let mut map: std::collections::HashMap<i32, Vec<FilmGenreNameRow>> =
+        std::collections::HashMap::new();
+    for r in rows {
+        map.entry(r.film_id).or_default().push(FilmGenreNameRow {
+            name_cs: r.name_cs,
+            slug: r.slug,
+        });
+    }
+    Ok(map)
 }
 
 /// Build pagination query string for film list/genre views.

--- a/cr-web/src/handlers/movies_api/mod.rs
+++ b/cr-web/src/handlers/movies_api/mod.rs
@@ -1,9 +1,11 @@
 mod cz_proxy;
+mod sledujteto;
 mod stream;
 mod subtitles;
 mod thumbnail;
 
 pub use cz_proxy::{movies_search, movies_video_url};
+pub use sledujteto::{sledujteto_resolve, sledujteto_search};
 pub use stream::{filemoon_resolve, movies_proxy_stream, movies_stream, stream_resolve};
 pub use subtitles::movies_subtitle;
 pub use thumbnail::{movies_thumb, movies_validate};

--- a/cr-web/src/handlers/movies_api/mod.rs
+++ b/cr-web/src/handlers/movies_api/mod.rs
@@ -1,11 +1,9 @@
 mod cz_proxy;
-mod sledujteto;
 mod stream;
 mod subtitles;
 mod thumbnail;
 
 pub use cz_proxy::{movies_search, movies_video_url};
-pub use sledujteto::{sledujteto_resolve, sledujteto_search};
 pub use stream::{filemoon_resolve, movies_proxy_stream, movies_stream, stream_resolve};
 pub use subtitles::movies_subtitle;
 pub use thumbnail::{movies_thumb, movies_validate};

--- a/cr-web/src/handlers/series.rs
+++ b/cr-web/src/handlers/series.rs
@@ -41,6 +41,7 @@ pub struct SeriesRow {
 pub struct EpisodeCardRow {
     #[allow(dead_code)] // Primary key; not rendered in series_list template
     pub id: i32,
+    pub series_id: i32,
     pub series_slug: String,
     pub series_title: String,
     pub series_original_title: Option<String>,
@@ -86,6 +87,47 @@ struct GenreRow {
     name_cs: String,
 }
 
+impl GenreRow {
+    /// Pretty Czech plural title for headings and SEO
+    /// (e.g. "Akční seriály", "Dramata", "Horory").
+    fn pretty_plural(&self) -> String {
+        let known: &str = match self.slug.as_str() {
+            "akcni" => "Akční seriály",
+            "animovany" => "Animované seriály",
+            "dobrodruzny" => "Dobrodružné seriály",
+            "dokumentarni" => "Dokumentární seriály",
+            "drama" => "Dramata",
+            "fantasy" => "Fantasy seriály",
+            "historicky" => "Historické seriály",
+            "horor" => "Horory",
+            "hudebni" => "Hudební seriály",
+            "komedie" => "Komedie",
+            "krimi" => "Kriminální seriály",
+            "mysteriozni" => "Mysteriózní seriály",
+            "rodinny" => "Rodinné seriály",
+            "romanticky" => "Romantické seriály",
+            "sci-fi" => "Sci-Fi seriály",
+            "thriller" => "Thrillery",
+            "tv-film" => "Televizní seriály",
+            "valecny" => "Válečné seriály",
+            "western" => "Westerny",
+            _ => "",
+        };
+        if known.is_empty() {
+            format!("{} seriály", self.name_cs)
+        } else {
+            known.to_string()
+        }
+    }
+}
+
+#[derive(FromRow)]
+struct SeriesGenreNameRow {
+    name_cs: String,
+    #[allow(dead_code)]
+    slug: String,
+}
+
 #[derive(FromRow)]
 struct CountRow {
     count: Option<i64>,
@@ -96,6 +138,11 @@ pub struct SeriesQuery {
     strana: Option<i64>,
     razeni: Option<String>,
     q: Option<String>,
+    zanry: Option<String>, // comma-separated include
+    bez: Option<String>,   // comma-separated exclude
+    rok: Option<String>,   // year filter
+    rezim: Option<String>, // "and" / "or"
+    smer: Option<String>,  // "asc" / "desc"
 }
 
 impl SeriesQuery {
@@ -103,17 +150,58 @@ impl SeriesQuery {
         self.strana.unwrap_or(1).max(1)
     }
 
+    fn sort_desc(&self) -> bool {
+        self.smer.as_deref() != Some("asc")
+    }
+
+    fn genre_mode_and(&self) -> bool {
+        self.rezim.as_deref() == Some("and")
+    }
+
     fn order_clause(&self) -> &'static str {
-        match self.razeni.as_deref() {
-            Some("rok") => "s.first_air_year DESC NULLS LAST, s.title",
-            Some("imdb") => "s.imdb_rating DESC NULLS LAST, s.title",
-            Some("nazev") => "s.title ASC",
-            _ => "s.added_at DESC NULLS LAST, s.title",
+        let desc = self.sort_desc();
+        match (self.razeni.as_deref(), desc) {
+            (Some("rok"), true) => "s.first_air_year DESC NULLS LAST, s.title",
+            (Some("rok"), false) => "s.first_air_year ASC NULLS LAST, s.title",
+            (Some("imdb"), true) => "s.imdb_rating DESC NULLS LAST, s.title",
+            (Some("imdb"), false) => "s.imdb_rating ASC NULLS LAST, s.title",
+            (Some("nazev"), true) => "s.title DESC",
+            (Some("nazev"), false) => "s.title ASC",
+            (_, true) => "s.added_at DESC NULLS LAST, s.title",
+            (_, false) => "s.added_at ASC NULLS LAST, s.title",
         }
     }
 
     fn sort_key(&self) -> &str {
         self.razeni.as_deref().unwrap_or("pridano")
+    }
+
+    fn include_genres(&self) -> Vec<String> {
+        self.zanry
+            .as_ref()
+            .map(|s| {
+                s.split(',')
+                    .map(|g| g.trim().to_string())
+                    .filter(|g| !g.is_empty())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    fn exclude_genres(&self) -> Vec<String> {
+        self.bez
+            .as_ref()
+            .map(|s| {
+                s.split(',')
+                    .map(|g| g.trim().to_string())
+                    .filter(|g| !g.is_empty())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    fn year_filter(&self) -> Option<i16> {
+        self.rok.as_ref().and_then(|s| s.trim().parse().ok())
     }
 }
 
@@ -134,6 +222,32 @@ struct SeriesListTemplate {
     sort_key: String,
     query_string: String,
     search_query: Option<String>,
+    open_filter: bool,
+    /// Genre slugs the user is filtering by right now (from `?zanry=` on main page).
+    selected_genre_slugs: Vec<String>,
+    /// Genres per series, keyed by series id — rendered as chips in desktop list view.
+    series_genres_map: std::collections::HashMap<i32, Vec<SeriesGenreNameRow>>,
+}
+
+impl SeriesListTemplate {
+    fn is_selected(&self, slug: &str) -> bool {
+        self.selected_genre_slugs.iter().any(|s| s == slug)
+    }
+    fn is_multi_filter_mode(&self) -> bool {
+        self.current_genre.is_some() || !self.selected_genre_slugs.is_empty()
+    }
+    fn is_current_genre(&self, g: &GenreRow) -> bool {
+        self.current_genre
+            .as_ref()
+            .is_some_and(|cg| cg.id == g.id)
+    }
+    fn series_genres(&self, series_id: &i32) -> &[SeriesGenreNameRow] {
+        static EMPTY: Vec<SeriesGenreNameRow> = Vec::new();
+        self.series_genres_map
+            .get(series_id)
+            .map(|v| v.as_slice())
+            .unwrap_or(EMPTY.as_slice())
+    }
 }
 
 #[derive(Template)]
@@ -197,6 +311,10 @@ pub async fn series_list(
         }
     });
 
+    let include = params.include_genres();
+    let exclude = params.exclude_genres();
+    let year_f = params.year_filter();
+
     // Search mode: show series results (by title). No search: show latest-
     // episode-per-series grid (bombuj.si style).
     let (total_count, series, episodes) = if let Some(ref pattern) = search_q {
@@ -222,15 +340,46 @@ pub async fn series_list(
             .fetch_all(&state.db)
             .await?;
         (count_row.count.unwrap_or(0), rows, Vec::new())
-    } else {
+    } else if include.is_empty() && exclude.is_empty() && year_f.is_none() {
+        // Default home listing (no filters): latest episode per series
         let count_row = sqlx::query_as::<_, CountRow>(
             "SELECT count(DISTINCT e.series_id) as count FROM episodes e",
         )
         .fetch_one(&state.db)
         .await?;
 
-        let episodes = fetch_latest_episode_cards(&state, None, SERIES_PER_PAGE, offset).await?;
+        let episodes = fetch_latest_episode_cards(
+            &state,
+            &[],
+            false,
+            &[],
+            None,
+            SERIES_PER_PAGE,
+            offset,
+        )
+        .await?;
         (count_row.count.unwrap_or(0), Vec::new(), episodes)
+    } else {
+        // Filters active on the all-series page
+        let count_row = count_filtered_series(
+            &state,
+            &include,
+            params.genre_mode_and(),
+            &exclude,
+            year_f,
+        )
+        .await?;
+        let episodes = fetch_latest_episode_cards(
+            &state,
+            &include,
+            params.genre_mode_and(),
+            &exclude,
+            year_f,
+            SERIES_PER_PAGE,
+            offset,
+        )
+        .await?;
+        (count_row, Vec::new(), episodes)
     };
 
     let total_pages = (total_count as f64 / SERIES_PER_PAGE as f64).ceil() as i64;
@@ -254,6 +403,10 @@ pub async fn series_list(
         }
     });
 
+    let selected_genre_slugs: Vec<String> = include.clone();
+    let open_filter = !selected_genre_slugs.is_empty();
+    let series_genres_map = load_series_genres_map(&state.db, &series, &episodes).await?;
+
     let tmpl = SeriesListTemplate {
         img: state.image_base_url.clone(),
         episodes,
@@ -266,71 +419,200 @@ pub async fn series_list(
         sort_key: params.sort_key().to_string(),
         query_string,
         search_query,
+        open_filter,
+        selected_genre_slugs,
+        series_genres_map,
     };
     Ok(Html(tmpl.render()?).into_response())
 }
 
-/// Latest-episode-per-series query. If `genre_id` is provided, only series
-/// belonging to that genre are included. Result is already sorted so the
-/// caller needn't reorder.
+/// Latest-episode-per-series query. Supports include/exclude genre slug lists
+/// (OR / AND mode) + optional year filter. `series.id` is carried through so
+/// list-view can look up genre chips per series.
 async fn fetch_latest_episode_cards(
     state: &AppState,
-    genre_id: Option<i32>,
+    include_slugs: &[String],
+    include_mode_and: bool,
+    exclude_slugs: &[String],
+    year_f: Option<i16>,
     limit: i64,
     offset: i64,
 ) -> WebResult<Vec<EpisodeCardRow>> {
-    let base = "WITH per_series AS ( \
-        SELECT DISTINCT ON (e.series_id) \
-            e.id, e.series_id, e.season, e.episode, e.has_subtitles, e.has_dub, e.created_at \
-        FROM episodes e \
-        {GENRE_JOIN} \
-        {GENRE_WHERE} \
-        ORDER BY e.series_id, e.created_at DESC \
-     ) \
-     SELECT ps.id, \
-        s.slug AS series_slug, \
-        s.title AS series_title, \
-        s.original_title AS series_original_title, \
-        s.cover_filename AS series_cover_filename, \
-        s.first_air_year AS series_first_air_year, \
-        s.imdb_rating AS series_imdb_rating, \
-        s.csfd_rating AS series_csfd_rating, \
-        s.description AS series_description, \
-        ps.season, ps.episode, ps.has_subtitles, ps.has_dub, ps.created_at, \
-        (SELECT e2.slug FROM episodes e2 WHERE e2.id = ps.id) AS episode_slug, \
-        (SELECT e2.episode_name FROM episodes e2 WHERE e2.id = ps.id) AS episode_name \
-     FROM per_series ps \
-     JOIN series s ON s.id = ps.series_id \
-     ORDER BY ps.created_at DESC NULLS LAST \
-     LIMIT $1 OFFSET $2";
-
-    let (genre_join, genre_where) = if genre_id.is_some() {
-        (
-            "JOIN series_genres sg ON sg.series_id = e.series_id",
-            "WHERE sg.genre_id = $3",
-        )
+    let mut where_parts: Vec<String> = Vec::new();
+    let mut bind_idx: i32 = 3; // $1 = limit, $2 = offset
+    if !include_slugs.is_empty() {
+        if include_mode_and {
+            where_parts.push(format!(
+                "s.id IN (SELECT sg.series_id FROM series_genres sg \
+                 JOIN genres g ON g.id = sg.genre_id \
+                 WHERE g.slug = ANY(${bind_idx}) \
+                 GROUP BY sg.series_id HAVING COUNT(DISTINCT g.slug) = {})",
+                include_slugs.len()
+            ));
+        } else {
+            where_parts.push(format!(
+                "s.id IN (SELECT sg.series_id FROM series_genres sg \
+                 JOIN genres g ON g.id = sg.genre_id \
+                 WHERE g.slug = ANY(${bind_idx}))"
+            ));
+        }
+        bind_idx += 1;
+    }
+    if !exclude_slugs.is_empty() {
+        where_parts.push(format!(
+            "s.id NOT IN (SELECT sg2.series_id FROM series_genres sg2 \
+             JOIN genres g2 ON g2.id = sg2.genre_id \
+             WHERE g2.slug = ANY(${bind_idx}))"
+        ));
+        bind_idx += 1;
+    }
+    if year_f.is_some() {
+        where_parts.push(format!("s.first_air_year = ${bind_idx}"));
+    }
+    let series_filter = if where_parts.is_empty() {
+        String::new()
     } else {
-        ("", "")
+        format!("AND {}", where_parts.join(" AND "))
     };
-    let sql = base
-        .replace("{GENRE_JOIN}", genre_join)
-        .replace("{GENRE_WHERE}", genre_where);
 
-    let rows = if let Some(gid) = genre_id {
-        sqlx::query_as::<_, EpisodeCardRow>(&sql)
-            .bind(limit)
-            .bind(offset)
-            .bind(gid)
-            .fetch_all(&state.db)
-            .await?
-    } else {
-        sqlx::query_as::<_, EpisodeCardRow>(&sql)
-            .bind(limit)
-            .bind(offset)
-            .fetch_all(&state.db)
-            .await?
-    };
-    Ok(rows)
+    let sql = format!(
+        "WITH per_series AS ( \
+            SELECT DISTINCT ON (e.series_id) \
+                e.id, e.series_id, e.season, e.episode, e.has_subtitles, e.has_dub, e.created_at \
+            FROM episodes e \
+            JOIN series s ON s.id = e.series_id \
+            WHERE 1=1 {series_filter} \
+            ORDER BY e.series_id, e.created_at DESC \
+         ) \
+         SELECT ps.id, \
+            s.id AS series_id, \
+            s.slug AS series_slug, \
+            s.title AS series_title, \
+            s.original_title AS series_original_title, \
+            s.cover_filename AS series_cover_filename, \
+            s.first_air_year AS series_first_air_year, \
+            s.imdb_rating AS series_imdb_rating, \
+            s.csfd_rating AS series_csfd_rating, \
+            s.description AS series_description, \
+            ps.season, ps.episode, ps.has_subtitles, ps.has_dub, ps.created_at, \
+            (SELECT e2.slug FROM episodes e2 WHERE e2.id = ps.id) AS episode_slug, \
+            (SELECT e2.episode_name FROM episodes e2 WHERE e2.id = ps.id) AS episode_name \
+         FROM per_series ps \
+         JOIN series s ON s.id = ps.series_id \
+         ORDER BY ps.created_at DESC NULLS LAST \
+         LIMIT $1 OFFSET $2"
+    );
+
+    let mut q = sqlx::query_as::<_, EpisodeCardRow>(&sql)
+        .bind(limit)
+        .bind(offset);
+    if !include_slugs.is_empty() {
+        q = q.bind(include_slugs.to_vec());
+    }
+    if !exclude_slugs.is_empty() {
+        q = q.bind(exclude_slugs.to_vec());
+    }
+    if let Some(yr) = year_f {
+        q = q.bind(yr);
+    }
+    Ok(q.fetch_all(&state.db).await?)
+}
+
+/// Count series matching include/exclude/year filters (for pagination).
+async fn count_filtered_series(
+    state: &AppState,
+    include_slugs: &[String],
+    include_mode_and: bool,
+    exclude_slugs: &[String],
+    year_f: Option<i16>,
+) -> WebResult<i64> {
+    let mut where_parts: Vec<String> = vec!["EXISTS (SELECT 1 FROM episodes e WHERE e.series_id = s.id)".to_string()];
+    let mut bind_idx: i32 = 1;
+    if !include_slugs.is_empty() {
+        if include_mode_and {
+            where_parts.push(format!(
+                "s.id IN (SELECT sg.series_id FROM series_genres sg \
+                 JOIN genres g ON g.id = sg.genre_id \
+                 WHERE g.slug = ANY(${bind_idx}) \
+                 GROUP BY sg.series_id HAVING COUNT(DISTINCT g.slug) = {})",
+                include_slugs.len()
+            ));
+        } else {
+            where_parts.push(format!(
+                "s.id IN (SELECT sg.series_id FROM series_genres sg \
+                 JOIN genres g ON g.id = sg.genre_id \
+                 WHERE g.slug = ANY(${bind_idx}))"
+            ));
+        }
+        bind_idx += 1;
+    }
+    if !exclude_slugs.is_empty() {
+        where_parts.push(format!(
+            "s.id NOT IN (SELECT sg2.series_id FROM series_genres sg2 \
+             JOIN genres g2 ON g2.id = sg2.genre_id \
+             WHERE g2.slug = ANY(${bind_idx}))"
+        ));
+        bind_idx += 1;
+    }
+    if year_f.is_some() {
+        where_parts.push(format!("s.first_air_year = ${bind_idx}"));
+    }
+    let sql = format!(
+        "SELECT count(*) as count FROM series s WHERE {}",
+        where_parts.join(" AND ")
+    );
+    let mut q = sqlx::query_as::<_, CountRow>(&sql);
+    if !include_slugs.is_empty() {
+        q = q.bind(include_slugs.to_vec());
+    }
+    if !exclude_slugs.is_empty() {
+        q = q.bind(exclude_slugs.to_vec());
+    }
+    if let Some(yr) = year_f {
+        q = q.bind(yr);
+    }
+    let row = q.fetch_one(&state.db).await?;
+    Ok(row.count.unwrap_or(0))
+}
+
+#[derive(FromRow)]
+struct SeriesGenreJoinRow {
+    series_id: i32,
+    name_cs: String,
+    slug: String,
+}
+
+/// Load genres for all displayed series (from search results + episode cards).
+async fn load_series_genres_map(
+    db: &sqlx::PgPool,
+    series: &[SeriesRow],
+    episodes: &[EpisodeCardRow],
+) -> WebResult<std::collections::HashMap<i32, Vec<SeriesGenreNameRow>>> {
+    let mut ids: Vec<i32> = series.iter().map(|s| s.id).collect();
+    ids.extend(episodes.iter().map(|e| e.series_id));
+    ids.sort_unstable();
+    ids.dedup();
+    if ids.is_empty() {
+        return Ok(std::collections::HashMap::new());
+    }
+    let rows = sqlx::query_as::<_, SeriesGenreJoinRow>(
+        "SELECT sg.series_id, g.name_cs, g.slug \
+         FROM series_genres sg JOIN genres g ON g.id = sg.genre_id \
+         WHERE sg.series_id = ANY($1) \
+         ORDER BY sg.series_id, g.name_cs",
+    )
+    .bind(ids)
+    .fetch_all(db)
+    .await?;
+    let mut map: std::collections::HashMap<i32, Vec<SeriesGenreNameRow>> =
+        std::collections::HashMap::new();
+    for r in rows {
+        map.entry(r.series_id).or_default().push(SeriesGenreNameRow {
+            name_cs: r.name_cs,
+            slug: r.slug,
+        });
+    }
+    Ok(map)
 }
 
 /// Resolve /serialy-online/{slug}/ — genre or series detail
@@ -338,6 +620,7 @@ pub async fn series_resolve(
     State(state): State<AppState>,
     Path(slug_raw): Path<String>,
     axum::extract::Query(params): axum::extract::Query<SeriesQuery>,
+    headers: axum::http::HeaderMap,
 ) -> WebResult<Response> {
     let state_clone = state.clone();
     // WebP cover
@@ -353,7 +636,20 @@ pub async fn series_resolve(
             .await?;
 
     if let Some(genre) = genre {
-        return series_by_genre(state, genre, params).await;
+        let from_series_home = headers
+            .get(axum::http::header::REFERER)
+            .and_then(|h| h.to_str().ok())
+            .map(|r| {
+                if let Some(path) = r.splitn(2, "://").nth(1).and_then(|s| s.split_once('/')) {
+                    let p = format!("/{}", path.1);
+                    let clean = p.split('?').next().unwrap_or(&p);
+                    clean == "/serialy-online/" || clean == "/serialy-online"
+                } else {
+                    false
+                }
+            })
+            .unwrap_or(false);
+        return series_by_genre(state, genre, params, from_series_home).await;
     }
 
     // Series detail
@@ -679,22 +975,42 @@ async fn series_by_genre(
     state: AppState,
     genre: GenreRow,
     params: SeriesQuery,
+    open_filter: bool,
 ) -> WebResult<Response> {
     let page = params.page();
     let offset = (page - 1) * SERIES_PER_PAGE;
+    let exclude = params.exclude_genres();
+    let year_f = params.year_filter();
+    let zanry_extras = params.include_genres();
 
-    let count_row = sqlx::query_as::<_, CountRow>(
-        "SELECT count(DISTINCT e.series_id) as count FROM episodes e \
-         JOIN series_genres sg ON sg.series_id = e.series_id WHERE sg.genre_id = $1",
+    // Merge path genre with ?zanry= extras into one include list
+    let mut include_slugs: Vec<String> = vec![genre.slug.clone()];
+    for s in zanry_extras.iter() {
+        if !include_slugs.contains(s) {
+            include_slugs.push(s.clone());
+        }
+    }
+
+    let total_count = count_filtered_series(
+        &state,
+        &include_slugs,
+        params.genre_mode_and(),
+        &exclude,
+        year_f,
     )
-    .bind(genre.id)
-    .fetch_one(&state.db)
     .await?;
-    let total_count = count_row.count.unwrap_or(0);
     let total_pages = (total_count as f64 / SERIES_PER_PAGE as f64).ceil() as i64;
 
-    let episodes =
-        fetch_latest_episode_cards(&state, Some(genre.id), SERIES_PER_PAGE, offset).await?;
+    let episodes = fetch_latest_episode_cards(
+        &state,
+        &include_slugs,
+        params.genre_mode_and(),
+        &exclude,
+        year_f,
+        SERIES_PER_PAGE,
+        offset,
+    )
+    .await?;
 
     let all_genres = sqlx::query_as::<_, GenreRow>(
         "SELECT g.id, g.slug, g.name_cs FROM genres g \
@@ -703,6 +1019,9 @@ async fn series_by_genre(
     )
     .fetch_all(&state.db)
     .await?;
+
+    let query_string = build_series_query_string(&params);
+    let series_genres_map = load_series_genres_map(&state.db, &[], &episodes).await?;
 
     let tmpl = SeriesListTemplate {
         img: state.image_base_url.clone(),
@@ -714,8 +1033,11 @@ async fn series_by_genre(
         total_count,
         current_genre: Some(genre),
         sort_key: params.sort_key().to_string(),
-        query_string: String::new(),
+        query_string,
         search_query: None,
+        open_filter: open_filter || !zanry_extras.is_empty(),
+        selected_genre_slugs: zanry_extras,
+        series_genres_map,
     };
     Ok(Html(tmpl.render()?).into_response())
 }
@@ -1033,6 +1355,27 @@ fn build_series_query_string(params: &SeriesQuery) -> String {
         if !t.is_empty() {
             parts.push(("q", t.to_string()));
         }
+    }
+    if let Some(ref z) = params.zanry
+        && !z.is_empty()
+    {
+        parts.push(("zanry", z.clone()));
+    }
+    if params.rezim.as_deref() == Some("and") {
+        parts.push(("rezim", "and".to_string()));
+    }
+    if params.smer.as_deref() == Some("asc") {
+        parts.push(("smer", "asc".to_string()));
+    }
+    if let Some(ref b) = params.bez
+        && !b.is_empty()
+    {
+        parts.push(("bez", b.clone()));
+    }
+    if let Some(ref r) = params.rok
+        && !r.is_empty()
+    {
+        parts.push(("rok", r.clone()));
     }
     super::build_pagination_qs(&parts)
 }

--- a/cr-web/src/handlers/series.rs
+++ b/cr-web/src/handlers/series.rs
@@ -176,28 +176,25 @@ impl SeriesQuery {
         self.razeni.as_deref().unwrap_or("pridano")
     }
 
+    fn parse_genre_slugs(input: Option<&String>) -> Vec<String> {
+        // Dedup to keep AND-mode `HAVING COUNT(DISTINCT g.slug) = slugs.len()` correct.
+        let mut slugs: Vec<String> = Vec::new();
+        if let Some(input) = input {
+            for s in input.split(',').map(|g| g.trim()).filter(|g| !g.is_empty()) {
+                if !slugs.iter().any(|x| x == s) {
+                    slugs.push(s.to_string());
+                }
+            }
+        }
+        slugs
+    }
+
     fn include_genres(&self) -> Vec<String> {
-        self.zanry
-            .as_ref()
-            .map(|s| {
-                s.split(',')
-                    .map(|g| g.trim().to_string())
-                    .filter(|g| !g.is_empty())
-                    .collect()
-            })
-            .unwrap_or_default()
+        Self::parse_genre_slugs(self.zanry.as_ref())
     }
 
     fn exclude_genres(&self) -> Vec<String> {
-        self.bez
-            .as_ref()
-            .map(|s| {
-                s.split(',')
-                    .map(|g| g.trim().to_string())
-                    .filter(|g| !g.is_empty())
-                    .collect()
-            })
-            .unwrap_or_default()
+        Self::parse_genre_slugs(self.bez.as_ref())
     }
 
     fn year_filter(&self) -> Option<i16> {
@@ -239,6 +236,9 @@ impl SeriesListTemplate {
     fn is_current_genre(&self, g: &GenreRow) -> bool {
         self.current_genre.as_ref().is_some_and(|cg| cg.id == g.id)
     }
+    // NOTE: Askama auto-refs arguments in template method calls — `{{ self.series_genres(s.id) }}`
+    // generates a call with `&s.id`. Keep the signature as `&i32` to match; Copilot's
+    // "accept i32 by value" suggestion would break Askama codegen here.
     fn series_genres(&self, series_id: &i32) -> &[SeriesGenreNameRow] {
         static EMPTY: Vec<SeriesGenreNameRow> = Vec::new();
         self.series_genres_map

--- a/cr-web/src/handlers/series.rs
+++ b/cr-web/src/handlers/series.rs
@@ -237,9 +237,7 @@ impl SeriesListTemplate {
         self.current_genre.is_some() || !self.selected_genre_slugs.is_empty()
     }
     fn is_current_genre(&self, g: &GenreRow) -> bool {
-        self.current_genre
-            .as_ref()
-            .is_some_and(|cg| cg.id == g.id)
+        self.current_genre.as_ref().is_some_and(|cg| cg.id == g.id)
     }
     fn series_genres(&self, series_id: &i32) -> &[SeriesGenreNameRow] {
         static EMPTY: Vec<SeriesGenreNameRow> = Vec::new();
@@ -348,27 +346,15 @@ pub async fn series_list(
         .fetch_one(&state.db)
         .await?;
 
-        let episodes = fetch_latest_episode_cards(
-            &state,
-            &[],
-            false,
-            &[],
-            None,
-            SERIES_PER_PAGE,
-            offset,
-        )
-        .await?;
+        let episodes =
+            fetch_latest_episode_cards(&state, &[], false, &[], None, SERIES_PER_PAGE, offset)
+                .await?;
         (count_row.count.unwrap_or(0), Vec::new(), episodes)
     } else {
         // Filters active on the all-series page
-        let count_row = count_filtered_series(
-            &state,
-            &include,
-            params.genre_mode_and(),
-            &exclude,
-            year_f,
-        )
-        .await?;
+        let count_row =
+            count_filtered_series(&state, &include, params.genre_mode_and(), &exclude, year_f)
+                .await?;
         let episodes = fetch_latest_episode_cards(
             &state,
             &include,
@@ -526,7 +512,8 @@ async fn count_filtered_series(
     exclude_slugs: &[String],
     year_f: Option<i16>,
 ) -> WebResult<i64> {
-    let mut where_parts: Vec<String> = vec!["EXISTS (SELECT 1 FROM episodes e WHERE e.series_id = s.id)".to_string()];
+    let mut where_parts: Vec<String> =
+        vec!["EXISTS (SELECT 1 FROM episodes e WHERE e.series_id = s.id)".to_string()];
     let mut bind_idx: i32 = 1;
     if !include_slugs.is_empty() {
         if include_mode_and {
@@ -607,10 +594,12 @@ async fn load_series_genres_map(
     let mut map: std::collections::HashMap<i32, Vec<SeriesGenreNameRow>> =
         std::collections::HashMap::new();
     for r in rows {
-        map.entry(r.series_id).or_default().push(SeriesGenreNameRow {
-            name_cs: r.name_cs,
-            slug: r.slug,
-        });
+        map.entry(r.series_id)
+            .or_default()
+            .push(SeriesGenreNameRow {
+                name_cs: r.name_cs,
+                slug: r.slug,
+            });
     }
     Ok(map)
 }
@@ -640,7 +629,7 @@ pub async fn series_resolve(
             .get(axum::http::header::REFERER)
             .and_then(|h| h.to_str().ok())
             .map(|r| {
-                if let Some(path) = r.splitn(2, "://").nth(1).and_then(|s| s.split_once('/')) {
+                if let Some(path) = r.split_once("://").and_then(|(_, s)| s.split_once('/')) {
                     let p = format!("/{}", path.1);
                     let clean = p.split('?').next().unwrap_or(&p);
                     clean == "/serialy-online/" || clean == "/serialy-online"

--- a/cr-web/static/css/index.css
+++ b/cr-web/static/css/index.css
@@ -570,3 +570,13 @@ body {
         gap: 0.5rem 1.5rem;
     }
 }
+
+@media (max-width: 400px) {
+    .search-container { padding: 1px; }
+    .search-input { padding: 0.4rem 0.7rem; font-size: 0.85rem; min-width: 0; }
+    .search-btn { padding: 0 0.7rem; font-size: 0.85rem; }
+}
+@media (max-width: 360px) {
+    .search-input { padding: 0.4rem 0.5rem; font-size: 0.8rem; }
+    .search-btn { padding: 0 0.55rem; font-size: 0.8rem; }
+}

--- a/cr-web/templates/base.html
+++ b/cr-web/templates/base.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}Česká republika{% endblock %} | ceskarepublika.wiki</title>
     <meta name="description" content="{% block meta_description %}Encyklopedický portál o České republice — kraje, obce, památky, koupání a další.{% endblock %}">
-    <link rel="stylesheet" href="/static/css/index.css?v=4">
+    <link rel="stylesheet" href="/static/css/index.css?v=5">
     <link rel="stylesheet" href="/static/css/map.css?v=5">
     <link rel="stylesheet" href="/static/css/lightbox.css?v=2">
     {# #367 — Leaflet CSS + JS is ~150 KB of synchronous network

--- a/cr-web/templates/films_list.html
+++ b/cr-web/templates/films_list.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
 
-{% block title %}{% match current_genre %}{% when Some with (g) %}{{ g.name_cs }} filmy online{% when None %}Filmy online{% endmatch %}{% endblock %}
+{% block title %}{% match current_genre %}{% when Some with (g) %}{{ g.pretty_plural() }} online{% when None %}Filmy online{% endmatch %}{% endblock %}
 
-{% block meta_description %}{% match current_genre %}{% when Some with (g) %}{{ g.name_cs }} filmy online zdarma — {{ total_count }} filmů ke zhlédnutí.{% when None %}Filmy online zdarma — {{ total_count }} filmů ke zhlédnutí na ceskarepublika.wiki.{% endmatch %}{% endblock %}
+{% block meta_description %}{% match current_genre %}{% when Some with (g) %}{{ g.pretty_plural() }} online zdarma — {{ total_count }} filmů ke zhlédnutí.{% when None %}Filmy online zdarma — {{ total_count }} filmů ke zhlédnutí na ceskarepublika.wiki.{% endmatch %}{% endblock %}
 
-{% block og_title %}{% match current_genre %}{% when Some with (g) %}{{ g.name_cs }} filmy online — ceskarepublika.wiki{% when None %}Filmy online — ceskarepublika.wiki{% endmatch %}{% endblock %}
-{% block og_description %}{% match current_genre %}{% when Some with (g) %}{{ g.name_cs }} filmy online zdarma. {{ total_count }} filmů ke zhlédnutí přímo v prohlížeči, bez registrace.{% when None %}Filmy online zdarma — {{ total_count }} filmů ke zhlédnutí přímo v prohlížeči, bez registrace. České i zahraniční filmy s českým dabingem nebo titulky.{% endmatch %}{% endblock %}
+{% block og_title %}{% match current_genre %}{% when Some with (g) %}{{ g.pretty_plural() }} online — ceskarepublika.wiki{% when None %}Filmy online — ceskarepublika.wiki{% endmatch %}{% endblock %}
+{% block og_description %}{% match current_genre %}{% when Some with (g) %}{{ g.pretty_plural() }} online zdarma. {{ total_count }} filmů ke zhlédnutí přímo v prohlížeči, bez registrace.{% when None %}Filmy online zdarma — {{ total_count }} filmů ke zhlédnutí přímo v prohlížeči, bez registrace. České i zahraniční filmy s českým dabingem nebo titulky.{% endmatch %}{% endblock %}
 {% block og_image %}https://ceskarepublika.wiki/static/img/og-filmy-online-v1.png{% endblock %}
 {% block og_type %}article{% endblock %}
 
@@ -22,11 +22,20 @@
 {% endblock %}
 
 {% block header_left %}
+{% match current_genre %}
+{% when Some with (_g) %}
+<a href="/filmy-online/" class="logo-group logo-link" style="display:flex;align-items:center;gap:0.5rem;">
+    <img src="/static/img/logo-filmy-a-serialy.svg?v=6"
+        alt="Logo Filmy online" title="Filmy online" class="header-emblem">
+    <span>Filmy online</span>
+</a>
+{% when None %}
 <div class="logo-group" style="display:flex;align-items:center;gap:0.5rem;">
     <img src="/static/img/logo-filmy-a-serialy.svg?v=6"
         alt="Logo Filmy online" title="Filmy online" class="header-emblem">
     <h1>Filmy online</h1>
 </div>
+{% endmatch %}
 {% endblock %}
 
 {# Search in header #}
@@ -48,7 +57,7 @@
         <span>›</span>
         {% match current_genre %}
         {% when Some with (g) %}
-        <a href="/filmy-online/">Filmy online</a> <span>›</span> <span>{{ g.name_cs }}</span>
+        <a href="/filmy-online/">Filmy online</a>
         {% when None %}
         <span>Filmy online</span>
         {% endmatch %}
@@ -60,14 +69,12 @@
         {% when Some with (q) %}
         <h2>Výsledky hledání pro „{{ q }}" <span class="count">({{ total_count }})</span></h2>
         {% when None %}
-        <h2>
             {% match current_genre %}
             {% when Some with (g) %}
-                {{ g.name_cs }} <span class="count">({{ total_count }})</span>
+            <h1>{{ g.pretty_plural() }}<span class="online-word"> online</span> <span class="count">({{ total_count }})</span></h1>
             {% when None %}
-                Vyberte si z {{ total_count }} filmů, které si můžete pustit online
+            <h2>Vyberte si z {{ total_count }} filmů<span class="online-word"> online</span></h2>
             {% endmatch %}
-        </h2>
         {% endmatch %}
         <div class="films-toolbar">
             <label class="toolbar-group">
@@ -103,22 +110,23 @@
                     <option value="sub">Jen s titulky</option>
                 </select>
             </label>
-            <button class="view-btn view-toggle" id="btn-view-toggle" onclick="toggleView()" title="Přepnout zobrazení mřížka / seznam" aria-label="Zobrazení">
+            <button class="view-btn view-toggle" id="btn-view-toggle" onclick="toggleView()" title="Přepnout na zobrazení seznamem" aria-label="Zobrazení">
                 <svg class="view-icon-grid" width="18" height="18" viewBox="0 0 18 18"><rect x="1" y="2" width="16" height="3" rx="1" fill="currentColor"/><rect x="1" y="7.5" width="16" height="3" rx="1" fill="currentColor"/><rect x="1" y="13" width="16" height="3" rx="1" fill="currentColor"/></svg>
                 <svg class="view-icon-list" width="18" height="18" viewBox="0 0 18 18" style="display:none;"><rect x="1" y="1" width="7" height="7" rx="1" fill="currentColor"/><rect x="10" y="1" width="7" height="7" rx="1" fill="currentColor"/><rect x="1" y="10" width="7" height="7" rx="1" fill="currentColor"/><rect x="10" y="10" width="7" height="7" rx="1" fill="currentColor"/></svg>
             </button>
-            <button class="view-btn" id="btn-filter-toggle" onclick="toggleFilter()" title="Filtrování">
+            <button class="view-btn" id="btn-filter-toggle" onclick="toggleFilter()" title="{% match current_genre %}{% when Some with (_g) %}Upřesnit nebo zrušit filtr{% when None %}Filtrování{% endmatch %}">
                 <svg width="18" height="18" viewBox="0 0 18 18"><path d="M1 3h16M4 9h10M7 15h4" stroke="currentColor" stroke-width="2" stroke-linecap="round" fill="none"/></svg>
             </button>
         </div>
     </div>
 
-    {# Advanced filter panel — hidden by default #}
-    <div class="filter-panel" id="filter-panel" style="display:none;"
+    {# Advanced filter panel — hidden by default, open when arriving from main listing #}
+    <div class="filter-panel" id="filter-panel" style="display:{% if open_filter %}block{% else %}none{% endif %};"
          {% match current_genre %}{% when Some with (cg) %}data-current-genre="{{ cg.slug }}"{% when None %}{% endmatch %}>
         <div class="filter-section">
             <div class="filter-label-row">
-                <label>Zahrnout žánry (zaškrtněte, které chcete):</label>
+                {% if self.is_multi_filter_mode() %}
+                <label>Zahrnout žánry:</label>
                 <div class="genre-mode">
                     <label class="mode-option">
                         <input type="radio" name="rezim" value="or" checked>
@@ -130,13 +138,17 @@
                     </label>
                     <span class="help-icon" tabindex="0" onclick="this.classList.toggle('show')">?<span class="help-popup"><strong>Alespoň jeden:</strong> zobrazí filmy, které mají některý z&nbsp;vybraných žánrů.<br><strong>Všechny:</strong> zobrazí jen filmy, které mají všechny vybrané žánry současně.</span></span>
                 </div>
+                {% else %}
+                <label>Vyberte žánr:</label>
+                {% endif %}
             </div>
             <div class="filter-genres" id="filter-genres-include">
                 {% for g in genres %}
-                {% match current_genre %}
-                {% when Some with (cg) %}{% if cg.id != g.id %}<label class="filter-chip"><input type="checkbox" value="{{ g.slug }}" data-filter="include"> {{ g.name_cs }}</label>{% endif %}
-                {% when None %}<label class="filter-chip"><input type="checkbox" value="{{ g.slug }}" data-filter="include"> {{ g.name_cs }}</label>
-                {% endmatch %}
+                {% if self.is_multi_filter_mode() %}
+                <label class="filter-chip{% if self.is_current_genre(g) %} current{% endif %}"{% if self.is_current_genre(g) %} aria-current="page"{% endif %}><input type="checkbox" value="{{ g.slug }}" data-filter="include"{% if self.is_current_genre(g) || self.is_selected(g.slug.as_str()) %} checked{% endif %}> {{ g.name_cs }}</label>
+                {% else %}
+                <a class="filter-chip filter-chip-link" href="/filmy-online/{{ g.slug }}/">{{ g.name_cs }}</a>
+                {% endif %}
                 {% endfor %}
             </div>
         </div>
@@ -155,16 +167,6 @@
             </div>
         </div>
         <div class="filter-section">
-            <div class="filter-label-row">
-                <label>Zvuková verze:</label>
-                <span class="help-icon" tabindex="0" onclick="this.classList.toggle('show')">?<span class="help-popup"><strong>Dabovaný (CZ/SK):</strong> film má český nebo slovenský dabing.<br><strong>S českými titulky:</strong> film je v původním jazyce s českými titulky.<br>Pokud nic nevyberete, zobrazí se všechny verze.</span></span>
-            </div>
-            <div class="filter-genres" id="filter-langs">
-                <label class="filter-chip lang"><input type="checkbox" value="dub" data-filter="lang"> Dabovaný (CZ/SK)</label>
-                <label class="filter-chip lang"><input type="checkbox" value="sub" data-filter="lang"> S českými titulky</label>
-            </div>
-        </div>
-        <div class="filter-section">
             <label for="filter-year">Rok vydání:</label>
             <select id="filter-year">
                 <option value="">Všechny roky</option>
@@ -175,24 +177,6 @@
             <button class="btn-reset" onclick="resetFilters()">Zrušit filtry</button>
         </div>
     </div>
-
-    {# Quick genre tags #}
-    <nav class="genre-nav">
-        {% if current_genre.is_none() %}
-        <span class="genre-tag current">Vše</span>
-        {% else %}
-        <a href="/filmy-online/" class="genre-tag">Vše</a>
-        {% endif %}
-        {% for g in genres %}
-        {% match current_genre %}{% when Some with (cg) %}{% if cg.id == g.id %}
-        <span class="genre-tag current">{{ g.name_cs }}</span>
-        {% else %}
-        <a href="/filmy-online/{{ g.slug }}/" class="genre-tag">{{ g.name_cs }}</a>
-        {% endif %}{% when None %}
-        <a href="/filmy-online/{{ g.slug }}/" class="genre-tag">{{ g.name_cs }}</a>
-        {% endmatch %}
-        {% endfor %}
-    </nav>
 
     {# Films grid/list #}
     <div class="films-grid" id="films-container">
@@ -217,6 +201,11 @@
                     {% when None %}
                     {% endmatch %}
                 </div>
+                {% match f.runtime_min %}
+                {% when Some with (m) %}
+                <span class="runtime-badge" title="Délka filmu">{{ m }} min</span>
+                {% when None %}
+                {% endmatch %}
             </div>
             <div class="film-body">
                 <div class="film-info">
@@ -229,6 +218,7 @@
                         {% match f.imdb_rating %}{% when Some with (r) %}<span class="badge imdb">IMDB {{ r }}</span>{% when None %}{% endmatch %}
                         {% match f.csfd_rating %}{% when Some with (r) %}<span class="badge csfd">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
                         {% match f.runtime_min %}{% when Some with (m) %}<span class="badge runtime">{{ m }} min</span>{% when None %}{% endmatch %}
+                        {% for fg in self.film_genres(f.id) %}<span class="genre-tag">{{ fg.name_cs }}</span>{% endfor %}
                     </div>
                     {% match f.description %}{% when Some with (d) %}<p class="film-desc">{{ d }}</p>{% when None %}{% endmatch %}
                 </div>
@@ -279,10 +269,21 @@
 
 /* --- Header + toolbar --- */
 .films-header { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 0.8rem; }
-.films-header h2 { margin: 0; font-size: 1.3rem; }
+.films-header h1, .films-header h2 { margin: 0; font-size: 1.3rem; font-weight: 700; }
 .films-header .count { color: #888; font-weight: 400; }
-.films-toolbar { display: flex; align-items: center; gap: 0.4rem; }
+.logo-link { text-decoration: none; color: inherit; cursor: pointer; }
+.logo-link:hover span { text-decoration: underline; }
+.logo-link, .logo-link * { cursor: pointer; }
+@media (max-width: 360px) { .online-word { display: none; } }
+.films-toolbar { display: flex; align-items: center; gap: 0.4rem; flex-wrap: wrap; }
 .films-toolbar select { padding: 0.3rem 0.5rem; border: 1px solid #ddd; border-radius: 6px; font-size: 0.85rem; background: white; cursor: pointer; }
+@media (max-width: 520px) {
+    .films-header h1, .films-header h2 { font-size: 1.1rem; }
+    .films-toolbar { gap: 0.3rem; }
+    .toolbar-group { margin-right: 0; gap: 0.25rem; }
+    .sort-select-combined { min-width: 0; padding-left: 0.4rem; padding-right: 0.4rem; max-width: 150px; }
+    .quick-audio-select { padding-left: 0.4rem; padding-right: 0.4rem; max-width: 80px; }
+}
 .view-btn { background: #f0f0f0; border: none; padding: 0.4rem; border-radius: 6px; cursor: pointer; color: #666; transition: background 0.2s, color 0.2s; display: flex; align-items: center; }
 .view-btn:hover { background: #e0e0e0; }
 .view-btn.active { background: #D7141A; color: white; }
@@ -293,10 +294,13 @@
 .filter-section > label { display: block; font-weight: 600; font-size: 0.85rem; color: #555; margin-bottom: 0.4rem; }
 .filter-genres { display: flex; flex-wrap: wrap; gap: 0.3rem; }
 /* Unified chip design — gray default, gold when selected (same as active category pill) */
-.filter-chip { display: inline-flex; align-items: center; gap: 0.25rem; padding: 0.3rem 0.8rem; border-radius: 999px; background: #f1f5f9; border: 1px solid transparent; color: #555; font-size: 0.82rem; cursor: pointer; transition: all 0.15s; user-select: none; }
+.filter-chip { display: inline-flex; align-items: center; gap: 0.25rem; padding: 0.3rem 0.8rem; border-radius: 999px; background: #f1f5f9; border: 1px solid transparent; color: #555; font-size: 0.82rem; cursor: pointer; transition: all 0.15s; user-select: none; text-decoration: none; }
 .filter-chip:hover { background: #e2e8f0; color: #333; }
 .filter-chip:has(input:checked) { background: #C5A059; color: white; border-color: #C5A059; font-weight: 600; }
 .filter-chip input { display: none; }
+.filter-chip-link { color: #11457E; font-weight: 600; }
+a.filter-chip-link:hover { background: #11457E; color: white; }
+.filter-chip.current { outline: 2px solid #11457E; outline-offset: 2px; }
 .filter-row { display: flex; gap: 1rem; flex-wrap: wrap; }
 .filter-row .filter-section { flex: 1; min-width: 150px; }
 .filter-row select { width: 100%; padding: 0.4rem 0.6rem; border: 1px solid #ddd; border-radius: 6px; font-size: 0.85rem; }
@@ -352,8 +356,14 @@
 .breadcrumb a:hover { text-decoration: underline; }
 
 /* --- Grid view --- */
-.films-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 1rem; }
+.films-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); gap: 0.7rem; }
+@media (min-width: 520px) { .films-grid { grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 1rem; } }
 @media (min-width: 768px) { .films-grid { grid-template-columns: repeat(auto-fill, minmax(165px, 1fr)); } }
+/* Very narrow screens (e.g. Z Fold outer): single column, but don't let cover fill the whole screen */
+@media (max-width: 360px) {
+    .films-grid { grid-template-columns: 1fr; gap: 0.6rem; }
+    .films-grid > .film-card { max-width: 240px; margin-left: auto; margin-right: auto; width: 100%; }
+}
 
 .film-card { text-decoration: none; color: inherit; border-radius: 8px; overflow: hidden; transition: transform 0.15s, box-shadow 0.15s; }
 .film-card:hover { transform: translateY(-3px); box-shadow: 0 4px 16px rgba(0,0,0,0.12); }
@@ -366,6 +376,7 @@
 .rating-badge { font-weight: 700; font-size: 0.7rem; padding: 2px 5px; border-radius: 4px; text-align: center; line-height: 1.3; }
 .rating-badge.imdb { background: #f5c518; color: #000; }
 .rating-badge.csfd { background: #ba0305; color: #fff; }
+.runtime-badge { position: absolute; bottom: 6px; right: 6px; background: rgba(0,0,0,0.75); color: #fff; font-weight: 600; font-size: 0.7rem; padding: 2px 6px; border-radius: 4px; line-height: 1.2; }
 
 .film-info { padding: 0.35rem 0; }
 .film-title { display: block; font-size: 0.88rem; font-weight: 500; line-height: 1.3; }
@@ -382,18 +393,32 @@
 .films-grid.list-view .film-card:hover { transform: none; box-shadow: 0 2px 8px rgba(0,0,0,0.08); }
 .films-grid.list-view .film-poster { width: 100px; min-width: 100px; flex-shrink: 0; border-radius: 6px; }
 .films-grid.list-view .rating-badges { display: none; }
+.films-grid.list-view .runtime-badge { display: none; }
 .films-grid.list-view .film-body { display: flex; flex-direction: column; flex: 1; min-width: 0; }
 .films-grid.list-view .film-info { padding: 0; }
 .films-grid.list-view .film-title { font-size: 1.05rem; font-weight: 600; }
 .films-grid.list-view .film-original { display: inline; font-size: 0.82rem; color: #888; font-style: italic; margin-left: 0.5rem; }
 .films-grid.list-view .film-year { display: inline; margin-left: 0.4rem; }
 .films-grid.list-view .film-list-extra { display: block; }
-.films-grid.list-view .film-ratings { display: flex; gap: 0.35rem; flex-wrap: wrap; margin: 0.4rem 0; }
+.films-grid.list-view .film-ratings { display: flex; gap: 0.35rem; flex-wrap: wrap; align-items: center; margin: 0.4rem 0; }
+.film-ratings .genre-tag { display: none; }
+.films-grid.list-view .film-ratings .genre-tag { display: inline-flex; align-items: center; font-size: 0.75rem; color: #555; background: #eceef2; padding: 0.2rem 0.6rem; border-radius: 999px; line-height: 1.3; }
+@media (max-width: 768px) { .films-grid.list-view .film-ratings .genre-tag { display: none; } }
 .films-grid.list-view .badge { display: inline-block; padding: 0.15rem 0.5rem; border-radius: 4px; font-size: 0.78rem; font-weight: 600; }
 .films-grid.list-view .badge.imdb { background: #f5c518; color: #000; }
 .films-grid.list-view .badge.csfd { background: #ba0305; color: #fff; }
 .films-grid.list-view .badge.runtime { background: #eee; color: #333; }
 .films-grid.list-view .film-desc { font-size: 0.85rem; color: #555; line-height: 1.6; margin: 0.3rem 0 0; display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
+/* Mobile list view: move IMDB/ČSFD/runtime back onto the poster (like grid), hide text-badge row so the description has room. */
+@media (max-width: 520px) {
+    .films-grid.list-view .rating-badges { display: flex; }
+    .films-grid.list-view .runtime-badge { display: block; }
+    .films-grid.list-view .film-ratings .badge { display: none; }
+    .films-grid.list-view .film-ratings { display: none; }
+    .films-grid.list-view .film-poster { width: 84px; min-width: 84px; }
+    .films-grid.list-view .film-title { font-size: 0.95rem; }
+    .films-grid.list-view .runtime-badge { font-size: 0.65rem; padding: 1px 4px; }
+}
 
 /* --- Pagination --- */
 .pagination { display: flex; justify-content: center; align-items: center; gap: 0.3rem; margin: 2rem 0; flex-wrap: wrap; }
@@ -409,16 +434,19 @@ function setView(mode) {
     const c = document.getElementById('films-container');
     const iconGrid = document.querySelector('.view-icon-grid');
     const iconList = document.querySelector('.view-icon-list');
+    const btn = document.getElementById('btn-view-toggle');
     if (mode === 'list') {
         c.classList.add('list-view');
         // In list view, show the "switch to grid" icon (grid squares)
         if (iconGrid) iconGrid.style.display = 'none';
         if (iconList) iconList.style.display = '';
+        if (btn) btn.setAttribute('title', 'Přepnout na zobrazení mřížkou');
     } else {
         c.classList.remove('list-view');
         // In grid view, show the "switch to list" icon (hamburger)
         if (iconGrid) iconGrid.style.display = '';
         if (iconList) iconList.style.display = 'none';
+        if (btn) btn.setAttribute('title', 'Přepnout na zobrazení seznamem');
     }
     localStorage.setItem('filmsView', mode);
 }
@@ -449,11 +477,9 @@ function applySort() { applySortCombined(document.getElementById('sort-select').
 
 function applyQuickAudio(v) {
     var u = new URL(window.location);
-    if (v === 'dub' || !v) {
-        // Default is dubbed - remove param
+    if (!v || v === 'vse') {
         u.searchParams.delete('jazyk');
     } else {
-        // "vse" or "sub" - set explicitly
         u.searchParams.set('jazyk', v);
     }
     u.searchParams.delete('strana');
@@ -477,22 +503,13 @@ function applyQuickAudio(v) {
             }
         }
     }
-    // Default is "dub" (dubbed only). Only change select if user set non-default.
     var jazyk = urlParams.get('jazyk');
     var qa = document.getElementById('quick-audio');
     if (qa) {
-        if (jazyk === 'vse' || jazyk === 'sub') {
+        if (jazyk === 'dub' || jazyk === 'sub') {
             qa.value = jazyk;
         } else {
-            qa.value = 'dub';  // default
-        }
-    }
-    // Also prefill detailed filter lang checkboxes to match default
-    if (!jazyk || jazyk === 'dub') {
-        var filterPanel = document.getElementById('filter-panel');
-        if (filterPanel) {
-            var dubCb = filterPanel.querySelector('#filter-langs input[value="dub"]');
-            if (dubCb) dubCb.checked = true;
+            qa.value = 'vse';
         }
     }
 })();
@@ -504,6 +521,16 @@ function toggleFilter() {
     if (p.style.display === 'none') { p.style.display = ''; b.classList.add('active'); }
     else { p.style.display = 'none'; b.classList.remove('active'); }
 }
+/* Auto-open from Referer applies on desktop only; on mobile (<=520px) always start hidden. */
+(function(){
+    var p = document.getElementById('filter-panel');
+    var b = document.getElementById('btn-filter-toggle');
+    if (!p) return;
+    if (p.style.display !== 'none' && window.innerWidth <= 520) {
+        p.style.display = 'none';
+    }
+    if (b && p.style.display !== 'none') b.classList.add('active');
+})();
 
 /* --- Populate year dropdown --- */
 (function() {
@@ -520,67 +547,50 @@ function toggleFilter() {
 function applyFilters() {
     var incEls = document.querySelectorAll('#filter-genres-include input:checked');
     var excEls = document.querySelectorAll('#filter-genres-exclude input:checked');
-    var langEls = document.querySelectorAll('#filter-langs input:checked');
     var inc = Array.from(incEls).map(i => i.value);
     var exc = Array.from(excEls).map(i => i.value);
-    var langs = Array.from(langEls).map(i => i.value);
     var year = document.getElementById('filter-year').value;
     var sort = document.getElementById('sort-select').value;
+    var jazyk = document.getElementById('quick-audio') ? document.getElementById('quick-audio').value : 'vse';
     var rezimEl = document.querySelector('input[name="rezim"]:checked');
     var rezim = rezimEl ? rezimEl.value : 'or';
-    var sortDir = document.getElementById('sort-dir-btn');
-    var dir = sortDir && sortDir.classList.contains('asc') ? 'asc' : 'desc';
 
-    // If we're on a genre subpage, include that genre implicitly
+    var langParam = (jazyk === 'dub' || jazyk === 'sub') ? jazyk : null;
+
+    // Decide primary genre (kept in URL path) vs. extras (go to ?zanry=)
     var panel = document.getElementById('filter-panel');
     var currentGenre = panel ? panel.getAttribute('data-current-genre') : null;
-    if (currentGenre && !inc.includes(currentGenre)) {
-        inc.unshift(currentGenre);
+    var primary = null;
+    var extras = [];
+    if (currentGenre && inc.includes(currentGenre)) {
+        primary = currentGenre;
+        extras = inc.filter(function(s){ return s !== currentGenre; });
+    } else if (inc.length === 1) {
+        primary = inc[0];
+    } else if (inc.length > 1) {
+        extras = inc.slice();
     }
 
-    var path = window.location.pathname;
-    // If user selected multiple include genres, go to /filmy-online/ with zanry= filter
-    // If only one include genre, go to its subpage /filmy-online/{slug}/
-    // Convert langs to backend format
-    // If user has both dub and sub checked → "vse", none → default (dub only), dub only → nothing, sub only → "sub"
-    var langParam = null;
-    if (langs.length === 0) {
-        langParam = 'vse';  // user explicitly deselected = show all
-    } else if (langs.length === 1 && langs[0] === 'dub') {
-        langParam = null;  // default
-    } else if (langs.length === 1) {
-        langParam = langs[0];  // sub
+    var u;
+    if (primary) {
+        u = new URL('/filmy-online/' + primary + '/', window.location.origin);
+        if (extras.length) u.searchParams.set('zanry', extras.join(','));
+        if (extras.length && rezim === 'and') u.searchParams.set('rezim', 'and');
     } else {
-        langParam = 'vse';  // both = all
+        u = new URL('/filmy-online/', window.location.origin);
+        if (extras.length > 1) u.searchParams.set('zanry', extras.join(','));
+        if (extras.length > 1 && rezim === 'and') u.searchParams.set('rezim', 'and');
     }
-
-    if (inc.length === 1) {
-        path = '/filmy-online/' + inc[0] + '/';
-        var u = new URL(path, window.location.origin);
-        if (exc.length) u.searchParams.set('bez', exc.join(','));
-        if (year) u.searchParams.set('rok', year);
-        if (langParam) u.searchParams.set('jazyk', langParam);
-        if (sort && sort !== 'pridano') u.searchParams.set('razeni', sort);
-        if (dir === 'asc') u.searchParams.set('smer', 'asc');
-        window.location = u.toString();
-        return;
-    }
-
-    // Multi-include or no include → listing page with filter
-    var u = new URL('/filmy-online/', window.location.origin);
-    if (inc.length > 1) u.searchParams.set('zanry', inc.join(','));
-    if (inc.length > 1 && rezim === 'and') u.searchParams.set('rezim', 'and');
     if (exc.length) u.searchParams.set('bez', exc.join(','));
     if (year) u.searchParams.set('rok', year);
     if (langParam) u.searchParams.set('jazyk', langParam);
-    if (sort && sort !== 'pridano') u.searchParams.set('razeni', sort);
-    if (dir === 'asc') u.searchParams.set('smer', 'asc');
+    if (sort && sort !== 'pridano:desc') u.searchParams.set('razeni', sort.split(':')[0]);
     window.location = u.toString();
 }
 
 function resetFilters() {
-    // Reset to current page (remove all query params)
-    window.location = window.location.pathname;
+    // Always return to the all-films listing (drop category + every query param)
+    window.location = '/filmy-online/';
 }
 
 /* --- Filter: prefill from URL + mutual exclusion + badge counter --- */
@@ -593,7 +603,6 @@ function resetFilters() {
     var incParam = urlParams.get('zanry');
     var excParam = urlParams.get('bez');
     var yearParam = urlParams.get('rok');
-    var langParam = urlParams.get('jazyk');
 
     if (incParam) {
         incParam.split(',').forEach(function(slug) {
@@ -616,20 +625,11 @@ function resetFilters() {
         var yrSel = document.getElementById('filter-year');
         if (yrSel) yrSel.value = yearParam;
     }
-    if (langParam) {
-        langParam.split(',').forEach(function(l) {
-            var cb = panel.querySelector('#filter-langs input[value="' + l + '"]');
-            if (cb) cb.checked = true;
-        });
-    }
-
     // Update filter toggle button with count of active filters
     function updateFilterBadge() {
         var checked = panel.querySelectorAll('input[type="checkbox"]:checked').length;
         var yr = document.getElementById('filter-year');
-        var lg = document.getElementById('filter-lang');
         if (yr && yr.value) checked++;
-        if (lg && lg.value) checked++;
 
         var btn = document.getElementById('btn-filter-toggle');
         if (btn) {
@@ -670,6 +670,50 @@ function resetFilters() {
         if (e.key === 'Enter') {
             e.preventDefault();
             applyFilters();
+        }
+    });
+})();
+
+/* --- Nice Czech tooltip + aria-label for genre chips --- */
+(function(){
+    var pretty = {
+        'akcni': 'Akční filmy',
+        'animovany': 'Animované filmy',
+        'dobrodruzny': 'Dobrodružné filmy',
+        'dokumentarni': 'Dokumentární filmy',
+        'drama': 'Dramata',
+        'fantasy': 'Fantasy filmy',
+        'historicky': 'Historické filmy',
+        'horor': 'Horory',
+        'hudebni': 'Hudební filmy',
+        'komedie': 'Komedie',
+        'krimi': 'Kriminální filmy',
+        'mysteriozni': 'Mysteriózní filmy',
+        'rodinny': 'Rodinné filmy',
+        'romanticky': 'Romantické filmy',
+        'sci-fi': 'Sci-Fi filmy',
+        'thriller': 'Thrillery',
+        'tv-film': 'Televizní filmy',
+        'valecny': 'Válečné filmy',
+        'western': 'Westerny'
+    };
+    var panel = document.getElementById('filter-panel');
+    var currentSlug = panel ? panel.getAttribute('data-current-genre') : null;
+    document.querySelectorAll('#filter-genres-include .filter-chip, #filter-genres-exclude .filter-chip').forEach(function(c){
+        var slug = null;
+        if (c.tagName === 'A') {
+            var m = c.getAttribute('href').match(/\/filmy-online\/([^\/]+)/);
+            if (m) slug = m[1];
+        } else if (c.classList.contains('current')) {
+            slug = currentSlug;
+        } else {
+            var input = c.querySelector('input');
+            if (input) slug = input.value;
+        }
+        var label = slug && pretty[slug];
+        if (label) {
+            c.title = label;
+            c.setAttribute('aria-label', label);
         }
     });
 })();

--- a/cr-web/templates/films_list.html
+++ b/cr-web/templates/films_list.html
@@ -136,7 +136,7 @@
                         <input type="radio" name="rezim" value="and">
                         <span>Všechny</span>
                     </label>
-                    <span class="help-icon" tabindex="0" onclick="this.classList.toggle('show')">?<span class="help-popup"><strong>Alespoň jeden:</strong> zobrazí filmy, které mají některý z&nbsp;vybraných žánrů.<br><strong>Všechny:</strong> zobrazí jen filmy, které mají všechny vybrané žánry současně.</span></span>
+                    <button type="button" class="help-icon" aria-label="Nápověda k režimu žánrů" onclick="this.classList.toggle('show')" onkeydown="if(event.key==='Enter'||event.key===' ')event.stopPropagation()">?<span class="help-popup"><strong>Alespoň jeden:</strong> zobrazí filmy, které mají některý z&nbsp;vybraných žánrů.<br><strong>Všechny:</strong> zobrazí jen filmy, které mají všechny vybrané žánry současně.</span></button>
                 </div>
                 {% else %}
                 <label>Vyberte žánr:</label>
@@ -155,7 +155,7 @@
         <div class="filter-section">
             <div class="filter-label-row">
                 <label>Vyloučit žánry:</label>
-                <span class="help-icon" tabindex="0" onclick="this.classList.toggle('show')">?<span class="help-popup"><strong>Vyloučit žánry:</strong> zaškrtnuté žánry nebudou mezi filmy zobrazeny. Například: pokud vyloučíte Horor, nezobrazí se žádné horory.</span></span>
+                <button type="button" class="help-icon" aria-label="Nápověda k vyloučení žánrů" onclick="this.classList.toggle('show')" onkeydown="if(event.key==='Enter'||event.key===' ')event.stopPropagation()">?<span class="help-popup"><strong>Vyloučit žánry:</strong> zaškrtnuté žánry nebudou mezi filmy zobrazeny. Například: pokud vyloučíte Horor, nezobrazí se žádné horory.</span></button>
             </div>
             <div class="filter-genres" id="filter-genres-exclude">
                 {% for g in genres %}
@@ -320,7 +320,7 @@ a.filter-chip-link:hover { background: #11457E; color: white; }
 .genre-mode .mode-option:hover { background: #e8e8e8; }
 .genre-mode .mode-option input { margin: 0; cursor: pointer; }
 .genre-mode .mode-option input:checked + span { font-weight: 600; color: #11457E; }
-.help-icon { position: relative; display: inline-flex; align-items: center; justify-content: center; width: 18px; height: 18px; border-radius: 50%; background: #888; color: white; font-size: 0.75rem; font-weight: 700; cursor: help; user-select: none; }
+.help-icon { position: relative; display: inline-flex; align-items: center; justify-content: center; width: 18px; height: 18px; border-radius: 50%; background: #888; color: white; font-size: 0.75rem; font-weight: 700; cursor: help; user-select: none; border: 0; padding: 0; font-family: inherit; line-height: 1; }
 .help-icon:hover, .help-icon:focus { background: #11457E; outline: none; }
 .help-icon .help-popup { display: none; position: absolute; top: 24px; right: 0; background: #222; color: white; padding: 0.6rem 0.8rem; border-radius: 6px; font-size: 0.75rem; font-weight: 400; width: 280px; max-width: 80vw; line-height: 1.4; z-index: 20; box-shadow: 0 4px 16px rgba(0,0,0,0.3); white-space: normal; text-align: left; }
 .help-icon.show .help-popup, .help-icon:hover .help-popup { display: block; }
@@ -584,7 +584,15 @@ function applyFilters() {
     if (exc.length) u.searchParams.set('bez', exc.join(','));
     if (year) u.searchParams.set('rok', year);
     if (langParam) u.searchParams.set('jazyk', langParam);
-    if (sort && sort !== 'pridano:desc') u.searchParams.set('razeni', sort.split(':')[0]);
+    if (sort && sort !== 'pridano:desc') {
+        var parts = sort.split(':');
+        u.searchParams.set('razeni', parts[0]);
+        if (parts[1] === 'asc') u.searchParams.set('smer', 'asc');
+        else u.searchParams.delete('smer');
+    } else {
+        u.searchParams.delete('razeni');
+        u.searchParams.delete('smer');
+    }
     window.location = u.toString();
 }
 

--- a/cr-web/templates/series_list.html
+++ b/cr-web/templates/series_list.html
@@ -122,7 +122,7 @@
                         <input type="radio" name="rezim" value="and">
                         <span>Všechny</span>
                     </label>
-                    <span class="help-icon" tabindex="0" onclick="this.classList.toggle('show')">?<span class="help-popup"><strong>Alespoň jeden:</strong> zobrazí seriály, které mají některý z&nbsp;vybraných žánrů.<br><strong>Všechny:</strong> zobrazí jen seriály, které mají všechny vybrané žánry současně.</span></span>
+                    <button type="button" class="help-icon" aria-label="Nápověda k režimu žánrů" onclick="this.classList.toggle('show')" onkeydown="if(event.key==='Enter'||event.key===' ')event.stopPropagation()">?<span class="help-popup"><strong>Alespoň jeden:</strong> zobrazí seriály, které mají některý z&nbsp;vybraných žánrů.<br><strong>Všechny:</strong> zobrazí jen seriály, které mají všechny vybrané žánry současně.</span></button>
                 </div>
                 {% else %}
                 <label>Vyberte žánr:</label>
@@ -141,7 +141,7 @@
         <div class="filter-section">
             <div class="filter-label-row">
                 <label>Vyloučit žánry:</label>
-                <span class="help-icon" tabindex="0" onclick="this.classList.toggle('show')">?<span class="help-popup"><strong>Vyloučit žánry:</strong> zaškrtnuté žánry nebudou mezi seriály zobrazeny. Například: pokud vyloučíte Horor, nezobrazí se žádné horory.</span></span>
+                <button type="button" class="help-icon" aria-label="Nápověda k vyloučení žánrů" onclick="this.classList.toggle('show')" onkeydown="if(event.key==='Enter'||event.key===' ')event.stopPropagation()">?<span class="help-popup"><strong>Vyloučit žánry:</strong> zaškrtnuté žánry nebudou mezi seriály zobrazeny. Například: pokud vyloučíte Horor, nezobrazí se žádné horory.</span></button>
             </div>
             <div class="filter-genres" id="filter-genres-exclude">
                 {% for g in genres %}
@@ -330,7 +330,7 @@ a.filter-chip-link:hover { background: #11457E; color: white; }
 .genre-mode .mode-option:hover { background: #e8e8e8; }
 .genre-mode .mode-option input { margin: 0; cursor: pointer; }
 .genre-mode .mode-option input:checked + span { font-weight: 600; color: #11457E; }
-.help-icon { position: relative; display: inline-flex; align-items: center; justify-content: center; width: 18px; height: 18px; border-radius: 50%; background: #888; color: white; font-size: 0.75rem; font-weight: 700; cursor: help; user-select: none; }
+.help-icon { position: relative; display: inline-flex; align-items: center; justify-content: center; width: 18px; height: 18px; border-radius: 50%; background: #888; color: white; font-size: 0.75rem; font-weight: 700; cursor: help; user-select: none; border: 0; padding: 0; font-family: inherit; line-height: 1; }
 .help-icon:hover, .help-icon:focus { background: #11457E; outline: none; }
 .help-icon .help-popup { display: none; position: absolute; top: 24px; right: 0; background: #222; color: white; padding: 0.6rem 0.8rem; border-radius: 6px; font-size: 0.75rem; font-weight: 400; width: 280px; max-width: 80vw; line-height: 1.4; z-index: 20; box-shadow: 0 4px 16px rgba(0,0,0,0.3); white-space: normal; text-align: left; }
 .help-icon.show .help-popup, .help-icon:hover .help-popup { display: block; }
@@ -541,7 +541,15 @@ function applyFilters() {
     }
     if (exc.length) u.searchParams.set('bez', exc.join(','));
     if (year) u.searchParams.set('rok', year);
-    if (sort && sort !== 'pridano:desc') u.searchParams.set('razeni', sort.split(':')[0]);
+    if (sort && sort !== 'pridano:desc') {
+        var parts = sort.split(':');
+        u.searchParams.set('razeni', parts[0]);
+        if (parts[1] === 'asc') u.searchParams.set('smer', 'asc');
+        else u.searchParams.delete('smer');
+    } else {
+        u.searchParams.delete('razeni');
+        u.searchParams.delete('smer');
+    }
     window.location = u.toString();
 }
 

--- a/cr-web/templates/series_list.html
+++ b/cr-web/templates/series_list.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
 
-{% block title %}{% match current_genre %}{% when Some with (g) %}{{ g.name_cs }} seriály online{% when None %}Seriály online{% endmatch %}{% endblock %}
+{% block title %}{% match current_genre %}{% when Some with (g) %}{{ g.pretty_plural() }} online{% when None %}Seriály online{% endmatch %}{% endblock %}
 
-{% block meta_description %}{% match current_genre %}{% when Some with (g) %}{{ g.name_cs }} seriály online zdarma — {{ total_count }} seriálů ke zhlédnutí.{% when None %}Seriály online zdarma — {{ total_count }} seriálů ke zhlédnutí na ceskarepublika.wiki.{% endmatch %}{% endblock %}
+{% block meta_description %}{% match current_genre %}{% when Some with (g) %}{{ g.pretty_plural() }} online zdarma — {{ total_count }} seriálů ke zhlédnutí.{% when None %}Seriály online zdarma — {{ total_count }} seriálů ke zhlédnutí na ceskarepublika.wiki.{% endmatch %}{% endblock %}
 
-{% block og_title %}{% match current_genre %}{% when Some with (g) %}{{ g.name_cs }} seriály online — ceskarepublika.wiki{% when None %}Seriály online — ceskarepublika.wiki{% endmatch %}{% endblock %}
-{% block og_description %}Seriály online zdarma — {{ total_count }} seriálů ke zhlédnutí.{% endblock %}
+{% block og_title %}{% match current_genre %}{% when Some with (g) %}{{ g.pretty_plural() }} online — ceskarepublika.wiki{% when None %}Seriály online — ceskarepublika.wiki{% endmatch %}{% endblock %}
+{% block og_description %}{% match current_genre %}{% when Some with (g) %}{{ g.pretty_plural() }} online zdarma. {{ total_count }} seriálů ke zhlédnutí přímo v prohlížeči, bez registrace.{% when None %}Seriály online zdarma — {{ total_count }} seriálů ke zhlédnutí přímo v prohlížeči, bez registrace. České i zahraniční seriály s českým dabingem nebo titulky.{% endmatch %}{% endblock %}
 {% block og_image %}https://ceskarepublika.wiki/static/img/og-filmy-a-serialy-v6.png{% endblock %}
 {% block og_type %}article{% endblock %}
 
@@ -22,17 +22,25 @@
 {% endblock %}
 
 {% block header_left %}
+{% match current_genre %}
+{% when Some with (_g) %}
+<a href="/serialy-online/" class="logo-group logo-link" style="display:flex;align-items:center;gap:0.5rem;">
+    <img src="/static/img/logo-filmy-a-serialy.svg?v=6"
+        alt="Logo Seriály online" title="Seriály online" class="header-emblem">
+    <span>Seriály online</span>
+</a>
+{% when None %}
 <div class="logo-group" style="display:flex;align-items:center;gap:0.5rem;">
-    <a href="/serialy-online/" style="display:flex;align-items:center;text-decoration:none;" alt="Seriály online" title="Seriály online">
-        <img src="/static/img/logo-filmy-a-serialy.svg?v=6" alt="Logo Seriály online" title="Seriály online" class="header-emblem">
-    </a>
-    <h1>{% match current_genre %}{% when Some with (g) %}{{ g.name_cs }}{% when None %}Seriály online{% endmatch %}</h1>
+    <img src="/static/img/logo-filmy-a-serialy.svg?v=6"
+        alt="Logo Seriály online" title="Seriály online" class="header-emblem">
+    <h1>Seriály online</h1>
 </div>
+{% endmatch %}
 {% endblock %}
 
 {% block header_search %}
 <div class="search-container" id="header-search-box">
-    <input type="text" id="series-search" class="search-input" placeholder="Hledat seriál..." autocomplete="off" {% match search_query %}{% when Some with (q) %}value="{{ q }}"{% when None %}{% endmatch %}>
+    <input type="text" id="series-search" class="search-input" placeholder="Hledat seriál..." autocomplete="off"{% match search_query %}{% when Some with (q) %} value="{{ q }}"{% when None %}{% endmatch %}>
     <button class="search-btn" onclick="doSearch()">Hledat</button>
     <div id="search-results" class="search-dropdown"></div>
 </div>
@@ -42,164 +50,226 @@
 
 {% block content %}
 <main class="series-page">
-<nav class="breadcrumb">
-    <a href="/" alt="Česká republika" title="Česká republika">Česká republika</a>
-    <span>›</span> <a href="/serialy-online/" alt="Seriály online" title="Seriály online">Seriály online</a>
-    {% match current_genre %}
-    {% when Some with (g) %}
-    <span>›</span> <span>{{ g.name_cs }}</span>
-    {% when None %}
-    {% endmatch %}
-</nav>
+    {# Breadcrumb — on subcategory ends at a link to Seriály online (no trailing genre) #}
+    <nav class="breadcrumb">
+        <a href="/">Česká republika</a>
+        <span>›</span>
+        {% match current_genre %}
+        {% when Some with (g) %}
+        <a href="/serialy-online/">Seriály online</a>
+        {% when None %}
+        <span>Seriály online</span>
+        {% endmatch %}
+    </nav>
 
-<div class="films-header">
-    <h2>
+    <div class="films-header">
         {% match search_query %}
-        {% when Some with (q) %}Výsledky hledání pro „{{ q }}" <span class="count">({{ total_count }})</span>
+        {% when Some with (q) %}
+        <h2>Výsledky hledání pro „{{ q }}" <span class="count">({{ total_count }})</span></h2>
         {% when None %}
             {% match current_genre %}
-            {% when Some with (g) %}{{ g.name_cs }} <span class="count">({{ total_count }})</span>
-            {% when None %}Nejnovější epizody z {{ total_count }} seriálů
+            {% when Some with (g) %}
+            <h1>{{ g.pretty_plural() }}<span class="online-word"> online</span> <span class="count">({{ total_count }})</span></h1>
+            {% when None %}
+            <h2>Nejnovější epizody z {{ total_count }} seriálů<span class="online-word"> online</span></h2>
             {% endmatch %}
         {% endmatch %}
-    </h2>
-    <div class="films-toolbar">
-        <label class="toolbar-group">
-            <span class="toolbar-label">Řazení:</span>
-            <select id="sort-select" onchange="applySortCombined(this.value)" aria-label="Řazení" class="sort-select-combined">
-                <option value="pridano:desc">Naposledy přidané</option>
-                <option value="rok:desc">Od nejnovějších</option>
-                <option value="imdb:desc">Nejlépe hodnocené IMDB</option>
-                <option value="nazev:asc">Podle názvu A–Z</option>
-            </select>
-        </label>
-        <button class="view-btn view-toggle" id="btn-view-toggle" onclick="toggleView()" aria-label="Přepnout zobrazení mřížka / seznam">
-            <svg class="view-icon-grid" width="18" height="18" viewBox="0 0 18 18"><rect x="1" y="2" width="16" height="3" rx="1" fill="currentColor"/><rect x="1" y="7.5" width="16" height="3" rx="1" fill="currentColor"/><rect x="1" y="13" width="16" height="3" rx="1" fill="currentColor"/></svg>
-            <svg class="view-icon-list" width="18" height="18" viewBox="0 0 18 18" style="display:none;"><rect x="1" y="1" width="7" height="7" rx="1" fill="currentColor"/><rect x="10" y="1" width="7" height="7" rx="1" fill="currentColor"/><rect x="1" y="10" width="7" height="7" rx="1" fill="currentColor"/><rect x="10" y="10" width="7" height="7" rx="1" fill="currentColor"/></svg>
-        </button>
+        <div class="films-toolbar">
+            <label class="toolbar-group">
+                <span class="toolbar-label">Řazení:</span>
+                <select id="sort-select" onchange="applySortCombined(this.value)" title="Řazení seriálů" class="sort-select-combined">
+                    <optgroup label="Podle přidání">
+                        <option value="pridano:desc">Naposledy přidané</option>
+                        <option value="pridano:asc">Nejdříve přidané</option>
+                    </optgroup>
+                    <optgroup label="Podle roku vydání">
+                        <option value="rok:desc">Od nejnovějších</option>
+                        <option value="rok:asc">Od nejstarších</option>
+                    </optgroup>
+                    <optgroup label="Podle hodnocení IMDB">
+                        <option value="imdb:desc">Nejlépe hodnocené první</option>
+                        <option value="imdb:asc">Nejhůře hodnocené první</option>
+                    </optgroup>
+                    <optgroup label="Podle abecedy">
+                        <option value="nazev:asc">Podle názvu A–Z</option>
+                        <option value="nazev:desc">Podle názvu Z–A</option>
+                    </optgroup>
+                </select>
+            </label>
+            <button class="view-btn view-toggle" id="btn-view-toggle" onclick="toggleView()" title="Přepnout na zobrazení seznamem" aria-label="Zobrazení">
+                <svg class="view-icon-grid" width="18" height="18" viewBox="0 0 18 18"><rect x="1" y="2" width="16" height="3" rx="1" fill="currentColor"/><rect x="1" y="7.5" width="16" height="3" rx="1" fill="currentColor"/><rect x="1" y="13" width="16" height="3" rx="1" fill="currentColor"/></svg>
+                <svg class="view-icon-list" width="18" height="18" viewBox="0 0 18 18" style="display:none;"><rect x="1" y="1" width="7" height="7" rx="1" fill="currentColor"/><rect x="10" y="1" width="7" height="7" rx="1" fill="currentColor"/><rect x="1" y="10" width="7" height="7" rx="1" fill="currentColor"/><rect x="10" y="10" width="7" height="7" rx="1" fill="currentColor"/></svg>
+            </button>
+            <button class="view-btn" id="btn-filter-toggle" onclick="toggleFilter()" title="{% match current_genre %}{% when Some with (_g) %}Upřesnit nebo zrušit filtr{% when None %}Filtrování{% endmatch %}">
+                <svg width="18" height="18" viewBox="0 0 18 18"><path d="M1 3h16M4 9h10M7 15h4" stroke="currentColor" stroke-width="2" stroke-linecap="round" fill="none"/></svg>
+            </button>
+        </div>
     </div>
-</div>
 
-<nav class="genre-nav">
-    {% if current_genre.is_none() %}
-    <span class="genre-tag current">Vše</span>
-    {% else %}
-    <a href="/serialy-online/" class="genre-tag" alt="Všechny seriály" title="Všechny seriály">Vše</a>
-    {% endif %}
-    {% for g in genres %}
-    {% match current_genre %}{% when Some with (cg) %}{% if cg.id == g.id %}
-    <span class="genre-tag current">{{ g.name_cs }}</span>
-    {% else %}
-    <a href="/serialy-online/{{ g.slug }}/" class="genre-tag" alt="{{ g.name_cs }} seriály" title="{{ g.name_cs }} seriály">{{ g.name_cs }}</a>
-    {% endif %}{% when None %}
-    <a href="/serialy-online/{{ g.slug }}/" class="genre-tag" alt="{{ g.name_cs }} seriály" title="{{ g.name_cs }} seriály">{{ g.name_cs }}</a>
-    {% endmatch %}
-    {% endfor %}
-</nav>
-
-{# Main grid: episodes (default) or series (search mode) #}
-{% if !episodes.is_empty() %}
-<div class="films-grid" id="films-container">
-    {% for ep in episodes %}
-    <a href="/serialy-online/{{ ep.series_slug }}/{% match ep.episode_slug %}{% when Some with (s) %}{{ s }}{% when None %}{{ ep.season }}x{{ ep.episode }}{% endmatch %}/" class="film-card" title="{{ ep.series_title }} — S{{ ep.season }}E{{ ep.episode }}">
-        <div class="film-poster">
-            {% match ep.series_cover_filename %}
-            {% when Some with (c) %}
-            <img src="/serialy-online/{{ ep.series_slug }}.webp" alt="{{ ep.series_title }}" title="{{ ep.series_title }}" loading="lazy" width="200" height="300">
-            {% when None %}
-            <div class="no-poster">{{ ep.series_title }}</div>
-            {% endmatch %}
-            <div class="rating-badges">
-                {% match ep.series_imdb_rating %}
-                {% when Some with (r) %}<span class="rating-badge imdb" title="IMDB hodnocení">{{ r }}</span>{% when None %}{% endmatch %}
-                {% match ep.series_csfd_rating %}
-                {% when Some with (r) %}<span class="rating-badge csfd" title="ČSFD hodnocení">{{ r }}%</span>{% when None %}{% endmatch %}
-            </div>
-            {% if ep.has_subtitles.unwrap_or(false) %}
-            <span class="cc-badge" title="České titulky">CC</span>
-            {% endif %}
-        </div>
-        <div class="film-body">
-            <div class="film-info">
-                <span class="film-title">{{ ep.series_title }}</span>
-                {% match ep.series_original_title %}{% when Some with (ot) %}{% if ot.as_str() != ep.series_title.as_str() %}<span class="film-original">{{ ot }}</span>{% endif %}{% when None %}{% endmatch %}
-                <span class="film-episode-label">{% match ep.episode_name %}{% when Some with (n) %}{% if !n.is_empty() && !n.starts_with(char::is_numeric) %}{{ n }} {% endif %}{% when None %}{% endmatch %}S{{ "{:02}"|format(ep.season) }}E{{ "{:02}"|format(ep.episode) }}</span>
-            </div>
-            <div class="film-list-extra">
-                <div class="film-ratings">
-                    {% match ep.series_imdb_rating %}{% when Some with (r) %}<span class="badge imdb">IMDB {{ r }}</span>{% when None %}{% endmatch %}
-                    {% match ep.series_csfd_rating %}{% when Some with (r) %}<span class="badge csfd">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
-                    {% match ep.series_first_air_year %}{% when Some with (y) %}<span class="badge year">{{ y }}</span>{% when None %}{% endmatch %}
+    {# Advanced filter panel — hidden by default, auto-opens when landing on subcategory from main listing #}
+    <div class="filter-panel" id="filter-panel" style="display:{% if open_filter %}block{% else %}none{% endif %};"
+         {% match current_genre %}{% when Some with (cg) %}data-current-genre="{{ cg.slug }}"{% when None %}{% endmatch %}>
+        <div class="filter-section">
+            <div class="filter-label-row">
+                {% if self.is_multi_filter_mode() %}
+                <label>Zahrnout žánry:</label>
+                <div class="genre-mode">
+                    <label class="mode-option">
+                        <input type="radio" name="rezim" value="or" checked>
+                        <span>Alespoň jeden</span>
+                    </label>
+                    <label class="mode-option">
+                        <input type="radio" name="rezim" value="and">
+                        <span>Všechny</span>
+                    </label>
+                    <span class="help-icon" tabindex="0" onclick="this.classList.toggle('show')">?<span class="help-popup"><strong>Alespoň jeden:</strong> zobrazí seriály, které mají některý z&nbsp;vybraných žánrů.<br><strong>Všechny:</strong> zobrazí jen seriály, které mají všechny vybrané žánry současně.</span></span>
                 </div>
-                {% match ep.series_description %}{% when Some with (d) %}<p class="film-desc">{{ d }}</p>{% when None %}{% endmatch %}
+                {% else %}
+                <label>Vyberte žánr:</label>
+                {% endif %}
+            </div>
+            <div class="filter-genres" id="filter-genres-include">
+                {% for g in genres %}
+                {% if self.is_multi_filter_mode() %}
+                <label class="filter-chip{% if self.is_current_genre(g) %} current{% endif %}"{% if self.is_current_genre(g) %} aria-current="page"{% endif %}><input type="checkbox" value="{{ g.slug }}" data-filter="include"{% if self.is_current_genre(g) || self.is_selected(g.slug.as_str()) %} checked{% endif %}> {{ g.name_cs }}</label>
+                {% else %}
+                <a class="filter-chip filter-chip-link" href="/serialy-online/{{ g.slug }}/">{{ g.name_cs }}</a>
+                {% endif %}
+                {% endfor %}
             </div>
         </div>
-    </a>
-    {% endfor %}
-</div>
-{% else %}
-<div class="films-grid" id="films-container">
-    {% for s in series %}
-    <a href="/serialy-online/{{ s.slug }}/" class="film-card" alt="{{ s.title }}" title="{{ s.title }}">
-        <div class="film-poster">
-            {% match s.cover_filename %}
-            {% when Some with (cover) %}
-            <img src="/serialy-online/{{ s.slug }}.webp" alt="{{ s.title }}" title="{{ s.title }}" loading="lazy" width="200" height="300">
-            {% when None %}
-            <div class="no-poster">{{ s.title }}</div>
-            {% endmatch %}
-            <div class="rating-badges">
-                {% match s.imdb_rating %}{% when Some with (r) %}<span class="rating-badge imdb" title="IMDB hodnocení">{{ r }}</span>{% when None %}{% endmatch %}
-                {% match s.csfd_rating %}{% when Some with (r) %}<span class="rating-badge csfd" title="ČSFD hodnocení">{{ r }}%</span>{% when None %}{% endmatch %}
+        <div class="filter-section">
+            <div class="filter-label-row">
+                <label>Vyloučit žánry:</label>
+                <span class="help-icon" tabindex="0" onclick="this.classList.toggle('show')">?<span class="help-popup"><strong>Vyloučit žánry:</strong> zaškrtnuté žánry nebudou mezi seriály zobrazeny. Například: pokud vyloučíte Horor, nezobrazí se žádné horory.</span></span>
+            </div>
+            <div class="filter-genres" id="filter-genres-exclude">
+                {% for g in genres %}
+                {% match current_genre %}
+                {% when Some with (cg) %}{% if cg.id != g.id %}<label class="filter-chip exclude"><input type="checkbox" value="{{ g.slug }}" data-filter="exclude"> {{ g.name_cs }}</label>{% endif %}
+                {% when None %}<label class="filter-chip exclude"><input type="checkbox" value="{{ g.slug }}" data-filter="exclude"> {{ g.name_cs }}</label>
+                {% endmatch %}
+                {% endfor %}
             </div>
         </div>
-        <div class="film-body">
-            <div class="film-info">
-                <span class="film-title">{{ s.title }}</span>
-                {% match s.original_title %}{% when Some with (ot) %}{% if ot.as_str() != s.title.as_str() %}<span class="film-original">{{ ot }}</span>{% endif %}{% when None %}{% endmatch %}
-                {% match s.first_air_year %}{% when Some with (y) %}<span class="film-year">{{ y }}</span>{% when None %}{% endmatch %}
-            </div>
-            <div class="film-list-extra">
-                <div class="film-ratings">
-                    {% match s.imdb_rating %}{% when Some with (r) %}<span class="badge imdb">IMDB {{ r }}</span>{% when None %}{% endmatch %}
-                    {% match s.csfd_rating %}{% when Some with (r) %}<span class="badge csfd">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
-                </div>
-                {% match s.description %}{% when Some with (d) %}<p class="film-desc">{{ d }}</p>{% when None %}{% endmatch %}
-            </div>
+        <div class="filter-section">
+            <label for="filter-year">Rok vydání:</label>
+            <select id="filter-year">
+                <option value="">Všechny roky</option>
+            </select>
         </div>
-    </a>
-    {% endfor %}
-</div>
-{% endif %}
+        <div class="filter-actions">
+            <button class="btn-apply" onclick="applyFilters()">Použít filtr</button>
+            <button class="btn-reset" onclick="resetFilters()">Zrušit filtry</button>
+        </div>
+    </div>
 
-{% if total_pages > 1 %}
-<nav class="pagination">
-    {% if page > 1 %}
-    <a href="?strana={{ page - 1 }}{{ query_string }}" class="page-link" alt="Předchozí stránka" title="Předchozí stránka">&laquo;</a>
-    {% endif %}
-    {% for p in 1..=total_pages %}
-    {% if p == page %}
-    <span class="page-link current">{{ p }}</span>
+    {# Main grid: episodes (default) or series (search mode) #}
+    {% if !episodes.is_empty() %}
+    <div class="films-grid" id="films-container">
+        {% for ep in episodes %}
+        <a href="/serialy-online/{{ ep.series_slug }}/{% match ep.episode_slug %}{% when Some with (s) %}{{ s }}{% when None %}{{ ep.season }}x{{ ep.episode }}{% endmatch %}/" class="film-card" title="{{ ep.series_title }} — S{{ ep.season }}E{{ ep.episode }}">
+            <div class="film-poster">
+                {% match ep.series_cover_filename %}
+                {% when Some with (c) %}
+                <img src="/serialy-online/{{ ep.series_slug }}.webp" alt="{{ ep.series_title }}" title="{{ ep.series_title }}" loading="lazy" width="200" height="300">
+                {% when None %}
+                <div class="no-poster">{{ ep.series_title }}</div>
+                {% endmatch %}
+                <div class="rating-badges">
+                    {% match ep.series_imdb_rating %}
+                    {% when Some with (r) %}<span class="rating-badge imdb" title="IMDB hodnocení">{{ r }}</span>{% when None %}{% endmatch %}
+                    {% match ep.series_csfd_rating %}
+                    {% when Some with (r) %}<span class="rating-badge csfd" title="ČSFD hodnocení">{{ r }}%</span>{% when None %}{% endmatch %}
+                </div>
+                {% if ep.has_subtitles.unwrap_or(false) %}
+                <span class="cc-badge" title="České titulky">CC</span>
+                {% endif %}
+            </div>
+            <div class="film-body">
+                <div class="film-info">
+                    <span class="film-title">{{ ep.series_title }}</span>
+                    {% match ep.series_original_title %}{% when Some with (ot) %}{% if ot.as_str() != ep.series_title.as_str() %}<span class="film-original">{{ ot }}</span>{% endif %}{% when None %}{% endmatch %}
+                    <span class="film-episode-label">{% match ep.episode_name %}{% when Some with (n) %}{% if !n.is_empty() && !n.starts_with(char::is_numeric) %}{{ n }} {% endif %}{% when None %}{% endmatch %}S{{ "{:02}"|format(ep.season) }}E{{ "{:02}"|format(ep.episode) }}</span>
+                </div>
+                <div class="film-list-extra">
+                    <div class="film-ratings">
+                        {% match ep.series_imdb_rating %}{% when Some with (r) %}<span class="badge imdb">IMDB {{ r }}</span>{% when None %}{% endmatch %}
+                        {% match ep.series_csfd_rating %}{% when Some with (r) %}<span class="badge csfd">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
+                        {% match ep.series_first_air_year %}{% when Some with (y) %}<span class="badge year">{{ y }}</span>{% when None %}{% endmatch %}
+                        {% for sg in self.series_genres(ep.series_id) %}<span class="genre-tag">{{ sg.name_cs }}</span>{% endfor %}
+                    </div>
+                    {% match ep.series_description %}{% when Some with (d) %}<p class="film-desc">{{ d }}</p>{% when None %}{% endmatch %}
+                </div>
+            </div>
+        </a>
+        {% endfor %}
+    </div>
     {% else %}
-    {% if p <= 2 || p > total_pages - 2 || (p >= page - 2 && p <= page + 2) %}
-    <a href="?strana={{ p }}{{ query_string }}" class="page-link" alt="Strana {{ p }}" title="Strana {{ p }}">{{ p }}</a>
-    {% else %}
-    {% if p == 3 && page > 5 %}<span class="page-dots">…</span>{% endif %}
-    {% if p == total_pages - 2 && page < total_pages - 4 %}<span class="page-dots">…</span>{% endif %}
+    <div class="films-grid" id="films-container">
+        {% for s in series %}
+        <a href="/serialy-online/{{ s.slug }}/" class="film-card" title="{{ s.title }}">
+            <div class="film-poster">
+                {% match s.cover_filename %}
+                {% when Some with (cover) %}
+                <img src="/serialy-online/{{ s.slug }}.webp" alt="{{ s.title }}" title="{{ s.title }}" loading="lazy" width="200" height="300">
+                {% when None %}
+                <div class="no-poster">{{ s.title }}</div>
+                {% endmatch %}
+                <div class="rating-badges">
+                    {% match s.imdb_rating %}{% when Some with (r) %}<span class="rating-badge imdb" title="IMDB hodnocení">{{ r }}</span>{% when None %}{% endmatch %}
+                    {% match s.csfd_rating %}{% when Some with (r) %}<span class="rating-badge csfd" title="ČSFD hodnocení">{{ r }}%</span>{% when None %}{% endmatch %}
+                </div>
+            </div>
+            <div class="film-body">
+                <div class="film-info">
+                    <span class="film-title">{{ s.title }}</span>
+                    {% match s.original_title %}{% when Some with (ot) %}{% if ot.as_str() != s.title.as_str() %}<span class="film-original">{{ ot }}</span>{% endif %}{% when None %}{% endmatch %}
+                    {% match s.first_air_year %}{% when Some with (y) %}<span class="film-year">{{ y }}</span>{% when None %}{% endmatch %}
+                </div>
+                <div class="film-list-extra">
+                    <div class="film-ratings">
+                        {% match s.imdb_rating %}{% when Some with (r) %}<span class="badge imdb">IMDB {{ r }}</span>{% when None %}{% endmatch %}
+                        {% match s.csfd_rating %}{% when Some with (r) %}<span class="badge csfd">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
+                        {% match s.first_air_year %}{% when Some with (y) %}<span class="badge year">{{ y }}</span>{% when None %}{% endmatch %}
+                        {% for sg in self.series_genres(s.id) %}<span class="genre-tag">{{ sg.name_cs }}</span>{% endfor %}
+                    </div>
+                    {% match s.description %}{% when Some with (d) %}<p class="film-desc">{{ d }}</p>{% when None %}{% endmatch %}
+                </div>
+            </div>
+        </a>
+        {% endfor %}
+    </div>
     {% endif %}
+
+    {% if total_pages > 1 %}
+    <nav class="pagination">
+        {% if page > 1 %}
+        <a href="?strana={{ page - 1 }}{{ query_string }}" class="page-link">&laquo;</a>
+        {% endif %}
+        {% for p in 1..=total_pages %}
+        {% if p == page %}
+        <span class="page-link current">{{ p }}</span>
+        {% else %}
+        {% if p <= 2 || p > total_pages - 2 || (p >= page - 2 && p <= page + 2) %}
+        <a href="?strana={{ p }}{{ query_string }}" class="page-link">{{ p }}</a>
+        {% else %}
+        {% if p == 3 && page > 5 %}<span class="page-dots">…</span>{% endif %}
+        {% if p == total_pages - 2 && page < total_pages - 4 %}<span class="page-dots">…</span>{% endif %}
+        {% endif %}
+        {% endif %}
+        {% endfor %}
+        {% if page < total_pages %}
+        <a href="?strana={{ page + 1 }}{{ query_string }}" class="page-link">&raquo;</a>
+        {% endif %}
+    </nav>
     {% endif %}
-    {% endfor %}
-    {% if page < total_pages %}
-    <a href="?strana={{ page + 1 }}{{ query_string }}" class="page-link" alt="Další stránka" title="Další stránka">&raquo;</a>
-    {% endif %}
-</nav>
-{% endif %}
 </main>
 
 <style>
 .series-page { max-width: 1200px; margin: 0 auto; padding: 1rem; }
 
-/* Search dropdown */
+/* --- Search: override base overflow:hidden to allow dropdown --- */
 #header-search-box { position: relative; overflow: visible !important; }
 .search-dropdown { display: none; position: absolute; top: calc(100% + 4px); left: 0; right: 0; background: white; border: 1px solid #ddd; border-radius: 12px; box-shadow: 0 8px 24px rgba(0,0,0,0.18); z-index: 200; max-height: 420px; overflow-y: auto; }
 .search-dropdown.open { display: block; }
@@ -212,29 +282,84 @@
 .search-item .si-title { font-weight: 500; display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .search-item .si-meta { font-size: 0.8rem; color: #888; }
 
-/* Header + toolbar */
-.breadcrumb { font-size: 0.85rem; color: #888; margin: 0.5rem 0 1rem; }
-.breadcrumb a { color: #11457E; text-decoration: none; }
+/* --- Header + toolbar --- */
 .films-header { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 0.8rem; }
-.films-header h2 { margin: 0; font-size: 1.3rem; }
+.films-header h1, .films-header h2 { margin: 0; font-size: 1.3rem; font-weight: 700; }
 .films-header .count { color: #888; font-weight: 400; }
-.films-toolbar { display: flex; align-items: center; gap: 0.4rem; }
-.toolbar-group { display: inline-flex; align-items: center; gap: 0.4rem; }
-.toolbar-label { font-size: 0.82rem; color: #555; font-weight: 500; }
-.sort-select-combined { padding: 0.4rem 0.7rem; border: 1px solid #ddd; border-radius: 6px; font-size: 0.85rem; cursor: pointer; background: white; min-width: 200px; }
-.view-btn { background: #f0f0f0; border: none; padding: 0.4rem; border-radius: 6px; cursor: pointer; color: #666; display: flex; align-items: center; transition: background 0.15s; }
+.logo-link { text-decoration: none; color: inherit; cursor: pointer; }
+.logo-link:hover span { text-decoration: underline; }
+.logo-link, .logo-link * { cursor: pointer; }
+@media (max-width: 360px) { .online-word { display: none; } }
+.films-toolbar { display: flex; align-items: center; gap: 0.4rem; flex-wrap: wrap; }
+.films-toolbar select { padding: 0.3rem 0.5rem; border: 1px solid #ddd; border-radius: 6px; font-size: 0.85rem; background: white; cursor: pointer; }
+@media (max-width: 520px) {
+    .films-header h1, .films-header h2 { font-size: 1.1rem; }
+    .films-toolbar { gap: 0.3rem; }
+    .toolbar-group { margin-right: 0; gap: 0.25rem; }
+    .sort-select-combined { min-width: 0; padding-left: 0.4rem; padding-right: 0.4rem; max-width: 150px; }
+}
+.view-btn { background: #f0f0f0; border: none; padding: 0.4rem; border-radius: 6px; cursor: pointer; color: #666; transition: background 0.2s, color 0.2s; display: flex; align-items: center; }
 .view-btn:hover { background: #e0e0e0; }
-.view-toggle { background: #f1f5f9; color: #555; border-radius: 6px; padding: 0.4rem 0.7rem; }
+.view-btn.active { background: #D7141A; color: white; }
 
-/* Genre tags */
-.genre-nav { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-bottom: 1.2rem; }
-.genre-tag { display: inline-flex; align-items: center; padding: 0.4rem 0.9rem; border-radius: 999px; background: #f1f5f9; color: #11457E; text-decoration: none; font-size: 0.85rem; font-weight: 600; transition: background 0.15s, color 0.15s; cursor: pointer; }
-.genre-tag:hover { background: #11457E; color: white; }
-.genre-tag.current { background: #C5A059; color: white; cursor: default; }
+/* --- Filter panel --- */
+.filter-panel { background: #f8f8f8; border: 1px solid #e0e0e0; border-radius: 12px; padding: 1rem 1.2rem; margin-bottom: 1rem; }
+.filter-section { margin-bottom: 0.8rem; }
+.filter-section > label { display: block; font-weight: 600; font-size: 0.85rem; color: #555; margin-bottom: 0.4rem; }
+.filter-genres { display: flex; flex-wrap: wrap; gap: 0.3rem; }
+.filter-chip { display: inline-flex; align-items: center; gap: 0.25rem; padding: 0.3rem 0.8rem; border-radius: 999px; background: #f1f5f9; border: 1px solid transparent; color: #555; font-size: 0.82rem; cursor: pointer; transition: all 0.15s; user-select: none; text-decoration: none; }
+.filter-chip:hover { background: #e2e8f0; color: #333; }
+.filter-chip:has(input:checked) { background: #C5A059; color: white; border-color: #C5A059; font-weight: 600; }
+.filter-chip input { display: none; }
+.filter-chip-link { color: #11457E; font-weight: 600; }
+a.filter-chip-link:hover { background: #11457E; color: white; }
+.filter-chip.current { outline: 2px solid #11457E; outline-offset: 2px; }
+.filter-actions { display: flex; gap: 0.5rem; margin-top: 0.5rem; }
+.btn-apply { padding: 0.4rem 1.2rem; background: #D7141A; color: white; border: none; border-radius: 6px; font-size: 0.85rem; cursor: pointer; font-weight: 600; transition: background 0.2s; }
+.btn-apply:hover { background: #11457E; }
+.btn-reset { padding: 0.4rem 1rem; background: #f0f0f0; color: #333; border: none; border-radius: 6px; font-size: 0.85rem; cursor: pointer; }
+.btn-reset:hover { background: #e0e0e0; }
 
-/* Films grid (cards) */
-.films-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 1rem; }
-.films-grid .film-card { text-decoration: none; color: inherit; display: block; border-radius: 8px; overflow: hidden; background: white; box-shadow: 0 1px 4px rgba(0,0,0,0.1); transition: transform 0.15s, box-shadow 0.15s; }
+#btn-filter-toggle { position: relative; }
+#btn-filter-toggle .filter-count { position: absolute; top: -5px; right: -5px; background: #D7141A; color: white; font-size: 0.65rem; font-weight: 700; min-width: 16px; height: 16px; border-radius: 50%; display: flex; align-items: center; justify-content: center; padding: 0 3px; box-shadow: 0 1px 3px rgba(0,0,0,0.2); }
+
+.filter-label-row { display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 0.4rem; }
+.filter-label-row > label { margin-bottom: 0 !important; }
+.genre-mode { display: flex; align-items: center; gap: 0.5rem; font-size: 0.8rem; }
+.genre-mode .mode-option { display: inline-flex; align-items: center; gap: 0.25rem; cursor: pointer; padding: 0.2rem 0.5rem; border-radius: 4px; transition: background 0.15s; }
+.genre-mode .mode-option:hover { background: #e8e8e8; }
+.genre-mode .mode-option input { margin: 0; cursor: pointer; }
+.genre-mode .mode-option input:checked + span { font-weight: 600; color: #11457E; }
+.help-icon { position: relative; display: inline-flex; align-items: center; justify-content: center; width: 18px; height: 18px; border-radius: 50%; background: #888; color: white; font-size: 0.75rem; font-weight: 700; cursor: help; user-select: none; }
+.help-icon:hover, .help-icon:focus { background: #11457E; outline: none; }
+.help-icon .help-popup { display: none; position: absolute; top: 24px; right: 0; background: #222; color: white; padding: 0.6rem 0.8rem; border-radius: 6px; font-size: 0.75rem; font-weight: 400; width: 280px; max-width: 80vw; line-height: 1.4; z-index: 20; box-shadow: 0 4px 16px rgba(0,0,0,0.3); white-space: normal; text-align: left; }
+.help-icon.show .help-popup, .help-icon:hover .help-popup { display: block; }
+
+/* Combined sort select (field + direction) */
+.sort-select-combined { padding: 0.4rem 0.7rem; border: 1px solid #ddd; border-radius: 6px; font-size: 0.85rem; cursor: pointer; background: white; min-width: 200px; }
+.sort-select-combined:focus { outline: 1px solid #11457E; }
+
+.toolbar-group { display: inline-flex; align-items: center; gap: 0.4rem; margin-right: 0.5rem; }
+.toolbar-label { font-size: 0.82rem; color: #555; font-weight: 500; }
+.view-toggle { background: #f1f5f9; color: #555; border: none; border-radius: 6px; padding: 0.4rem 0.7rem; cursor: pointer; transition: all 0.15s; display: inline-flex; align-items: center; }
+.view-toggle:hover { background: #e2e8f0; }
+
+/* --- Breadcrumb --- */
+.breadcrumb { font-size: 0.85rem; color: #888; margin-bottom: 0.8rem; }
+.breadcrumb a { color: #11457E; text-decoration: none; }
+.breadcrumb a:hover { text-decoration: underline; }
+
+/* --- Grid view --- */
+.films-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); gap: 0.7rem; }
+@media (min-width: 520px) { .films-grid { grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 1rem; } }
+@media (min-width: 768px) { .films-grid { grid-template-columns: repeat(auto-fill, minmax(165px, 1fr)); } }
+/* Very narrow screens (e.g. Z Fold outer): single column, don't let cover fill whole screen */
+@media (max-width: 360px) {
+    .films-grid { grid-template-columns: 1fr; gap: 0.6rem; }
+    .films-grid > .film-card { max-width: 240px; margin-left: auto; margin-right: auto; width: 100%; }
+}
+
+.film-card { text-decoration: none; color: inherit; display: block; border-radius: 8px; overflow: hidden; background: white; box-shadow: 0 1px 4px rgba(0,0,0,0.1); transition: transform 0.15s, box-shadow 0.15s; }
 .films-grid .film-card:hover { transform: translateY(-2px); box-shadow: 0 4px 12px rgba(0,0,0,0.15); }
 .film-poster { aspect-ratio: 2/3; background: #222; position: relative; }
 .film-poster img { width: 100%; height: 100%; object-fit: cover; display: block; }
@@ -259,14 +384,33 @@
 .badge.year { background: #e2e8f0; color: #333; }
 .film-desc { font-size: 0.8rem; color: #555; margin: 0.3rem 0 0; display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
 
-/* List view — rows instead of grid */
-.films-grid.list-view { grid-template-columns: 1fr; }
-.films-grid.list-view .film-card { display: grid; grid-template-columns: 120px 1fr; }
-.films-grid.list-view .film-poster { aspect-ratio: 2/3; max-width: 120px; }
-.films-grid.list-view .film-body { padding: 0.8rem 1rem; }
+/* --- List view --- */
+.films-grid.list-view { grid-template-columns: 1fr; gap: 0.6rem; }
+.films-grid.list-view .film-card { display: flex; gap: 1rem; align-items: flex-start; padding: 0.6rem; background: #fafafa; border-radius: 10px; border: 1px solid #eee; }
+.films-grid.list-view .film-card:hover { transform: none; box-shadow: 0 2px 8px rgba(0,0,0,0.08); }
+.films-grid.list-view .film-poster { width: 100px; min-width: 100px; flex-shrink: 0; border-radius: 6px; aspect-ratio: 2/3; max-width: 100px; }
+.films-grid.list-view .rating-badges { display: none; }
+.films-grid.list-view .film-body { display: flex; flex-direction: column; flex: 1; min-width: 0; padding: 0.2rem 0; }
+.films-grid.list-view .film-info { padding: 0; }
+.films-grid.list-view .film-title { font-size: 1.05rem; font-weight: 600; white-space: normal; }
+.films-grid.list-view .film-original { display: inline; font-size: 0.82rem; color: #888; font-style: italic; margin-left: 0.5rem; }
 .films-grid.list-view .film-list-extra { display: block; }
+.films-grid.list-view .film-ratings { display: flex; gap: 0.35rem; flex-wrap: wrap; align-items: center; margin: 0.4rem 0; }
+.film-ratings .genre-tag { display: none; }
+.films-grid.list-view .film-ratings .genre-tag { display: inline-flex; align-items: center; font-size: 0.75rem; color: #555; background: #eceef2; padding: 0.2rem 0.6rem; border-radius: 999px; line-height: 1.3; }
+@media (max-width: 768px) { .films-grid.list-view .film-ratings .genre-tag { display: none; } }
+.films-grid.list-view .badge { display: inline-block; padding: 0.15rem 0.5rem; border-radius: 4px; font-size: 0.78rem; font-weight: 600; }
+.films-grid.list-view .film-desc { font-size: 0.85rem; color: #555; line-height: 1.6; margin: 0.3rem 0 0; display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
+/* Mobile list view: move IMDB/ČSFD back onto the poster (like grid), hide text-badge row to give description room. */
+@media (max-width: 520px) {
+    .films-grid.list-view .rating-badges { display: flex; }
+    .films-grid.list-view .film-ratings .badge { display: none; }
+    .films-grid.list-view .film-ratings { display: none; }
+    .films-grid.list-view .film-poster { width: 84px; min-width: 84px; max-width: 84px; }
+    .films-grid.list-view .film-title { font-size: 0.95rem; }
+}
 
-/* Pagination */
+/* --- Pagination --- */
 .pagination { display: flex; justify-content: center; align-items: center; gap: 0.3rem; margin: 2rem 0; flex-wrap: wrap; }
 .page-link { display: inline-flex; align-items: center; justify-content: center; padding: 0.4rem 0.8rem; border-radius: 999px; background: #f1f5f9; color: #11457E; text-decoration: none; font-size: 0.85rem; font-weight: 600; min-width: 2.2rem; transition: background 0.15s, color 0.15s; }
 .page-link:hover { background: #11457E; color: white; }
@@ -275,24 +419,22 @@
 </style>
 
 <script>
-function doSearch() {
-    var q = document.getElementById('series-search').value.trim();
-    if (q.length >= 2) window.location = '/serialy-online/?q=' + encodeURIComponent(q);
-}
-
-/* View toggle (grid/list) */
+/* --- View toggle (single button, switches icon + dynamic tooltip) --- */
 function setView(mode) {
     var c = document.getElementById('films-container');
     var iconGrid = document.querySelector('.view-icon-grid');
     var iconList = document.querySelector('.view-icon-list');
+    var btn = document.getElementById('btn-view-toggle');
     if (mode === 'list') {
         c.classList.add('list-view');
         if (iconGrid) iconGrid.style.display = 'none';
         if (iconList) iconList.style.display = '';
+        if (btn) btn.setAttribute('title', 'Přepnout na zobrazení mřížkou');
     } else {
         c.classList.remove('list-view');
         if (iconGrid) iconGrid.style.display = '';
         if (iconList) iconList.style.display = 'none';
+        if (btn) btn.setAttribute('title', 'Přepnout na zobrazení seznamem');
     }
     localStorage.setItem('seriesView', mode);
 }
@@ -302,21 +444,28 @@ function toggleView() {
 }
 (function(){ var s = localStorage.getItem('seriesView'); if (s === 'list') setView('list'); })();
 
-/* Sort */
+/* --- Sort (combined field + direction) --- */
 function applySortCombined(v) {
-    var field = v.split(':')[0];
+    var parts = v.split(':');
+    var field = parts[0];
+    var dir = parts[1] || 'desc';
     var u = new URL(window.location);
-    if (field === 'pridano') u.searchParams.delete('razeni');
+    if (field === 'pridano' && dir === 'desc') u.searchParams.delete('razeni');
     else u.searchParams.set('razeni', field);
+    if (dir === 'asc') u.searchParams.set('smer', 'asc');
+    else u.searchParams.delete('smer');
     u.searchParams.delete('strana');
     window.location = u.toString();
 }
+
 (function() {
     var urlParams = new URLSearchParams(window.location.search);
     var razeni = urlParams.get('razeni') || 'pridano';
+    var smer = urlParams.get('smer') === 'asc' ? 'asc' : 'desc';
     var sortSel = document.getElementById('sort-select');
     if (sortSel) {
-        var target = razeni === 'nazev' ? 'nazev:asc' : razeni + ':desc';
+        var target = razeni + ':' + smer;
+        if (razeni === 'nazev' && !urlParams.get('smer')) target = 'nazev:asc';
         for (var i = 0; i < sortSel.options.length; i++) {
             if (sortSel.options[i].value === target) {
                 sortSel.selectedIndex = i;
@@ -326,7 +475,207 @@ function applySortCombined(v) {
     }
 })();
 
-/* Autocomplete */
+/* --- Filter panel toggle --- */
+function toggleFilter() {
+    var p = document.getElementById('filter-panel');
+    var b = document.getElementById('btn-filter-toggle');
+    if (p.style.display === 'none') { p.style.display = ''; b.classList.add('active'); }
+    else { p.style.display = 'none'; b.classList.remove('active'); }
+}
+/* Auto-open from Referer on desktop; on mobile (<=520px) always start hidden. */
+(function(){
+    var p = document.getElementById('filter-panel');
+    var b = document.getElementById('btn-filter-toggle');
+    if (!p) return;
+    if (p.style.display !== 'none' && window.innerWidth <= 520) {
+        p.style.display = 'none';
+    }
+    if (b && p.style.display !== 'none') b.classList.add('active');
+})();
+
+/* --- Populate year dropdown --- */
+(function() {
+    var sel = document.getElementById('filter-year');
+    if (!sel) return;
+    var now = new Date().getFullYear();
+    for (var y = now + 1; y >= 1950; y--) {
+        var o = document.createElement('option');
+        o.value = y; o.textContent = y;
+        sel.appendChild(o);
+    }
+})();
+
+/* --- Apply / Reset filters --- */
+function applyFilters() {
+    var incEls = document.querySelectorAll('#filter-genres-include input:checked');
+    var excEls = document.querySelectorAll('#filter-genres-exclude input:checked');
+    var inc = Array.from(incEls).map(function(i){ return i.value; });
+    var exc = Array.from(excEls).map(function(i){ return i.value; });
+    var year = document.getElementById('filter-year').value;
+    var sort = document.getElementById('sort-select').value;
+    var rezimEl = document.querySelector('input[name="rezim"]:checked');
+    var rezim = rezimEl ? rezimEl.value : 'or';
+
+    var panel = document.getElementById('filter-panel');
+    var currentGenre = panel ? panel.getAttribute('data-current-genre') : null;
+    var primary = null;
+    var extras = [];
+    if (currentGenre && inc.includes(currentGenre)) {
+        primary = currentGenre;
+        extras = inc.filter(function(s){ return s !== currentGenre; });
+    } else if (inc.length === 1) {
+        primary = inc[0];
+    } else if (inc.length > 1) {
+        extras = inc.slice();
+    }
+
+    var u;
+    if (primary) {
+        u = new URL('/serialy-online/' + primary + '/', window.location.origin);
+        if (extras.length) u.searchParams.set('zanry', extras.join(','));
+        if (extras.length && rezim === 'and') u.searchParams.set('rezim', 'and');
+    } else {
+        u = new URL('/serialy-online/', window.location.origin);
+        if (extras.length > 1) u.searchParams.set('zanry', extras.join(','));
+        if (extras.length > 1 && rezim === 'and') u.searchParams.set('rezim', 'and');
+    }
+    if (exc.length) u.searchParams.set('bez', exc.join(','));
+    if (year) u.searchParams.set('rok', year);
+    if (sort && sort !== 'pridano:desc') u.searchParams.set('razeni', sort.split(':')[0]);
+    window.location = u.toString();
+}
+
+function resetFilters() {
+    window.location = '/serialy-online/';
+}
+
+/* --- Filter: prefill + mutual exclusion + badge counter --- */
+(function() {
+    var panel = document.getElementById('filter-panel');
+    if (!panel) return;
+
+    var urlParams = new URLSearchParams(window.location.search);
+    var incParam = urlParams.get('zanry');
+    var excParam = urlParams.get('bez');
+    var yearParam = urlParams.get('rok');
+
+    if (incParam) {
+        incParam.split(',').forEach(function(slug) {
+            var cb = panel.querySelector('#filter-genres-include input[value="' + slug + '"]');
+            if (cb) cb.checked = true;
+        });
+    }
+    var rezimParam = urlParams.get('rezim');
+    if (rezimParam === 'and') {
+        var rb = panel.querySelector('input[name="rezim"][value="and"]');
+        if (rb) rb.checked = true;
+    }
+    if (excParam) {
+        excParam.split(',').forEach(function(slug) {
+            var cb = panel.querySelector('#filter-genres-exclude input[value="' + slug + '"]');
+            if (cb) cb.checked = true;
+        });
+    }
+    if (yearParam) {
+        var yrSel = document.getElementById('filter-year');
+        if (yrSel) yrSel.value = yearParam;
+    }
+
+    function updateFilterBadge() {
+        var checked = panel.querySelectorAll('input[type="checkbox"]:checked').length;
+        var yr = document.getElementById('filter-year');
+        if (yr && yr.value) checked++;
+
+        var btn = document.getElementById('btn-filter-toggle');
+        if (btn) {
+            var badge = btn.querySelector('.filter-count');
+            if (checked > 0) {
+                if (!badge) {
+                    badge = document.createElement('span');
+                    badge.className = 'filter-count';
+                    btn.appendChild(badge);
+                }
+                badge.textContent = checked;
+            } else if (badge) {
+                badge.remove();
+            }
+        }
+    }
+    updateFilterBadge();
+
+    panel.addEventListener('change', function(e) {
+        var cb = e.target;
+        if (cb.type === 'checkbox' && cb.dataset.filter) {
+            var otherSection = cb.dataset.filter === 'include' ? 'exclude' : 'include';
+            if (cb.checked) {
+                var sibling = panel.querySelector(
+                    '#filter-genres-' + otherSection + ' input[value="' + cb.value + '"]'
+                );
+                if (sibling) sibling.checked = false;
+            }
+        }
+        updateFilterBadge();
+    });
+
+    panel.addEventListener('keydown', function(e) {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            applyFilters();
+        }
+    });
+})();
+
+/* --- Nice Czech tooltip + aria-label for genre chips --- */
+(function(){
+    var pretty = {
+        'akcni': 'Akční seriály',
+        'animovany': 'Animované seriály',
+        'dobrodruzny': 'Dobrodružné seriály',
+        'dokumentarni': 'Dokumentární seriály',
+        'drama': 'Dramata',
+        'fantasy': 'Fantasy seriály',
+        'historicky': 'Historické seriály',
+        'horor': 'Horory',
+        'hudebni': 'Hudební seriály',
+        'komedie': 'Komedie',
+        'krimi': 'Kriminální seriály',
+        'mysteriozni': 'Mysteriózní seriály',
+        'rodinny': 'Rodinné seriály',
+        'romanticky': 'Romantické seriály',
+        'sci-fi': 'Sci-Fi seriály',
+        'thriller': 'Thrillery',
+        'tv-film': 'Televizní seriály',
+        'valecny': 'Válečné seriály',
+        'western': 'Westerny'
+    };
+    var panel = document.getElementById('filter-panel');
+    var currentSlug = panel ? panel.getAttribute('data-current-genre') : null;
+    document.querySelectorAll('#filter-genres-include .filter-chip, #filter-genres-exclude .filter-chip').forEach(function(c){
+        var slug = null;
+        if (c.tagName === 'A') {
+            var m = c.getAttribute('href').match(/\/serialy-online\/([^\/]+)/);
+            if (m) slug = m[1];
+        } else if (c.classList.contains('current')) {
+            slug = currentSlug;
+        } else {
+            var input = c.querySelector('input');
+            if (input) slug = input.value;
+        }
+        var label = slug && pretty[slug];
+        if (label) {
+            c.title = label;
+            c.setAttribute('aria-label', label);
+        }
+    });
+})();
+
+/* --- Search: button click → results --- */
+function doSearch() {
+    var q = document.getElementById('series-search').value.trim();
+    if (q.length >= 2) window.location = '/serialy-online/?q=' + encodeURIComponent(q);
+}
+
+/* --- Search autocomplete --- */
 (function() {
     var input = document.getElementById('series-search');
     var dd = document.getElementById('search-results');


### PR DESCRIPTION
<!-- claude-session: d3fa5f77-e620-435a-80b9-efdaa45a1cb1 -->

## Summary
- Adds filter panel (include/exclude genres, year, dubbing/subs, quality) to `/serialy-online/` — previously films-only
- SEO: H1 on `/filmy-online/žánr/` and `/serialy-online/žánr/` subcategory pages; H2 on main listing
- `GenreRow::pretty_plural()` for proper Czech titles: "Horory", "Dramata", "Televizní filmy", "Sci-Fi filmy"
- Breadcrumb ends with a link to the parent list (not a trailing genre span)
- Header logo becomes a clickable link when on a subcategory
- Multi-include genre filter via `?zanry=slug1,slug2` array bind
- `audio_filter`: no hidden default to "dub" when `jazyk` is empty — now shows all
- `film_genres_map` loaded once per list and rendered as chips in desktop list view
- Mobile CSS tweaks in `index.css` + viewport in `base.html`

Already deployed locally to production and verified via Playwright before opening this PR (per project 4-stage workflow):

## Test plan
- [x] `curl https://ceskarepublika.wiki/filmy-online/horor/` → `<title>Horory online`, H1 `Horory online (2461)`
- [x] `/serialy-online/sci-fi/` filter panel with genre chips, year dropdown, "Použít filtr"/"Zrušit filtry"
- [x] `/serialy-online/drama/` → H1 "Dramata online (545)" (pretty_plural)
- [x] Mobile 390px (iPhone 13) — no overflow, filter toggle badge visible, grid 2-col
- [x] Console: only Edge INFO (lazy-loading placeholders), 0 errors/warnings
- [x] Breadcrumb `Česká republika › Filmy online` — terminal link back to parent list
- [x] Header logo on subcategory clickable, links to parent
- [ ] CI green (Check & Clippy, Format, Test)
- [ ] Copilot review