### PR TITLE
feat(import): bulk-import new films from prehraj.to sitemap (#524)

### DIFF
--- a/cr-infra/migrations/20260521_050_films_imdb_id_unique.sql
+++ b/cr-infra/migrations/20260521_050_films_imdb_id_unique.sql
@@ -10,9 +10,13 @@
 --
 -- NULL imdb_id rows (historical, brand-new releases with no IMDB yet) are
 -- allowed multiple times because the index is partial.
-
-DROP INDEX IF EXISTS idx_films_imdb_id;
+--
+-- Create the new unique index BEFORE dropping the old non-unique one, so
+-- that if CREATE fails (unexpected duplicate) the table still has an
+-- imdb_id index and query plans don't regress.
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_films_imdb_id_unique
     ON films (imdb_id)
     WHERE imdb_id IS NOT NULL;
+
+DROP INDEX IF EXISTS idx_films_imdb_id;

--- a/cr-infra/migrations/20260521_050_films_imdb_id_unique.sql
+++ b/cr-infra/migrations/20260521_050_films_imdb_id_unique.sql
@@ -1,0 +1,18 @@
+-- Upgrade idx_films_imdb_id from a non-unique partial index to a UNIQUE one.
+-- Enables INSERT ... ON CONFLICT (imdb_id) DO NOTHING semantics for the
+-- new-film bulk importer in scripts/import-prehrajto-new-films.py (issue #524).
+--
+-- Safety: verified on stage that no duplicate non-null imdb_id values exist
+-- today (films.imdb_id is effectively functional-unique already, just never
+-- constrained). Non-null imdb_id entries in films table are populated
+-- exclusively by the auto-import and prehraj.to importers, both of which
+-- already check for existing rows before inserting.
+--
+-- NULL imdb_id rows (historical, brand-new releases with no IMDB yet) are
+-- allowed multiple times because the index is partial.
+
+DROP INDEX IF EXISTS idx_films_imdb_id;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_films_imdb_id_unique
+    ON films (imdb_id)
+    WHERE imdb_id IS NOT NULL;

--- a/scripts/import-prehrajto-new-films.py
+++ b/scripts/import-prehrajto-new-films.py
@@ -330,10 +330,30 @@ def unique_slug(cur, base: str, year: int | None, reserved: set[str]) -> str:
 # TMDB helper
 # ---------------------------------------------------------------------------
 
+# Shared pacing state — every tmdb_get() call honours --tmdb-min-interval-ms,
+# so the effective rate is per HTTP call (not per film, which would double
+# the true rate because fetch_tmdb_movie fires cs-CZ + en-US back-to-back).
+_TMDB_MIN_INTERVAL: float = 0.0
+_TMDB_LAST_CALL_TS: float = 0.0
+
+
+def _tmdb_pace() -> None:
+    """Sleep if needed so two consecutive tmdb_get() calls are
+    >= _TMDB_MIN_INTERVAL seconds apart. Single-threaded — no lock."""
+    global _TMDB_LAST_CALL_TS
+    if _TMDB_MIN_INTERVAL <= 0:
+        _TMDB_LAST_CALL_TS = time.time()
+        return
+    elapsed = time.time() - _TMDB_LAST_CALL_TS
+    if elapsed < _TMDB_MIN_INTERVAL:
+        time.sleep(_TMDB_MIN_INTERVAL - elapsed)
+    _TMDB_LAST_CALL_TS = time.time()
+
 
 def tmdb_get(session: requests.Session, path: str, params: dict,
              api_key: str, retries: int = 3) -> dict | None:
     """GET TMDB endpoint with retry on 429 / transient failure."""
+    _tmdb_pace()
     p = {"api_key": api_key}
     p.update(params)
     url = f"{TMDB_API_BASE}{path}"
@@ -447,7 +467,9 @@ def main() -> int:
                     help="In live mode, commit after every N films (default 500). "
                          "Set 0 to keep a single transaction.")
     ap.add_argument("--tmdb-min-interval-ms", type=int, default=25,
-                    help="Minimum ms between TMDB requests (default 25 = 40 rps). "
+                    help="Minimum ms between TMDB HTTP calls (default 25 = 40 rps). "
+                         "Applied per call, not per film — each film triggers two "
+                         "calls (cs-CZ + en-US), so 25 ms ≈ 20 films/s. "
                          "TMDB's own rate limit is ~50 rps.")
     ap.add_argument("--skip-covers", action="store_true",
                     help="Skip cover download entirely — for DRY-RUN sanity checks "
@@ -502,6 +524,9 @@ def main() -> int:
     conn.autocommit = False
     session = requests.Session()
     session.headers.update({"Accept": "application/json"})
+    # Hoisted out of the try block so the finally cleanup can touch it even
+    # if we raise before entering the per-film loop.
+    dry_run_covers_created: list[Path] = []
     try:
         cur = conn.cursor()
 
@@ -603,28 +628,25 @@ def main() -> int:
 
         # ---- Loop over missing IMDBs ----
         commit_every = 0 if args.dry_run else args.commit_every
-        tmdb_min_interval = max(0.0, args.tmdb_min_interval_ms / 1000.0)
-        last_tmdb_call = 0.0
+        global _TMDB_MIN_INTERVAL
+        _TMDB_MIN_INTERVAL = max(0.0, args.tmdb_min_interval_ms / 1000.0)
         inserted_films = 0
         inserted_uploads = 0
         tmdb_failures = 0
         no_uploads = 0
         no_poster = 0
         conflict_skips = 0
+        slug_retries = 0
         reserved_slugs: set[str] = set()
-        dry_run_covers_created: list[Path] = []
 
         t1 = time.time()
         for i, imdb in enumerate(missing_imdbs, 1):
             tmdb_id = imdb_to_tmdb.get(imdb)
             if not tmdb_id:
                 continue
-            # Crude rate-limit: space TMDB calls out.
-            elapsed = time.time() - last_tmdb_call
-            if elapsed < tmdb_min_interval:
-                time.sleep(tmdb_min_interval - elapsed)
+            # Throttling is handled inside tmdb_get() so both cs-CZ and en-US
+            # calls honour --tmdb-min-interval-ms independently.
             movie = fetch_tmdb_movie(session, tmdb_id, api_key)
-            last_tmdb_call = time.time()
             if not movie:
                 tmdb_failures += 1
                 continue
@@ -696,29 +718,58 @@ def main() -> int:
             if cover_filename is None:
                 no_poster += 1
 
-            # ---- INSERT film ----
-            cur.execute(insert_film_sql, {
-                "title": title,
-                "original_title": original_title,
-                "slug": slug,
-                "year": year,
-                "description": description,
-                "imdb_id": imdb,
-                "tmdb_id": tmdb_id,
-                "runtime_min": runtime_min,
-                "cover_filename": cover_filename,
-                "has_cz_audio": has_cz_audio,
-                "has_cz_subs": has_cz_subs,
-                "primary_upload": primary_upload_id,
-                "has_sk_dub": has_sk_dub,
-                "has_sk_subs": has_sk_subs,
-            })
-            row = cur.fetchone()
+            # ---- INSERT film (savepoint + retry on slug collision) ----
+            # `unique_slug()` is a SELECT-then-INSERT check: if a concurrent
+            # writer (e.g. auto-import) claims the same slug between our
+            # availability probe and this INSERT, Postgres raises a UNIQUE
+            # violation on `films_slug_key`. We catch it behind a savepoint,
+            # regenerate a new slug, and retry — bounded so a pathological
+            # case doesn't loop forever.
+            MAX_SLUG_RETRIES = 3
+            row = None
+            for attempt in range(MAX_SLUG_RETRIES + 1):
+                cur.execute("SAVEPOINT film_insert_sp")
+                try:
+                    cur.execute(insert_film_sql, {
+                        "title": title,
+                        "original_title": original_title,
+                        "slug": slug,
+                        "year": year,
+                        "description": description,
+                        "imdb_id": imdb,
+                        "tmdb_id": tmdb_id,
+                        "runtime_min": runtime_min,
+                        "cover_filename": cover_filename,
+                        "has_cz_audio": has_cz_audio,
+                        "has_cz_subs": has_cz_subs,
+                        "primary_upload": primary_upload_id,
+                        "has_sk_dub": has_sk_dub,
+                        "has_sk_subs": has_sk_subs,
+                    })
+                    row = cur.fetchone()
+                    cur.execute("RELEASE SAVEPOINT film_insert_sp")
+                    break
+                except psycopg2.errors.UniqueViolation as e:
+                    cur.execute("ROLLBACK TO SAVEPOINT film_insert_sp")
+                    cur.execute("RELEASE SAVEPOINT film_insert_sp")
+                    constraint = getattr(getattr(e, "diag", None), "constraint_name", None) or ""
+                    if "slug" not in constraint:
+                        # imdb_id conflict (ON CONFLICT DO NOTHING handles it
+                        # as row=None) or some other unique index — re-raise.
+                        raise
+                    if attempt == MAX_SLUG_RETRIES:
+                        log.error("slug retry exhausted for imdb=%s slug=%s",
+                                  imdb, slug)
+                        raise
+                    slug_retries += 1
+                    log.warning("slug '%s' collided (%s); regenerating for imdb=%s",
+                                slug, constraint, imdb)
+                    slug = unique_slug(cur, base_slug, year, reserved_slugs)
+                    reserved_slugs.add(slug)
             if row is None:
                 # ON CONFLICT DO NOTHING — someone else inserted this imdb
-                # between our missing-check SELECT and now (or re-run hit a
-                # row created by earlier iteration of this loop in a prior
-                # crashed run). Skip uploads.
+                # between our missing-check SELECT and now (or a re-run hit a
+                # row created by an earlier crashed run). Skip uploads.
                 conflict_skips += 1
                 continue
             film_id = row[0]
@@ -754,30 +805,30 @@ def main() -> int:
 
         log.info("Done in %.1fs: inserted %d films, %d uploads",
                  time.time() - t1, inserted_films, inserted_uploads)
-        log.info("  tmdb_failures=%d  no_uploads=%d  no_poster=%d  conflict_skips=%d",
-                 tmdb_failures, no_uploads, no_poster, conflict_skips)
+        log.info("  tmdb_failures=%d  no_uploads=%d  no_poster=%d  "
+                 "conflict_skips=%d  slug_retries=%d",
+                 tmdb_failures, no_uploads, no_poster, conflict_skips, slug_retries)
 
-        # ---- Row-count invariant: never decreases ----
+        # ---- Row-count invariant ----
+        # Monotonic growth is the hard invariant (never decrease). Equality
+        # with before+inserted is the "ideal" state; a mismatch can happen
+        # legitimately when a concurrent writer inserts rows between our
+        # baseline COUNT and the final COUNT, so we only warn there — both
+        # in live and dry-run modes.
         cur.execute("SELECT COUNT(*) FROM films")
         films_count_after = cur.fetchone()[0]
         expected_after = films_count_before + inserted_films
-        if args.dry_run:
-            # In dry-run mode the inserts are still visible within the open
-            # transaction; they'll roll back on the final conn.rollback().
-            if films_count_after != expected_after:
-                log.error("INVARIANT (dry-run pre-rollback): count mismatch "
-                          "before=%d after=%d expected=%d",
-                          films_count_before, films_count_after, expected_after)
-                conn.rollback()
-                return 3
-        elif films_count_after < films_count_before:
+        if films_count_after < films_count_before:
             log.error("FATAL: films count DECREASED %d → %d",
                       films_count_before, films_count_after)
             return 3
-        elif films_count_after != expected_after:
-            log.warning("films count after (%d) != before+inserted (%d); "
-                        "probably concurrent import — still monotonic",
-                        films_count_after, expected_after)
+        if films_count_after != expected_after:
+            log.warning(
+                "%sfilms count after (%d) != before+inserted (%d); "
+                "probably concurrent import — still monotonic",
+                "DRY-RUN: " if args.dry_run else "",
+                films_count_after, expected_after,
+            )
         log.info("films count OK: before=%d after=%d (+%d)",
                  films_count_before, films_count_after,
                  films_count_after - films_count_before)
@@ -785,14 +836,6 @@ def main() -> int:
         if args.dry_run:
             log.info("DRY-RUN: ROLLBACK")
             conn.rollback()
-            # Clean up cover files created during the dry run so re-running
-            # a real import from scratch starts with a clean cover dir.
-            for p in dry_run_covers_created:
-                try:
-                    if p and p.exists():
-                        p.unlink()
-                except OSError:
-                    pass
         else:
             conn.commit()
             log.info("COMMIT")
@@ -801,6 +844,15 @@ def main() -> int:
         conn.rollback()
         raise
     finally:
+        # Dry-run cover cleanup runs here so any covers downloaded before
+        # an early exit / raised exception still get unlinked.
+        if args.dry_run:
+            for p in dry_run_covers_created:
+                try:
+                    if p and p.exists():
+                        p.unlink()
+                except OSError:
+                    pass
         conn.close()
         session.close()
 

--- a/scripts/import-prehrajto-new-films.py
+++ b/scripts/import-prehrajto-new-films.py
@@ -1,0 +1,809 @@
+#!/usr/bin/env python3
+"""Bulk-import NEW films from prehraj.to sitemap pilot (issue #524).
+
+Sibling of scripts/import-prehrajto-uploads.py (#520). Where #520 only
+enriched films already present in `films`, this script INSERTs brand-new
+`films` rows for IMDB-matched clusters whose imdb_id is not yet in the DB,
+then attaches their prehraj.to uploads with the same logic.
+
+Metadata comes from TMDB, never from prehraj.to upload titles:
+  * `title`          = TMDB cs-CZ `.title` (fallback to `.original_title`)
+  * `original_title` = TMDB en-US `.title`  (stored only when different from CZ)
+  * `description`    = TMDB cs-CZ `.overview` (fallback to en-US `.overview`)
+  * `year`           = `.release_date[:4]`
+  * `runtime_min`    = `.runtime`
+  * `cover_filename` = downloaded via auto_import.cover_downloader.download_cover
+  * `generated_description` = NULL (filled later by Gemma-4 SEO job, #527)
+
+Safety guarantees (hard-enforced at runtime):
+  - Never DELETE from films, film_prehrajto_uploads, or any other table.
+  - Never UPDATE existing films rows — uses `INSERT ... ON CONFLICT (imdb_id)
+    DO NOTHING` so re-runs skip films someone else already inserted.
+  - Row-count monotonicity: `SELECT COUNT(*) FROM films` after run ==
+    before + len(candidate imdbs missing from DB) − ON-CONFLICT skips.
+    Never decreases.
+  - --dry-run uses a single transaction + ROLLBACK at the end.
+  - Live run commits in batches (every --commit-every films) to avoid
+    multi-hour transactions; invariant still fires at the end.
+
+Usage:
+  DATABASE_URL=postgres://... TMDB_API_KEY=... \\
+      python3 scripts/import-prehrajto-new-films.py \\
+          --sitemap-dir /tmp/prehrajto-pilot \\
+          --matches /tmp/prehrajto-pilot/matches-full.csv \\
+          --covers-dir data/movies/covers-webp \\
+          --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import html
+import logging
+import math
+import os
+import re
+import sys
+import time
+import unicodedata
+from collections import defaultdict
+from collections.abc import Iterator
+from pathlib import Path
+
+try:
+    import psycopg2
+    import psycopg2.extras
+except ImportError:
+    print("ERROR: psycopg2 not installed. pip install psycopg2-binary", file=sys.stderr)
+    sys.exit(2)
+
+try:
+    import requests
+except ImportError:
+    print("ERROR: requests not installed. pip install requests", file=sys.stderr)
+    sys.exit(2)
+
+# auto_import is a proper package at scripts/auto_import. Import the existing
+# cover downloader to avoid reimplementing TMDB image → WebP conversion.
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _SCRIPTS_DIR.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+from scripts.auto_import.cover_downloader import download_cover  # noqa: E402
+from scripts.auto_import.enricher import TMDB_MOVIE_GENRE_MAP  # noqa: E402
+
+log = logging.getLogger("import-prehrajto-new-films")
+
+TMDB_API_BASE = "https://api.themoviedb.org/3"
+TMDB_DEFAULT_TIMEOUT = 15
+
+
+# ---------------------------------------------------------------------------
+# Sitemap parsing + clustering (vendored from scripts/import-prehrajto-uploads.py)
+# ---------------------------------------------------------------------------
+
+_LOC_RE = re.compile(r"<loc>([^<]+)</loc>")
+_TITLE_RE = re.compile(r"<video:title>([^<]*)</video:title>")
+_DUR_RE = re.compile(r"<video:duration>(\d+)</video:duration>")
+_VIEWS_RE = re.compile(r"<video:view_count>(\d+)</video:view_count>")
+_LIVE_RE = re.compile(r"<video:live>(yes|no)</video:live>")
+_URL_BLOCK_RE = re.compile(r"<url>(.*?)</url>", re.DOTALL)
+_UPLOAD_ID_RE = re.compile(r"/([a-f0-9]{13,16})(?:[/?#]|$)")
+_YEAR_RE = re.compile(r"\b(19[2-9]\d|20[0-3]\d)\b")
+_EPISODE_RE = re.compile(r"\bS\d{1,2}[\s._-]?E\d{1,3}\b", re.IGNORECASE)
+
+
+def extract_year(title: str) -> int | None:
+    m = _YEAR_RE.search(title)
+    return int(m.group(1)) if m else None
+
+
+def normalize(s: str) -> str:
+    s = unicodedata.normalize("NFKD", s)
+    s = "".join(c for c in s if not unicodedata.combining(c))
+    return re.sub(r"[^a-z0-9]+", "", s.lower())
+
+
+def strip_title(title: str) -> str:
+    t = title
+    t = re.sub(r"\[([^\]]*)\]", r" \1 ", t)
+    t = re.sub(r"\(([^)]*)\)", r" \1 ", t)
+    t = _YEAR_RE.sub(" ", t)
+    t = re.sub(r"\.(?=[A-Za-z])", " ", t)
+    for g in (
+        r"c(?:z|s)\s*dabing", r"s(?:k|l)\s*dabing",
+        r"c(?:z|s)\s*tit(?:ulky)?", r"s(?:k|l)\s*tit(?:ulky)?",
+        r"c(?:z|s)\s*dab", r"s(?:k|l)\s*dab",
+        r"cztit", r"cesky\s*dabing", r"dabing", r"dabovane",
+    ):
+        t = re.sub(g, " ", t, flags=re.IGNORECASE)
+    t = re.sub(
+        r"\b(cz|sk|en|cesky|slovensky|titulky|tit|subs?|dub|eng|"
+        r"hd|fhd|full\s*hd|1080p|720p|4k|2160p|uhd|webrip|bluray|bdrip|dvdrip|"
+        r"hdtv|tvrip|hd\s*rip|dvd\s*rip|web\.?dl|x264|x265|h\.?264|h\.?265|hevc|"
+        r"aac|ac3|5\.1|avi|mkv|mp4|"
+        r"cely\s*film|cely|remastered|extended|uncut|directors?\s*cut|novinka|"
+        r"top\s*hit|hit|novinka|premiera|"
+        r"romant\.?|drama|horor|thriller|akc\.?|komedie|sci[-.]?fi|fantasy|rodinny|"
+        r"muzikal|p\.?p\.?|valec\.?|dobrodruzny|animovany|animovane|anim\.?|"
+        r"krimi|sportovni|koko|povidky|cd\.?\d*)\b",
+        " ", t, flags=re.IGNORECASE,
+    )
+    t = re.sub(r"\s+", " ", t).strip(" -_.,/|")
+    t = re.sub(r"[,\.]\s*(?=[,\.])", "", t)
+    t = re.sub(r"\s*,\s*$", "", t)
+    t = re.sub(r"^\s*[,\.-]+\s*", "", t)
+    return re.sub(r"\s+", " ", t).strip(" -_.,/|")
+
+
+def _unescape(s: str) -> str:
+    return html.unescape(html.unescape(s))
+
+
+def parse_sitemap(path: Path, chunk_size: int = 1 << 20) -> Iterator[dict]:
+    carry = ""
+    with open(path, encoding="utf-8", errors="replace") as f:
+        while True:
+            chunk = f.read(chunk_size)
+            if not chunk:
+                break
+            data = carry + chunk
+            last_close = data.rfind("</url>")
+            if last_close < 0:
+                carry = data
+                continue
+            complete = data[: last_close + len("</url>")]
+            carry = data[last_close + len("</url>") :]
+            for m in _URL_BLOCK_RE.finditer(complete):
+                block = m.group(1)
+                loc_m = _LOC_RE.search(block)
+                title_m = _TITLE_RE.search(block)
+                if not loc_m or not title_m:
+                    continue
+                dur_m = _DUR_RE.search(block)
+                views_m = _VIEWS_RE.search(block)
+                live_m = _LIVE_RE.search(block)
+                yield {
+                    "url": _unescape(loc_m.group(1)),
+                    "title": _unescape(title_m.group(1)),
+                    "duration": int(dur_m.group(1)) if dur_m else 0,
+                    "views": int(views_m.group(1)) if views_m else 0,
+                    "live": live_m.group(1) if live_m else "no",
+                }
+
+
+def film_shape(row: dict) -> bool:
+    t, d = row["title"], row["duration"]
+    if row["live"] == "yes" or not t:
+        return False
+    if _EPISODE_RE.search(t):
+        return False
+    if d < 60 * 60 or d > 240 * 60:
+        return False
+    if extract_year(t) is None:
+        return False
+    return row["views"] >= 50
+
+
+def cluster_key(row: dict) -> tuple:
+    core = normalize(strip_title(row["title"]))
+    year = extract_year(row["title"])
+    dur_bucket = row["duration"] // (3 * 60)
+    return (core, year, dur_bucket)
+
+
+def extract_upload_id(url: str) -> str | None:
+    m = _UPLOAD_ID_RE.search(url or "")
+    return m.group(1) if m else None
+
+
+# ---------------------------------------------------------------------------
+# Language detection (vendored from scripts/import-prehrajto-uploads.py)
+# ---------------------------------------------------------------------------
+
+CZ_DIACRITICS = set("ěščřžýáíéúůťďňôäľĺŕ")
+CZ_WORDS = {
+    "a", "i", "do", "na", "se", "si", "ze", "za", "po", "pro", "pod", "nad",
+    "v", "u", "o", "s", "k", "ke", "ku", "je", "jsou", "byl", "byla", "bylo",
+    "mě", "mně", "mi", "tě", "ty", "ten", "ta", "to", "jeho", "její",
+    "není", "náš", "naše", "svůj", "svá", "svou", "svém", "svému",
+    "co", "kdo", "kde", "kdy", "proč", "jak", "jaký", "která",
+    "jsem", "jsi", "jsme", "jste",
+}
+
+CZ_DUB_RE = re.compile(r"(?:\bcz\s*dab(?:ing)?\b|\bczdab\w*|\bczdub\w*|\bcesk[aáyý]\s*dab(?:ing)?\b|\bc[zs]\s*dabing\b|cesky\s*dabing|cz\s*\.dab\b)", re.IGNORECASE)
+CZ_SUB_RE = re.compile(r"(?:\bcz\s*tit(?:ulky)?\b|\bcztit\w*|\bcz\s*subs?\b|\bc[zs]\s*titulky\b|cesk[yé]\s*titulky)", re.IGNORECASE)
+SK_DUB_RE = re.compile(r"(?:\bsk\s*dab(?:ing)?\b|\bskdab\w*|\bskdub\w*|\bsloven(?:sk[yáé]|ina)\s*dab(?:ing)?\b)", re.IGNORECASE)
+SK_SUB_RE = re.compile(r"(?:\bsk\s*tit(?:ulky)?\b|\bsktit\w*)", re.IGNORECASE)
+EN_ONLY_RE = re.compile(r"(?:\bengsub\b|\beng\s*sub\b|\beng\s*only\b|\bengdub\b)", re.IGNORECASE)
+
+
+def detect_lang(title: str) -> str:
+    if not title:
+        return "UNKNOWN"
+    t = title.lower()
+    if CZ_DUB_RE.search(t):
+        return "CZ_DUB"
+    if SK_DUB_RE.search(t):
+        return "SK_DUB"
+    if CZ_SUB_RE.search(t):
+        return "CZ_SUB"
+    if SK_SUB_RE.search(t):
+        return "SK_SUB"
+    has_cz = bool(re.search(r"\bcz\b", t)) or bool(re.search(r"\bcesk[yáyé]", t))
+    if EN_ONLY_RE.search(t) and not has_cz:
+        return "EN"
+    dia_hits = sum(1 for c in t if c in CZ_DIACRITICS)
+    tokens = re.findall(r"[a-záčďéěíňóřšťúůýž]+", t)
+    cz_word_hits = sum(1 for tok in tokens if tok in CZ_WORDS)
+    if dia_hits >= 1 and cz_word_hits >= 1:
+        return "CZ_NATIVE"
+    if dia_hits >= 2:
+        return "CZ_NATIVE"
+    return "UNKNOWN"
+
+
+# ---------------------------------------------------------------------------
+# Primary-upload scoring (vendored)
+# ---------------------------------------------------------------------------
+
+LANG_PRIORITY = {
+    "CZ_DUB": 6, "CZ_NATIVE": 5, "CZ_SUB": 4,
+    "SK_DUB": 3, "SK_SUB": 2, "UNKNOWN": 1, "EN": 0,
+}
+
+_RES_RE = re.compile(r"(2160p|1080p|720p|480p|BDRip|BluRay|WEBRip|WEB[\s-]?DL|HDRip|DVDRip|HDTV|TVRip|CAM|TS)", re.IGNORECASE)
+_RES_SCORE = {
+    "2160p": 6, "1080p": 5, "720p": 4, "480p": 2,
+    "BLURAY": 5, "BDRIP": 4, "WEBRIP": 4, "WEBDL": 4, "WEB-DL": 4, "WEB DL": 4,
+    "HDRIP": 3, "HDTV": 3, "TVRIP": 2, "DVDRIP": 2,
+    "CAM": 0, "TS": 0,
+}
+
+
+def extract_resolution(title: str) -> str | None:
+    m = _RES_RE.search(title or "")
+    return m.group(1).lower() if m else None
+
+
+def _res_score(hint: str | None) -> int:
+    if not hint:
+        return 1
+    key = hint.upper().replace("-", "").replace(" ", "")
+    return _RES_SCORE.get(key, 1)
+
+
+def rank(lang_class: str, resolution_hint: str | None, view_count: int) -> float:
+    lp = LANG_PRIORITY.get(lang_class, 0)
+    rs = _res_score(resolution_hint)
+    vs = math.log10((view_count or 0) + 1)
+    return lp * 1000 + rs * 10 + vs
+
+
+# ---------------------------------------------------------------------------
+# Slug helpers (vendored from scripts/auto_import/enricher.py)
+# ---------------------------------------------------------------------------
+
+
+def slugify(text: str) -> str:
+    if not text:
+        return ""
+    s = unicodedata.normalize("NFKD", text)
+    s = s.encode("ascii", "ignore").decode("ascii")
+    s = s.lower()
+    s = re.sub(r"[^a-z0-9]+", "-", s)
+    return s.strip("-")
+
+
+def unique_slug(cur, base: str, year: int | None, reserved: set[str]) -> str:
+    """Find a free slug — check DB + in-batch reserved set.
+
+    Mirrors enricher._unique_slug but additionally de-duplicates against
+    slugs already assigned earlier in the same run (reserved), since new
+    films are inserted one-by-one and a batch of two films with the same
+    title would otherwise collide on the `films.slug` UNIQUE constraint.
+    """
+    def free(candidate: str) -> bool:
+        if candidate in reserved:
+            return False
+        cur.execute("SELECT 1 FROM films WHERE slug = %s", (candidate,))
+        return cur.fetchone() is None
+
+    if not base:
+        base = "film"
+    if free(base):
+        return base
+    if year:
+        candidate = f"{base}-{year}"
+        if free(candidate):
+            return candidate
+    counter = 2
+    while True:
+        candidate = f"{base}-{counter}"
+        if free(candidate):
+            return candidate
+        counter += 1
+
+
+# ---------------------------------------------------------------------------
+# TMDB helper
+# ---------------------------------------------------------------------------
+
+
+def tmdb_get(session: requests.Session, path: str, params: dict,
+             api_key: str, retries: int = 3) -> dict | None:
+    """GET TMDB endpoint with retry on 429 / transient failure."""
+    p = {"api_key": api_key}
+    p.update(params)
+    url = f"{TMDB_API_BASE}{path}"
+    for attempt in range(retries):
+        try:
+            r = session.get(url, params=p, timeout=TMDB_DEFAULT_TIMEOUT)
+        except requests.RequestException as e:
+            log.warning("TMDB %s attempt %d failed: %s", path, attempt + 1, e)
+            time.sleep(1 + attempt)
+            continue
+        if r.status_code == 404:
+            return None
+        if r.status_code == 429:
+            wait = int(r.headers.get("Retry-After", 5))
+            log.warning("TMDB rate-limited; sleeping %ds", wait)
+            time.sleep(wait)
+            continue
+        if r.status_code != 200:
+            log.warning("TMDB %s HTTP %d", path, r.status_code)
+            return None
+        try:
+            return r.json()
+        except ValueError:
+            return None
+    return None
+
+
+def fetch_tmdb_movie(session: requests.Session, tmdb_id: int,
+                     api_key: str) -> dict | None:
+    """Fetch cs-CZ + en-US /movie/{id} and merge into one dict.
+
+    Returns keys: title_cs, title_en, original_title, overview_cs, overview_en,
+    year, runtime_min, poster_path, genre_ids, imdb_id. Returns None if both
+    language fetches fail (usually a stale tmdb_id).
+    """
+    cs = tmdb_get(session, f"/movie/{tmdb_id}", {"language": "cs-CZ"}, api_key)
+    en = tmdb_get(session, f"/movie/{tmdb_id}", {"language": "en-US"}, api_key)
+    if not cs and not en:
+        return None
+    src_cs = cs or {}
+    src_en = en or {}
+    rd = src_cs.get("release_date") or src_en.get("release_date") or ""
+    year = int(rd[:4]) if len(rd) >= 4 and rd[:4].isdigit() else None
+    return {
+        "tmdb_id": tmdb_id,
+        "imdb_id": src_cs.get("imdb_id") or src_en.get("imdb_id") or None,
+        "title_cs": (src_cs.get("title") or "").strip() or None,
+        "title_en": (src_en.get("title") or "").strip() or None,
+        "original_title": (src_en.get("original_title") or src_cs.get("original_title") or "").strip() or None,
+        "overview_cs": (src_cs.get("overview") or "").strip() or None,
+        "overview_en": (src_en.get("overview") or "").strip() or None,
+        "year": year,
+        "runtime_min": src_cs.get("runtime") or src_en.get("runtime") or None,
+        "poster_path": src_cs.get("poster_path") or src_en.get("poster_path") or None,
+        "genre_ids": [g["id"] for g in (src_cs.get("genres") or src_en.get("genres") or []) if g.get("id")],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Matches CSV loader
+# ---------------------------------------------------------------------------
+
+
+def load_matches(path: Path) -> dict[tuple, dict]:
+    """Same shape as scripts/import-prehrajto-uploads.py: cluster_key → row."""
+    matches_by_key: dict[tuple, dict] = {}
+    with open(path, newline="", encoding="utf-8") as f:
+        for row in csv.DictReader(f):
+            if row["verdict"] not in ("MATCHED", "LIKELY"):
+                continue
+            if not row["imdb_id"] or not row["tmdb_id"]:
+                continue
+            try:
+                year = int(row["cluster_year"]) if row["cluster_year"] else None
+                dur_bucket = int(row["cluster_duration_min"]) // 3
+            except ValueError:
+                continue
+            key = (row["cluster_core"], year, dur_bucket)
+            matches_by_key[key] = row
+    return matches_by_key
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        stream=sys.stderr,
+    )
+
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument("--sitemap-dir", required=True,
+                    help="Directory containing video-sitemap-*.xml files")
+    ap.add_argument("--matches", required=True,
+                    help="Path to matches-full.csv (from pilot)")
+    ap.add_argument("--covers-dir", default="data/movies/covers-webp",
+                    help="Directory to write cover WebPs into (created if missing)")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Run end-to-end but ROLLBACK at the end — no writes persisted "
+                         "and no cover files left behind (covers are deleted if dry-run)")
+    ap.add_argument("--limit", type=int, default=0,
+                    help="Process at most N new films (0 = all)")
+    ap.add_argument("--commit-every", type=int, default=500,
+                    help="In live mode, commit after every N films (default 500). "
+                         "Set 0 to keep a single transaction.")
+    ap.add_argument("--tmdb-min-interval-ms", type=int, default=25,
+                    help="Minimum ms between TMDB requests (default 25 = 40 rps). "
+                         "TMDB's own rate limit is ~50 rps.")
+    ap.add_argument("--skip-covers", action="store_true",
+                    help="Skip cover download entirely — for DRY-RUN sanity checks "
+                         "without hitting image.tmdb.org")
+    args = ap.parse_args()
+
+    dsn = os.environ.get("DATABASE_URL", "").strip()
+    if not dsn:
+        log.error("DATABASE_URL env var required")
+        return 2
+    api_key = os.environ.get("TMDB_API_KEY", "").strip()
+    if not api_key:
+        log.error("TMDB_API_KEY env var required")
+        return 2
+
+    sitemap_dir = Path(args.sitemap_dir)
+    files = sorted(sitemap_dir.glob("video-sitemap-*.xml"),
+                   key=lambda p: int(re.search(r"(\d+)", p.stem).group(1)))
+    if not files:
+        log.error("no video-sitemap-*.xml files in %s", sitemap_dir)
+        return 2
+
+    covers_dir = Path(args.covers_dir)
+    covers_dir.mkdir(parents=True, exist_ok=True)
+
+    # ---- Load matches from pilot CSV ----
+    log.info("Loading matches from %s ...", args.matches)
+    matches_by_key = load_matches(Path(args.matches))
+    log.info("  %d IMDB-matched clusters in CSV", len(matches_by_key))
+
+    # ---- Stream-parse sitemaps, bucketing uploads by cluster_key ----
+    log.info("Parsing %d sitemaps from %s ...", len(files), sitemap_dir)
+    t0 = time.time()
+    wanted_keys = set(matches_by_key.keys())
+    clusters: dict[tuple, list[dict]] = defaultdict(list)
+    total_entries = 0
+    film_shape_count = 0
+    for p in files:
+        for r in parse_sitemap(p):
+            total_entries += 1
+            if not film_shape(r):
+                continue
+            film_shape_count += 1
+            k = cluster_key(r)
+            if k in wanted_keys:
+                clusters[k].append(r)
+    log.info("  %d entries scanned in %.1fs (%d film-shape, %d clusters matched)",
+             total_entries, time.time() - t0, film_shape_count, len(clusters))
+
+    # ---- Connect, compute NEW cohort (imdb_id not in DB) ----
+    conn = psycopg2.connect(dsn)
+    conn.autocommit = False
+    session = requests.Session()
+    session.headers.update({"Accept": "application/json"})
+    try:
+        cur = conn.cursor()
+
+        cur.execute("SELECT COUNT(*) FROM films")
+        films_count_before = cur.fetchone()[0]
+        log.info("films baseline count: %d", films_count_before)
+
+        candidate_imdbs = sorted({m["imdb_id"] for m in matches_by_key.values()})
+        cur.execute(
+            "SELECT imdb_id FROM films WHERE imdb_id = ANY(%s)",
+            (candidate_imdbs,),
+        )
+        existing_imdbs = {r[0] for r in cur.fetchall()}
+        missing_imdbs = [i for i in candidate_imdbs if i not in existing_imdbs]
+        log.info("  %d candidates, %d already in DB → %d NEW to import",
+                 len(candidate_imdbs), len(existing_imdbs), len(missing_imdbs))
+
+        # Build imdb_id → tmdb_id (first seen wins; multiple cluster keys can
+        # point to the same IMDB).
+        imdb_to_tmdb: dict[str, int] = {}
+        # Build imdb_id → list of upload dicts (aggregated across all clusters
+        # that resolved to that IMDB).
+        imdb_to_uploads: dict[str, list[dict]] = defaultdict(list)
+        for key, match in matches_by_key.items():
+            imdb = match["imdb_id"]
+            if imdb in existing_imdbs:
+                continue
+            try:
+                tid = int(match["tmdb_id"])
+            except ValueError:
+                continue
+            if imdb not in imdb_to_tmdb:
+                imdb_to_tmdb[imdb] = tid
+            imdb_to_uploads[imdb].extend(clusters.get(key, []))
+        log.info("  %d new IMDBs with tmdb_id + uploads queue",
+                 sum(1 for u in imdb_to_uploads.values() if u))
+
+        if args.limit:
+            missing_imdbs = missing_imdbs[: args.limit]
+            log.info("  --limit=%d, narrowing to %d IMDBs",
+                     args.limit, len(missing_imdbs))
+
+        if not missing_imdbs:
+            log.info("Nothing to do — all candidates already in DB.")
+            return 0
+
+        # ---- Genre slug → id lookup ----
+        cur.execute("SELECT slug, id FROM genres")
+        slug_to_genre_id = dict(cur.fetchall())
+
+        # ---- SQL statements ----
+        # INSERT film. ON CONFLICT (imdb_id) requires the partial UNIQUE index
+        # added by migration 050; we always supply a non-NULL imdb_id so the
+        # conflict target is well-defined.
+        insert_film_sql = """
+        INSERT INTO films (
+            title, original_title, slug, year, description, generated_description,
+            imdb_id, tmdb_id, runtime_min, cover_filename,
+            imdb_rating, csfd_rating,
+            sktorrent_video_id, sktorrent_cdn, sktorrent_qualities,
+            has_dub, has_subtitles,
+            prehrajto_url, prehrajto_has_dub, prehrajto_has_subs,
+            prehrajto_primary_upload_id, prehrajto_has_sk_dub, prehrajto_has_sk_subs,
+            created_at, added_at
+        ) VALUES (
+            %(title)s, %(original_title)s, %(slug)s, %(year)s, %(description)s, NULL,
+            %(imdb_id)s, %(tmdb_id)s, %(runtime_min)s, %(cover_filename)s,
+            NULL, NULL,
+            NULL, NULL, NULL,
+            false, false,
+            NULL, %(has_cz_audio)s, %(has_cz_subs)s,
+            %(primary_upload)s, %(has_sk_dub)s, %(has_sk_subs)s,
+            NOW(), NOW()
+        )
+        ON CONFLICT (imdb_id) WHERE imdb_id IS NOT NULL DO NOTHING
+        RETURNING id
+        """
+        insert_upload_sql = """
+        INSERT INTO film_prehrajto_uploads
+            (film_id, upload_id, url, title, duration_sec, view_count,
+             lang_class, resolution_hint, last_seen_at, is_alive)
+        VALUES
+            (%(film_id)s, %(upload_id)s, %(url)s, %(title)s, %(duration_sec)s,
+             %(view_count)s, %(lang_class)s, %(resolution_hint)s, NOW(), TRUE)
+        ON CONFLICT (film_id, upload_id) DO UPDATE SET
+            url             = EXCLUDED.url,
+            title           = EXCLUDED.title,
+            duration_sec    = EXCLUDED.duration_sec,
+            view_count      = EXCLUDED.view_count,
+            lang_class      = EXCLUDED.lang_class,
+            resolution_hint = EXCLUDED.resolution_hint,
+            last_seen_at    = EXCLUDED.last_seen_at,
+            is_alive        = TRUE
+        """
+        insert_genre_sql = (
+            "INSERT INTO film_genres (film_id, genre_id) VALUES (%s, %s) "
+            "ON CONFLICT DO NOTHING"
+        )
+
+        # ---- Loop over missing IMDBs ----
+        commit_every = 0 if args.dry_run else args.commit_every
+        tmdb_min_interval = max(0.0, args.tmdb_min_interval_ms / 1000.0)
+        last_tmdb_call = 0.0
+        inserted_films = 0
+        inserted_uploads = 0
+        tmdb_failures = 0
+        no_uploads = 0
+        no_poster = 0
+        conflict_skips = 0
+        reserved_slugs: set[str] = set()
+        dry_run_covers_created: list[Path] = []
+
+        t1 = time.time()
+        for i, imdb in enumerate(missing_imdbs, 1):
+            tmdb_id = imdb_to_tmdb.get(imdb)
+            if not tmdb_id:
+                continue
+            # Crude rate-limit: space TMDB calls out.
+            elapsed = time.time() - last_tmdb_call
+            if elapsed < tmdb_min_interval:
+                time.sleep(tmdb_min_interval - elapsed)
+            movie = fetch_tmdb_movie(session, tmdb_id, api_key)
+            last_tmdb_call = time.time()
+            if not movie:
+                tmdb_failures += 1
+                continue
+            # Sanity: TMDB's imdb_id should match the pilot CSV's imdb_id.
+            if movie["imdb_id"] and movie["imdb_id"] != imdb:
+                log.warning("IMDB mismatch for tmdb_id=%s: pilot=%s tmdb=%s — skipping",
+                            tmdb_id, imdb, movie["imdb_id"])
+                continue
+
+            # ---- Metadata ----
+            title = movie["title_cs"] or movie["title_en"] or movie["original_title"] or "Film"
+            title_en = movie["title_en"]
+            original_title = title_en if title_en and title_en != title else None
+            description = movie["overview_cs"] or movie["overview_en"]
+            year = movie["year"]
+            runtime_min = movie["runtime_min"]
+
+            base_slug = slugify(title)
+            slug = unique_slug(cur, base_slug, year, reserved_slugs)
+            reserved_slugs.add(slug)
+
+            # ---- Aggregate uploads for this IMDB ----
+            seen_ids: set[str] = set()
+            per_upload: list[dict] = []
+            for u in imdb_to_uploads.get(imdb, []):
+                upload_id = extract_upload_id(u["url"])
+                if not upload_id or upload_id in seen_ids:
+                    continue
+                seen_ids.add(upload_id)
+                lang = detect_lang(u["title"])
+                res = extract_resolution(u["title"])
+                per_upload.append({
+                    "upload_id": upload_id,
+                    "url": u["url"],
+                    "title": u["title"],
+                    "duration_sec": u["duration"] or None,
+                    "view_count": u["views"] or None,
+                    "lang_class": lang,
+                    "resolution_hint": res,
+                    "_rank": rank(lang, res, u["views"]),
+                })
+
+            if not per_upload:
+                # No uploads attached — per issue, skip (this film wouldn't be
+                # playable anyway). Counts toward `no_uploads` stat.
+                no_uploads += 1
+                continue
+
+            per_upload.sort(key=lambda d: -d["_rank"])
+            primary_upload_id = per_upload[0]["upload_id"]
+            has_cz_audio = any(u["lang_class"] in ("CZ_DUB", "CZ_NATIVE") for u in per_upload)
+            has_cz_subs = any(u["lang_class"] == "CZ_SUB" for u in per_upload)
+            has_sk_dub = any(u["lang_class"] == "SK_DUB" for u in per_upload)
+            has_sk_subs = any(u["lang_class"] == "SK_SUB" for u in per_upload)
+
+            # ---- Cover download (poster_path → WebP). TMDB-only; no SKT
+            # fallback because this cohort has no SKT source by definition. ----
+            cover_filename: str | None = None
+            if movie["poster_path"] and not args.skip_covers:
+                try:
+                    paths = download_cover(movie["poster_path"], slug, covers_dir)
+                except Exception as e:
+                    log.warning("cover download raised for %s: %s", slug, e)
+                    paths = None
+                if paths:
+                    cover_filename = slug
+                    if args.dry_run:
+                        dry_run_covers_created.extend(paths)
+            if cover_filename is None:
+                no_poster += 1
+
+            # ---- INSERT film ----
+            cur.execute(insert_film_sql, {
+                "title": title,
+                "original_title": original_title,
+                "slug": slug,
+                "year": year,
+                "description": description,
+                "imdb_id": imdb,
+                "tmdb_id": tmdb_id,
+                "runtime_min": runtime_min,
+                "cover_filename": cover_filename,
+                "has_cz_audio": has_cz_audio,
+                "has_cz_subs": has_cz_subs,
+                "primary_upload": primary_upload_id,
+                "has_sk_dub": has_sk_dub,
+                "has_sk_subs": has_sk_subs,
+            })
+            row = cur.fetchone()
+            if row is None:
+                # ON CONFLICT DO NOTHING — someone else inserted this imdb
+                # between our missing-check SELECT and now (or re-run hit a
+                # row created by earlier iteration of this loop in a prior
+                # crashed run). Skip uploads.
+                conflict_skips += 1
+                continue
+            film_id = row[0]
+            inserted_films += 1
+
+            # ---- INSERT uploads ----
+            upload_rows = [
+                {**{k: v for k, v in u.items() if not k.startswith("_")},
+                 "film_id": film_id}
+                for u in per_upload
+            ]
+            psycopg2.extras.execute_batch(cur, insert_upload_sql, upload_rows, page_size=200)
+            inserted_uploads += len(upload_rows)
+
+            # ---- Genre links ----
+            for tmdb_gid in movie["genre_ids"]:
+                genre_slug = TMDB_MOVIE_GENRE_MAP.get(tmdb_gid)
+                if not genre_slug:
+                    continue
+                gid = slug_to_genre_id.get(genre_slug)
+                if gid is None:
+                    continue
+                cur.execute(insert_genre_sql, (film_id, gid))
+
+            if commit_every and inserted_films % commit_every == 0:
+                conn.commit()
+
+            if i % 100 == 0:
+                rate = i / (time.time() - t1)
+                log.info("[%d/%d]  films+=%d  uploads+=%d  tmdb_fail=%d  rate=%.1f/s",
+                         i, len(missing_imdbs), inserted_films, inserted_uploads,
+                         tmdb_failures, rate)
+
+        log.info("Done in %.1fs: inserted %d films, %d uploads",
+                 time.time() - t1, inserted_films, inserted_uploads)
+        log.info("  tmdb_failures=%d  no_uploads=%d  no_poster=%d  conflict_skips=%d",
+                 tmdb_failures, no_uploads, no_poster, conflict_skips)
+
+        # ---- Row-count invariant: never decreases ----
+        cur.execute("SELECT COUNT(*) FROM films")
+        films_count_after = cur.fetchone()[0]
+        expected_after = films_count_before + inserted_films
+        if args.dry_run:
+            # In dry-run mode the inserts are still visible within the open
+            # transaction; they'll roll back on the final conn.rollback().
+            if films_count_after != expected_after:
+                log.error("INVARIANT (dry-run pre-rollback): count mismatch "
+                          "before=%d after=%d expected=%d",
+                          films_count_before, films_count_after, expected_after)
+                conn.rollback()
+                return 3
+        elif films_count_after < films_count_before:
+            log.error("FATAL: films count DECREASED %d → %d",
+                      films_count_before, films_count_after)
+            return 3
+        elif films_count_after != expected_after:
+            log.warning("films count after (%d) != before+inserted (%d); "
+                        "probably concurrent import — still monotonic",
+                        films_count_after, expected_after)
+        log.info("films count OK: before=%d after=%d (+%d)",
+                 films_count_before, films_count_after,
+                 films_count_after - films_count_before)
+
+        if args.dry_run:
+            log.info("DRY-RUN: ROLLBACK")
+            conn.rollback()
+            # Clean up cover files created during the dry run so re-running
+            # a real import from scratch starts with a clean cover dir.
+            for p in dry_run_covers_created:
+                try:
+                    if p and p.exists():
+                        p.unlink()
+                except OSError:
+                    pass
+        else:
+            conn.commit()
+            log.info("COMMIT")
+        return 0
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+        session.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
<!-- claude-session: 74da902e-6000-4680-8b0a-b1bb3db8128b -->

Part of #518 — closes #524 once the stage + prod run is verified.

## Summary
Add a new-film importer that INSERTs brand-new `films` rows for IMDB-matched clusters not yet in DB, then attaches their prehraj.to uploads and rollup flags. Sibling of `scripts/import-prehrajto-uploads.py` (which was #520, upload-only).

**Scope of the cohort:** pilot CSV has 18 947 IMDB-matched candidates; 10 163 already in DB, leaving **8 784 NEW films to import**. Verified locally by running `--dry-run --limit 0` against `cr_dev`.

## Files
| Path | Purpose |
|---|---|
| `cr-infra/migrations/20260521_050_films_imdb_id_unique.sql` | Upgrade `idx_films_imdb_id` → UNIQUE partial index so `ON CONFLICT (imdb_id) DO NOTHING` works |
| `scripts/import-prehrajto-new-films.py` | The importer (~550 LOC; sitemap parsing + language detection + primary-upload scoring vendored from #520, TMDB fetch + film INSERT + cover download are new) |

## Metadata mapping (TMDB → films)
- `title` = TMDB `/movie/{id}?language=cs-CZ` `.title` (fallback `.original_title`)
- `original_title` = TMDB `/movie/{id}?language=en-US` `.title` (stored only when ≠ CZ title)
- `description` = TMDB cs-CZ `.overview` (fallback en-US)
- `year` = `.release_date[:4]`
- `runtime_min` = `.runtime`
- `cover_filename` = mirrored via `auto_import.cover_downloader.download_cover` (TMDB poster → WebP at 200×300 and 780×1170)
- `genre_ids` → `film_genres` via existing `TMDB_MOVIE_GENRE_MAP`
- `generated_description` = **NULL** (filled later by #527 Gemma-4 SEO job)
- `prehrajto_has_dub` / `_has_subs` / `_has_sk_dub` / `_has_sk_subs` / `_primary_upload_id` computed from attached uploads (same logic as #520)
- Identification predicate for the cohort stays `sktorrent_video_id IS NULL AND prehrajto_primary_upload_id IS NOT NULL` — no dedicated flag column added.

## Safety invariants (hard-enforced at runtime)
- ❌ No `DELETE` or `TRUNCATE` in the script.
- ❌ No `UPDATE` on existing `films` rows — `INSERT ... ON CONFLICT (imdb_id) DO NOTHING RETURNING id` so re-runs skip rows that someone else (or an earlier crashed run) already inserted. The `conflict_skips` counter reports how many fell through.
- ✅ Row-count monotonicity: films count after >= before is the hard invariant; a mismatch against `before + inserted` is logged (possible concurrent import) but still passes.
- ✅ `--dry-run` wraps the whole run in a single transaction that `ROLLBACK`s at the end; any cover WebPs downloaded during dry-run are `unlink`ed on exit.
- ✅ `--commit-every N` (default 500) checkpoints in live mode so the transaction stays bounded.

## Local verification
```
$ DATABASE_URL=postgres://cr_dev_user@localhost/cr_dev \
  TMDB_API_KEY=... \
  python3 scripts/import-prehrajto-new-films.py \
      --sitemap-dir /tmp/prehrajto-pilot \
      --matches /tmp/prehrajto-pilot/matches-full.csv \
      --dry-run --limit 3 --skip-covers
  38946 IMDB-matched clusters in CSV
  9164441 entries scanned in 134.3s (110850 film-shape, 38911 clusters matched)
  films baseline count: 17137
  18947 candidates, 10163 already in DB → 8784 NEW to import
  Done in 1.1s: inserted 3 films, 3 uploads
  films count OK: before=17137 after=17140 (+3)
  DRY-RUN: ROLLBACK
```
Post-rollback: `SELECT COUNT(*) FROM films` still returns 17 137. ✅

End-to-end test with cover download (`--limit 1`, no `--skip-covers`): TMDB poster mirrored to `/tmp/new-films-test-covers/the-lure-of-jade.webp` and `-large.webp`, then unlinked on rollback. ✅

Migration 050 is idempotent (`DROP INDEX IF EXISTS ... CREATE UNIQUE INDEX IF NOT EXISTS ...`) and verified locally: 17 129 non-null `imdb_id` values are all distinct.

## Operational — requires user authorization
Running the importer touches shared DBs, so this PR is code-only. I'll not run the migration or the importer on stage/prod until you approve. Recommended order:

- [ ] **You:** trigger `scripts/backup-db.sh` on prod (R2 snapshot)
- [ ] **You:** run migration 050 on stage (e.g. via existing migration tooling)
- [ ] **You or me under your supervision:** `--dry-run` on stage (verify counts, spot-check 10 sample rows printed via extra logging)
- [ ] **You or me:** live run on stage (no `--dry-run`, `--commit-every 500`)
- [ ] **You:** spot-check 50 random newly-imported films (poster loads, player resolves, both titles shown, "Další zdroje" shows N uploads)
- [ ] **You:** coordinate with SEO / indexing
- [ ] **You:** run migration 050 + importer on prod
- [ ] **You:** re-run `--dry-run` on prod post-commit to confirm idempotency (should insert 0)

## Test plan
- [x] `python3 scripts/import-prehrajto-new-films.py --help` renders cleanly
- [x] Helper smoke-tests: `extract_year`, `extract_upload_id`, `detect_lang`, `slugify`
- [x] Dry-run limit=3 `--skip-covers` on cr_dev → 3 inserts, clean ROLLBACK
- [x] Dry-run limit=1 WITH covers → TMDB poster downloaded to WebP, cleaned up after rollback
- [x] Migration 050 idempotency (re-apply = no-op notices)
- [ ] Dry-run on stage (requires `STAGING_DATABASE_URL` access)
- [ ] Live run on stage (`--commit-every 500`)
- [ ] Spot-check 50 random stage films on the UI
- [ ] Live run on prod

## Risks / rollback
- **Schema risk:** migration 050 briefly acquires an exclusive lock on `films` while creating the unique index; at 17 137 rows the wall-clock cost is <1 s locally. Rollback = `DROP INDEX idx_films_imdb_id_unique; CREATE INDEX idx_films_imdb_id ON films (imdb_id) WHERE imdb_id IS NOT NULL;`.
- **Data risk:** importer only INSERTs, never mutates existing rows. Rollback = `DELETE FROM films WHERE id > <snapshot_max_id> AND sktorrent_video_id IS NULL AND prehrajto_primary_upload_id IS NOT NULL AND created_at > <run_start>;` (plus cascading `film_prehrajto_uploads` + `film_genres`). Pre-run R2 backup is the real safety net.
- **Cover disk usage:** 8 784 films × 2 WebPs × ~70 KB ≈ **~1.2 GB** in `data/movies/covers-webp/`. Existing covers live in the same dir, so verify free space before running.

## Non-goals
- TMDB match re-derivation — pilot CSV already has `imdb_id` + `tmdb_id` per cluster.
- Gemma SEO rewrite — deferred to #527.
- Weekly reconciliation — deferred to #525.
- Running this on prod — deferred to explicit user approval.