### PR TITLE
feat(search): films autocomplete tolerates trailing year

### DIFF
--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -692,10 +692,7 @@ pub async fn films_search(
     Ok(axum::Json(results).into_response())
 }
 
-async fn search_films_by_title(
-    db: &sqlx::PgPool,
-    q: &str,
-) -> Result<Vec<SearchRow>, sqlx::Error> {
+async fn search_films_by_title(db: &sqlx::PgPool, q: &str) -> Result<Vec<SearchRow>, sqlx::Error> {
     let pattern = format!("%{q}%");
     let starts_pattern = format!("{q}%");
     sqlx::query_as::<_, SearchRow>(

--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -657,7 +657,11 @@ async fn films_by_genre(
     Ok(Html(tmpl.render()?).into_response())
 }
 
-/// GET /api/films/search?q=matrix — search autocomplete
+/// GET /api/films/search?q=matrix — search autocomplete.
+///
+/// If the raw query returns nothing and it ends with a year pattern
+/// (" (YYYY)" or " YYYY"), retry without the trailing year — users often
+/// type "Mstitel (1989)" but the title column stores only "Mstitel".
 pub async fn films_search(
     State(state): State<AppState>,
     axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
@@ -667,24 +671,12 @@ pub async fn films_search(
         return Ok(axum::Json(Vec::<SearchResult>::new()).into_response());
     }
 
-    let pattern = format!("%{q}%");
-    let starts_pattern = format!("{q}%");
-    let rows = sqlx::query_as::<_, SearchRow>(
-        "SELECT slug, title, year, imdb_rating, cover_filename \
-         FROM films \
-         WHERE title ILIKE $1 OR original_title ILIKE $1 \
-         ORDER BY \
-           CASE WHEN title ILIKE $2 THEN 0 \
-                WHEN title ILIKE $1 THEN 1 \
-                WHEN original_title ILIKE $2 THEN 2 \
-                ELSE 3 END, \
-           imdb_rating DESC NULLS LAST \
-         LIMIT 10",
-    )
-    .bind(&pattern)
-    .bind(&starts_pattern)
-    .fetch_all(&state.db)
-    .await?;
+    let mut rows = search_films_by_title(&state.db, q).await?;
+    if rows.is_empty()
+        && let Some(stripped) = strip_trailing_year(q)
+    {
+        rows = search_films_by_title(&state.db, &stripped).await?;
+    }
 
     let results: Vec<SearchResult> = rows
         .into_iter()
@@ -698,6 +690,45 @@ pub async fn films_search(
         .collect();
 
     Ok(axum::Json(results).into_response())
+}
+
+async fn search_films_by_title(
+    db: &sqlx::PgPool,
+    q: &str,
+) -> Result<Vec<SearchRow>, sqlx::Error> {
+    let pattern = format!("%{q}%");
+    let starts_pattern = format!("{q}%");
+    sqlx::query_as::<_, SearchRow>(
+        "SELECT slug, title, year, imdb_rating, cover_filename \
+         FROM films \
+         WHERE title ILIKE $1 OR original_title ILIKE $1 \
+         ORDER BY \
+           CASE WHEN title ILIKE $2 THEN 0 \
+                WHEN title ILIKE $1 THEN 1 \
+                WHEN original_title ILIKE $2 THEN 2 \
+                ELSE 3 END, \
+           imdb_rating DESC NULLS LAST \
+         LIMIT 10",
+    )
+    .bind(&pattern)
+    .bind(&starts_pattern)
+    .fetch_all(db)
+    .await
+}
+
+/// Strip a trailing year pattern (" (YYYY)" or " YYYY") from a search query.
+/// Requires leading whitespace and ≥2 chars remaining — avoids stripping a
+/// standalone year like "1984" or short titles like "X 1989".
+fn strip_trailing_year(q: &str) -> Option<String> {
+    static RE: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+        regex::Regex::new(r"\s+(?:\(\d{4}\)|\d{4})\s*$").expect("const regex literal compiles")
+    });
+    let m = RE.find(q)?;
+    let before = q[..m.start()].trim_end();
+    if before.chars().count() < 2 {
+        return None;
+    }
+    Some(before.to_string())
 }
 
 /// GET /filmy-online/{slug}.webp — serve WebP cover image
@@ -1239,4 +1270,55 @@ fn not_found_response() -> Response {
         Html("<h1>404 — Stránka nenalezena</h1>"),
     )
         .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::strip_trailing_year;
+
+    #[test]
+    fn strips_parenthesized_year() {
+        assert_eq!(
+            strip_trailing_year("Mstitel (1989)").as_deref(),
+            Some("Mstitel")
+        );
+        assert_eq!(
+            strip_trailing_year("The Matrix (1999)").as_deref(),
+            Some("The Matrix")
+        );
+        assert_eq!(
+            strip_trailing_year("Mstitel  (1989)  ").as_deref(),
+            Some("Mstitel")
+        );
+    }
+
+    #[test]
+    fn strips_bare_year() {
+        assert_eq!(
+            strip_trailing_year("Mstitel 1989").as_deref(),
+            Some("Mstitel")
+        );
+        assert_eq!(
+            strip_trailing_year("Rambo II 1985").as_deref(),
+            Some("Rambo II")
+        );
+    }
+
+    #[test]
+    fn does_not_strip_when_no_year_at_end() {
+        assert_eq!(strip_trailing_year("2001: A Space Odyssey"), None);
+        assert_eq!(strip_trailing_year("Matrix"), None);
+        assert_eq!(strip_trailing_year("Terminator 2"), None);
+    }
+
+    #[test]
+    fn does_not_strip_bare_year_alone() {
+        assert_eq!(strip_trailing_year("1984"), None);
+        assert_eq!(strip_trailing_year("2025"), None);
+    }
+
+    #[test]
+    fn does_not_strip_when_remaining_too_short() {
+        assert_eq!(strip_trailing_year("X 1989"), None);
+    }
 }


### PR DESCRIPTION
<!-- claude-session: d3fa5f77-e620-435a-80b9-efdaa45a1cb1 -->

## Summary
Users frequently type film names with a year — "Mstitel (1989)" or "Mstitel 1989" — but the autocomplete API returns "Nic nenalezeno" because `ILIKE '%Mstitel (1989)%'` never matches (year is stored separately from title).

**Flow:**
1. Run the original `ILIKE` query against `title`/`original_title` unchanged — titles like "2001: A Space Odyssey" or "1984" keep working exactly as before.
2. If that returns zero rows **and** the query ends with a trailing year ("(YYYY)" or bare "YYYY" with leading whitespace), strip it and re-run the same query.

The strip regex (`\s+(?:\(\d{4}\)|\d{4})\s*$`) requires leading whitespace and ≥2 chars remaining after stripping, so standalone `1984` and titles like `X 1989` are not mangled.

## Test plan
- [x] 5 unit tests on `strip_trailing_year` (parenthesized / bare / no-year / bare-year-alone / too-short) — all green
- [x] `cargo test -p cr-web` (21/21) + `cargo clippy -- -D warnings` (clean)
- [x] Cross-compiled + deployed to prod; health 200
- [x] `curl /api/films/search?q=Mstitel%20(1989)` → returns Mstitel 1989 (previously empty array)
- [x] `curl /api/films/search?q=Mstitel%201989` → returns Mstitel 1989 (bare year variant)
- [x] `curl /api/films/search?q=1984` → primary query still returns George Orwell's "1984" (standalone year not stripped)
- [x] Playwright: typed "Mstitel (1989)" on /filmy-online/ — dropdown now shows 10 results with "Mstitel (1989) — IMDB 5.75" at position 2; previously "Nic nenalezeno". 0 console errors.