### PR TITLE
fix(og): films_list + film_detail og:image 404

### DIFF
--- a/cr-web/templates/film_detail.html
+++ b/cr-web/templates/film_detail.html
@@ -6,7 +6,7 @@
 
 {% block og_title %}{{ film.title }}{% match film.year %}{% when Some with (y) %} ({{ y }}){% when None %}{% endmatch %} — film online{% endblock %}
 {% block og_description %}{% match film.description %}{% when Some with (d) %}{{ d }}{% when None %}{{ film.title }}{% match film.year %}{% when Some with (y) %} ({{ y }}){% when None %}{% endmatch %} — sledujte online zdarma na ceskarepublika.wiki{% endmatch %}{% endblock %}
-{% block og_image %}{% match film.cover_filename %}{% when Some with (c) %}https://ceskarepublika.wiki/filmy-online/{{ film.slug }}-large.webp{% when None %}https://ceskarepublika.wiki/static/img/og-filmy-online-v1.png{% endmatch %}{% endblock %}
+{% block og_image %}{% match film.cover_filename %}{% when Some with (c) %}https://ceskarepublika.wiki/filmy-online/{{ film.slug }}-large.webp{% when None %}https://ceskarepublika.wiki/static/img/og-filmy-a-serialy-v6.png{% endmatch %}{% endblock %}
 {% block og_type %}video.movie{% endblock %}
 
 {# Portrait poster dimensions (780×1170, 2:3 aspect) trigger Discord's

--- a/cr-web/templates/films_list.html
+++ b/cr-web/templates/films_list.html
@@ -6,14 +6,14 @@
 
 {% block og_title %}{% match current_genre %}{% when Some with (g) %}{{ g.pretty_plural() }} online — ceskarepublika.wiki{% when None %}Filmy online — ceskarepublika.wiki{% endmatch %}{% endblock %}
 {% block og_description %}{% match current_genre %}{% when Some with (g) %}{{ g.pretty_plural() }} online zdarma. {{ total_count }} filmů ke zhlédnutí přímo v prohlížeči, bez registrace.{% when None %}Filmy online zdarma — {{ total_count }} filmů ke zhlédnutí přímo v prohlížeči, bez registrace. České i zahraniční filmy s českým dabingem nebo titulky.{% endmatch %}{% endblock %}
-{% block og_image %}https://ceskarepublika.wiki/static/img/og-filmy-online-v1.png{% endblock %}
+{% block og_image %}https://ceskarepublika.wiki/static/img/og-filmy-a-serialy-v6.png{% endblock %}
 {% block og_type %}article{% endblock %}
 
 {% block leaflet %}{% endblock %}
 
 {% block head %}
 <link rel="icon" type="image/svg+xml" href="/static/img/logo-filmy-a-serialy.svg?v=6">
-<meta property="og:image:secure_url" content="https://ceskarepublika.wiki/static/img/og-filmy-online-v1.png">
+<meta property="og:image:secure_url" content="https://ceskarepublika.wiki/static/img/og-filmy-a-serialy-v6.png">
 <meta property="og:image:type" content="image/png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">


### PR DESCRIPTION
<!-- claude-session: d3fa5f77-e620-435a-80b9-efdaa45a1cb1 -->

## Summary
- `og-filmy-online-v1.png` was referenced by `films_list.html` and `film_detail.html` but the image was never committed to the repo. Production returned HTTP 404 for that URL, so Facebook/Discord/WhatsApp rendered an empty preview card for `/filmy-online/` and for any film without a cover.
- Both templates now point to `og-filmy-a-serialy-v6.png` — the same 1200×630 Seznam-safe PNG already used by `series_list.html`, `tv_porady_list.html`, `series_detail.html`, and other fallback paths.
- Already cross-compiled and deployed to production for verification before opening this PR.

## Test plan
- [x] `curl -sS https://ceskarepublika.wiki/filmy-online/ -A facebookexternalhit/1.1 | grep og:image` → now shows `og-filmy-a-serialy-v6.png`
- [x] `curl -sI https://ceskarepublika.wiki/static/img/og-filmy-a-serialy-v6.png` → HTTP 200
- [x] `curl -s -o /dev/null -w '%{http_code}' https://ceskarepublika.wiki/health` → 200 after deploy
- [ ] `facebookexternalhit/1.1` scrape on real share (forced via Sharing Debugger → "Scrape Again"); Facebook caches the old empty preview and will keep serving it until invalidated