### PR TITLE
feat(prehrajto): serve Další zdroje from DB (#521)

### DIFF
--- a/cr-infra/migrations/20260520_049_film_prehrajto_uploads_is_direct.sql
+++ b/cr-infra/migrations/20260520_049_film_prehrajto_uploads_is_direct.sql
@@ -1,0 +1,25 @@
+-- Lazily-filled "direct CDN vs proxied" flag for each prehraj.to upload.
+--
+-- TRUE  = last resolve produced a `*.premiumcdn.net` URL (direct, fast
+--         HTML5 `<video>` playback — the green "přímý" badge in the UI).
+-- FALSE = last resolve produced a non-premiumcdn URL (prehraj.to's own
+--         proxy path — the orange "proxy" badge).
+-- NULL  = not yet resolved by the server-side stream endpoint, so we do
+--         not know. Importer never populates this; the column is
+--         opportunistically corrected on the first hit of
+--         `/api/movies/stream/{upload_id}`.
+--
+-- Why nullable + lazy, not an importer field: validating every upload
+-- at import time would take a per-upload page scrape (~60 k calls first
+-- run), and the direct/proxy state can flip later as prehraj.to moves
+-- storage — so pay for the check only when a user actually watches.
+--
+-- This column supports issue #521 (serve "Další zdroje" from the DB
+-- instead of a live scrape + per-result validate).
+
+ALTER TABLE film_prehrajto_uploads
+    ADD COLUMN IF NOT EXISTS is_direct BOOLEAN;
+
+-- No index: the column is a per-row descriptor read as part of the
+-- "all alive uploads for film X" query. The existing
+-- `idx_fpu_film_alive` partial index already covers that access path.

--- a/cr-web/src/config.rs
+++ b/cr-web/src/config.rs
@@ -48,6 +48,13 @@ pub struct AppConfig {
     /// Optional CZ-hosted proxy for scraping geo-blocked sources (prehraj.to,
     /// SK Torrent). None if unconfigured.
     pub cz_proxy: Option<CzProxyConfig>,
+    /// Serve the detail-page "Další zdroje" block from
+    /// `film_prehrajto_uploads` (DB) instead of the legacy live
+    /// search + per-result validate against prehraj.to. Set
+    /// `PREHRAJTO_SOURCES_FROM_DB=1` to enable. Rollback is just
+    /// flipping the flag back — the old search/validate handlers stay
+    /// routed so the template's fallback path keeps working.
+    pub prehrajto_sources_from_db: bool,
     /// Cloudflare API token scoped to Zone.Cache Purge. Enables the admin
     /// `/admin/cache/` page to invalidate CDN cache on demand. `None` when the
     /// env vars aren't provisioned — UI hides the purge actions in that case.
@@ -114,6 +121,11 @@ impl AppConfig {
             _ => None,
         };
 
+        let prehrajto_sources_from_db = matches!(
+            std::env::var("PREHRAJTO_SOURCES_FROM_DB").as_deref(),
+            Ok("1")
+        );
+
         let cf_cache_purge = match (
             std::env::var("CF_CACHE_PURGE_TOKEN")
                 .ok()
@@ -138,6 +150,7 @@ impl AppConfig {
             admin_import_run_enabled,
             admin_cache_purge_enabled,
             cz_proxy,
+            prehrajto_sources_from_db,
             cf_cache_purge,
         }))
     }

--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -252,6 +252,12 @@ struct FilmDetailTemplate {
     genres: Vec<FilmGenreNameRow>,
     #[allow(dead_code)] // Fetched from DB but not rendered via Askama; JS handles sources
     sources: Vec<FilmSourceRow>,
+    /// Gate the "Další zdroje" JS between the legacy live-scrape flow
+    /// and the new DB-backed `/api/films/{id}/prehrajto-sources`
+    /// endpoint (issue #521). Template renders this into a JS
+    /// boolean — flipping `PREHRAJTO_SOURCES_FROM_DB` at the
+    /// process env + restart is all it takes to roll back.
+    prehrajto_sources_from_db: bool,
 }
 
 // --- Search API types ---
@@ -458,6 +464,7 @@ pub async fn films_detail(
         film,
         genres,
         sources,
+        prehrajto_sources_from_db: state.config.prehrajto_sources_from_db,
     };
     Ok(Html(tmpl.render()?).into_response())
 }

--- a/cr-web/src/handlers/movies_api/cz_proxy.rs
+++ b/cr-web/src/handlers/movies_api/cz_proxy.rs
@@ -101,6 +101,17 @@ pub async fn movies_search(
 ) -> crate::error::WebResult<Json<SearchResponse>> {
     use crate::error::WebError;
 
+    // Issue #521 moved the detail-page "Další zdroje" flow off this
+    // endpoint. Rare traffic here while the flag is on usually means a
+    // stale cached template or a manual caller — worth an info log for
+    // the cutover window. Kept fully functional for rollback.
+    if state.config.prehrajto_sources_from_db {
+        tracing::info!(
+            q = %params.q.trim(),
+            "movies_search hit while PREHRAJTO_SOURCES_FROM_DB is on (deprecated path)"
+        );
+    }
+
     let query = params.q.trim().to_string();
     if query.is_empty() {
         return Err(WebError::bad_request("Missing search query"));

--- a/cr-web/src/handlers/movies_api/mod.rs
+++ b/cr-web/src/handlers/movies_api/mod.rs
@@ -5,7 +5,7 @@ mod subtitles;
 mod thumbnail;
 
 pub use cz_proxy::{movies_search, movies_video_url};
-pub use prehrajto::prehrajto_stream_upload;
+pub use prehrajto::{prehrajto_sources, prehrajto_stream_upload};
 pub use stream::{filemoon_resolve, movies_proxy_stream, movies_stream, stream_resolve};
 pub use subtitles::movies_subtitle;
 pub use thumbnail::{movies_thumb, movies_validate};

--- a/cr-web/src/handlers/movies_api/prehrajto.rs
+++ b/cr-web/src/handlers/movies_api/prehrajto.rs
@@ -21,7 +21,7 @@ use axum::Json;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Redirect, Response};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sqlx::FromRow;
 use tokio::sync::Semaphore;
@@ -270,11 +270,21 @@ async fn do_scrape(state: &AppState, upload_id: &str, row: &UploadRow) -> TryRes
     let scrape_started = Instant::now();
     match scrape_content_url(state, &row.url).await {
         Ok(Some(video_url)) => {
+            // Classify the resolved URL once, and opportunistically
+            // persist the flag for the "Další zdroje" DB listing (#521)
+            // before deciding whether to redirect. The DB update happens
+            // on both paths so a proxy upload eventually flips to
+            // `is_direct = FALSE` even though we still refuse to
+            // redirect to it — the list endpoint then shows it with the
+            // "proxy" badge instead of optimistic "direct".
+            let is_direct = is_allowed_stream_url(&video_url);
+            persist_is_direct(state, upload_id, is_direct).await;
+
             // Belt-and-suspenders: the CZ proxy is a trusted component,
             // but a compromise or upstream change should not turn this
             // endpoint into an open redirect. Refuse anything off the
             // CDN allow-list (`premiumcdn.net`).
-            if !is_allowed_stream_url(&video_url) {
+            if !is_direct {
                 tracing::error!(
                     upload_id,
                     "resolved URL not on CDN allow-list — refusing to redirect"
@@ -344,6 +354,29 @@ async fn do_scrape(state: &AppState, upload_id: &str, row: &UploadRow) -> TryRes
             };
             TryResolveOutcome::HardError((status, message).into_response())
         }
+    }
+}
+
+/// Write `is_direct` for this `upload_id` when it changes. Called on
+/// every successful scrape so the DB-backed "Další zdroje" listing
+/// (#521) reflects the latest direct/proxy classification prehraj.to
+/// reports — no importer-time validate needed. A DB failure here is
+/// non-fatal (the next scrape will try again); log and move on.
+async fn persist_is_direct(state: &AppState, upload_id: &str, is_direct: bool) {
+    // `IS DISTINCT FROM` keeps the UPDATE a no-op when the flag is
+    // already correct (including across NULL → bool transitions), so
+    // repeated hits on a fresh cache don't churn the row.
+    let res = sqlx::query(
+        "UPDATE film_prehrajto_uploads \
+         SET is_direct = $1 \
+         WHERE upload_id = $2 AND is_direct IS DISTINCT FROM $1",
+    )
+    .bind(is_direct)
+    .bind(upload_id)
+    .execute(&state.db)
+    .await;
+    if let Err(e) = res {
+        tracing::warn!(upload_id, is_direct, error = ?e, "persist_is_direct failed");
     }
 }
 
@@ -454,6 +487,86 @@ pub async fn prehrajto_stream_upload(
         Err(resp) => resp,
     }
 }
+
+/// One row in the "Další zdroje" listing. Public so the Serialize impl
+/// produces a stable JSON contract for the template JS that consumes it.
+#[derive(Serialize, FromRow)]
+pub struct PrehrajtoSourceRow {
+    pub upload_id: String,
+    pub url: String,
+    pub title: String,
+    pub duration_sec: Option<i32>,
+    pub resolution_hint: Option<String>,
+    pub lang_class: String,
+    /// `Some(true)` = resolved to a `premiumcdn.net` URL on the last hit,
+    /// `Some(false)` = proxied, `None` = never resolved yet by the server
+    /// (the template renders this as "unknown" and optimistically treats
+    /// it like `direct` so existing playback flows keep working).
+    pub is_direct: Option<bool>,
+}
+
+/// `GET /api/films/{film_id}/prehrajto-sources` — list of all alive
+/// uploads for a film, ranked the same way the stream endpoint's
+/// fallback picks the primary (lang-class → resolution → views).
+/// Replaces the legacy live-scrape path for the detail-page "Další
+/// zdroje" block once `PREHRAJTO_SOURCES_FROM_DB=1`.
+pub async fn prehrajto_sources(
+    State(state): State<AppState>,
+    Path(film_id): Path<i32>,
+) -> Response {
+    match sqlx::query_as::<_, PrehrajtoSourceRow>(PREHRAJTO_SOURCES_SQL)
+        .bind(film_id)
+        .fetch_all(&state.db)
+        .await
+    {
+        Ok(rows) => Json(json!({
+            "film_id": film_id,
+            "count": rows.len(),
+            "sources": rows,
+        }))
+        .into_response(),
+        Err(e) => {
+            tracing::error!(film_id, error = ?e, "prehrajto_sources DB query failed");
+            (StatusCode::INTERNAL_SERVER_ERROR, "db error").into_response()
+        }
+    }
+}
+
+/// Ranking kept in sync with [`next_best_upload`] so the first row of
+/// this list is also the upload the stream endpoint would try first —
+/// same order the pilot importer uses for `prehrajto_primary_upload_id`.
+const PREHRAJTO_SOURCES_SQL: &str = r#"
+    SELECT upload_id, url, title, duration_sec, resolution_hint,
+           lang_class, is_direct
+    FROM film_prehrajto_uploads
+    WHERE film_id = $1 AND is_alive = TRUE
+    ORDER BY
+      CASE lang_class
+        WHEN 'CZ_DUB'    THEN 6
+        WHEN 'CZ_NATIVE' THEN 5
+        WHEN 'CZ_SUB'    THEN 4
+        WHEN 'SK_DUB'    THEN 3
+        WHEN 'SK_SUB'    THEN 2
+        WHEN 'UNKNOWN'   THEN 1
+        ELSE 0
+      END DESC,
+      CASE LOWER(COALESCE(resolution_hint, ''))
+        WHEN '2160p'  THEN 6
+        WHEN 'bluray' THEN 5
+        WHEN '1080p'  THEN 5
+        WHEN '720p'   THEN 4
+        WHEN 'bdrip'  THEN 4
+        WHEN 'webrip' THEN 4
+        WHEN 'web-dl' THEN 4
+        WHEN 'hdrip'  THEN 3
+        WHEN 'hdtv'   THEN 3
+        WHEN '480p'   THEN 2
+        WHEN 'dvdrip' THEN 2
+        WHEN 'tvrip'  THEN 2
+        ELSE 1
+      END DESC,
+      COALESCE(view_count, 0) DESC
+"#;
 
 #[cfg(test)]
 mod tests {
@@ -594,5 +707,51 @@ mod tests {
             interpret_proxy_response(&empty).unwrap_err(),
             "proxy-malformed"
         );
+    }
+
+    // --- `PrehrajtoSourceRow` JSON contract -----------------------------
+    // Locks the JSON shape the film-detail template JS depends on. If a
+    // field is renamed or dropped here the template stops rendering the
+    // "Další zdroje" block, so this test is cheap insurance.
+
+    #[test]
+    fn source_row_serializes_with_expected_fields() {
+        let row = PrehrajtoSourceRow {
+            upload_id: "558bd2364b350".to_string(),
+            url: "https://prehraj.to/some-slug-558bd2364b350".to_string(),
+            title: "Example Movie 1080p CZ".to_string(),
+            duration_sec: Some(5412),
+            resolution_hint: Some("1080p".to_string()),
+            lang_class: "CZ_DUB".to_string(),
+            is_direct: Some(true),
+        };
+        let json = serde_json::to_value(&row).expect("serialize");
+        assert_eq!(json["upload_id"], "558bd2364b350");
+        assert_eq!(json["url"], "https://prehraj.to/some-slug-558bd2364b350");
+        assert_eq!(json["title"], "Example Movie 1080p CZ");
+        assert_eq!(json["duration_sec"], 5412);
+        assert_eq!(json["resolution_hint"], "1080p");
+        assert_eq!(json["lang_class"], "CZ_DUB");
+        assert_eq!(json["is_direct"], true);
+    }
+
+    #[test]
+    fn source_row_serializes_null_is_direct_as_json_null() {
+        let row = PrehrajtoSourceRow {
+            upload_id: "0123456789abc".to_string(),
+            url: "https://prehraj.to/x-0123456789abc".to_string(),
+            title: "Unknown".to_string(),
+            duration_sec: None,
+            resolution_hint: None,
+            lang_class: "UNKNOWN".to_string(),
+            is_direct: None,
+        };
+        let json = serde_json::to_value(&row).expect("serialize");
+        assert!(
+            json["is_direct"].is_null(),
+            "template JS treats null as unknown/optimistic direct"
+        );
+        assert!(json["duration_sec"].is_null());
+        assert!(json["resolution_hint"].is_null());
     }
 }

--- a/cr-web/src/main.rs
+++ b/cr-web/src/main.rs
@@ -212,6 +212,10 @@ async fn main() -> Result<()> {
             axum::routing::get(handlers::movies_api::prehrajto_stream_upload),
         )
         .route(
+            "/films/{film_id}/prehrajto-sources",
+            axum::routing::get(handlers::movies_api::prehrajto_sources),
+        )
+        .route(
             "/movies/thumb",
             axum::routing::get(handlers::movies_api::movies_thumb),
         )

--- a/cr-web/templates/film_detail.html
+++ b/cr-web/templates/film_detail.html
@@ -422,11 +422,55 @@ var cachedPrehrajtoPlayed = false;
 /* --- Přehraj.to: search, validate (direct vs proxy), auto-play if no SK Torrent --- */
 (function() {
     var filmTitle = "{{ film.title }}";
+    var filmId = {{ film.id }};
     var section = document.getElementById('prehrajto-section');
     var container = document.getElementById('prehrajto-results');
     var hasSktorrent = typeof sktorrentVideoId !== 'undefined';
     if (!section || !container || !filmTitle) return;
 
+    {% if prehrajto_sources_from_db %}
+    // DB-backed flow (issue #521). No outbound prehraj.to calls on render;
+    // the list is served directly from `film_prehrajto_uploads`. `is_direct`
+    // is `true`/`false` once the stream endpoint has resolved the upload at
+    // least once, otherwise `null` — we optimistically render unknowns as
+    // "direct" so existing playback flows keep working the first time a
+    // user tries an upload.
+    fetch('/api/films/' + filmId + '/prehrajto-sources')
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+            if (!data || !data.sources || !data.sources.length) return;
+
+            section.style.display = '';
+            var autoPlayed = false;
+            data.sources.forEach(function(src, idx) {
+                var movie = {
+                    url: src.url,
+                    title: src.title,
+                    // Thumbnails aren't in the DB — placeholder until we
+                    // either persist them at import or proxy them lazily.
+                    thumbnail: '',
+                    year: '',
+                };
+                var height = parseResolutionHint(src.resolution_hint);
+                var isDirect = src.is_direct !== false; // null → optimistic direct
+                var item = createItem(movie, isDirect, src.duration_sec, height);
+                if (!isDirect) item.classList.add('proxy-item');
+                // The server already ranked the list (lang-class →
+                // resolution → views), so appending in order matches the
+                // same ordering the stream endpoint uses for fallback —
+                // no client-side runtime-diff sort needed.
+                container.appendChild(item);
+
+                // Autoplay the first direct entry if there's no SK Torrent
+                // and no cached prehraj.to hit — mirrors the legacy flow.
+                if (idx === 0 && isDirect && !hasSktorrent && !cachedPrehrajtoPlayed && !autoPlayed) {
+                    autoPlayed = true;
+                    setTimeout(function() { item.click(); }, 500);
+                }
+            });
+        })
+        .catch(function() {});
+    {% else %}
     fetch('/api/movies/search?q=' + encodeURIComponent(filmTitle))
         .then(function(r) { return r.json(); })
         .then(function(data) {
@@ -512,6 +556,22 @@ var cachedPrehrajtoPlayed = false;
             validateBatch(0);
         })
         .catch(function() {});
+    {% endif %}
+
+    /* Map a `resolution_hint` string ("1080p", "bluray", "hdrip", …) to a
+       height in pixels so the badge CSS (`quality-hd` / `sd` / `low`)
+       picks the right color. Mirrors the SQL ranking in
+       `PREHRAJTO_SOURCES_SQL` — keep the two in sync. */
+    function parseResolutionHint(hint) {
+        if (!hint) return 0;
+        var h = hint.toLowerCase();
+        if (h === '2160p') return 2160;
+        if (h === '1080p' || h === 'bluray') return 1080;
+        if (h === '720p' || h === 'bdrip' || h === 'webrip' || h === 'web-dl') return 720;
+        if (h === 'hdrip' || h === 'hdtv') return 540;
+        if (h === '480p' || h === 'dvdrip' || h === 'tvrip') return 480;
+        return 0;
+    }
 
     function createItem(movie, isDirect, durationSec, height) {
         var item = document.createElement('div');


### PR DESCRIPTION
<!-- claude-session: 74da902e-6000-4680-8b0a-b1bb3db8128b -->

Closes #521

## Summary
Replaces the live prehraj.to search + per-result validate the film-detail page fires on every render with a DB-backed endpoint. Every open of a popular film currently triggers one search + N validate calls (often 10+) to prehraj.to; after this change and with the flag on, popular pages issue zero outbound prehraj.to requests during render.

Cutover is gated by the env var **`PREHRAJTO_SOURCES_FROM_DB=1`**. The old `/api/movies/search` + `/api/movies/validate` path stays fully routed — rollback is flipping the flag back and restarting.

## Changes
- **Migration `20260520_049`** adds a nullable `is_direct` column to `film_prehrajto_uploads`. NULL = not yet resolved server-side, TRUE = last resolve hit `*.premiumcdn.net`, FALSE = proxied. Filled lazily by the stream endpoint on the first hit per upload; no importer-time validate pass needed.
- **`GET /api/films/{film_id}/prehrajto-sources`** returns a JSON array of alive uploads ranked identically to the stream endpoint's fallback (lang-class → resolution → view count). Stable shape: `upload_id`, `url`, `title`, `duration_sec`, `resolution_hint`, `lang_class`, `is_direct`.
- **`AppConfig.prehrajto_sources_from_db`** read once at startup from `PREHRAJTO_SOURCES_FROM_DB=1`. `FilmDetailTemplate` renders it into a JS boolean the template uses to pick the flow.
- **`do_scrape` now persists `is_direct`** before the allow-list decision, so uploads we refuse to redirect to still get their flag flipped in the DB — the list endpoint then shows them with the "proxy" badge instead of optimistic "direct".
- **Deprecation info log** on `movies_search` when the flag is on, so stray legacy traffic is visible during the cutover window.
- **Template flow:** when the flag is on, a single call to the new endpoint populates "Další zdroje" — no per-result validate, no client-side runtime filter (the server ranking is authoritative), and autoplay clicks the first direct entry after 500 ms.

## Tests
- `cargo test -p cr-web --bin cr-web handlers::movies_api::prehrajto` — 11/11 (2 new `PrehrajtoSourceRow` JSON-shape tests that pin the field names and the `is_direct: null` rendering the template depends on)
- `cargo clippy -p cr-web --all-targets -- -D warnings` — clean
- `cargo fmt --check -p cr-web` — clean

## Test plan
- [x] Build + unit tests + clippy + fmt — clean
- [ ] Run migration on stage, confirm column added
- [ ] Open detail page for a film with known uploads with flag off → legacy flow still works
- [ ] Flip flag on, reload → new endpoint, zero prehraj.to traffic during render
- [ ] Confirm autoplay picks first direct entry; `is_direct: null` rows render as optimistic direct
- [ ] After a few `/api/movies/stream/{upload_id}` hits, spot-check DB — `is_direct` is set
- [ ] Apply to prod