### PR TITLE
fix(gemma): address Copilot review on PR #539

### DIFF
--- a/scripts/auto_import/gemma_writer.py
+++ b/scripts/auto_import/gemma_writer.py
@@ -132,3 +132,30 @@ def generate_unique_cs(
     builder = _build_prompt_series if is_series else _build_prompt_film
     prompt = builder(title, year, sources)
     return _call(prompt, keys[0])
+
+
+# ---------------------------------------------------------------------------
+# Public API for external batch jobs
+# ---------------------------------------------------------------------------
+# Batch scripts that drive their own key rotation + retry policy (e.g.
+# scripts/generate-film-descriptions-prehrajto.py) need direct access to
+# the prompt builder, the key loader, and a one-shot Gemini call. Expose
+# stable non-underscore aliases so those callers don't depend on what the
+# internal API happens to be named today.
+
+build_prompt_film = _build_prompt_film
+build_prompt_series = _build_prompt_series
+load_keys = _load_keys
+
+
+def call_gemma(prompt: str, key: str, timeout: int = DEFAULT_TIMEOUT) -> str | None:
+    """Single Gemini call with a caller-supplied key.
+
+    Returns the generated text, or None on:
+      * HTTP 429 (after sleeping `RATE_LIMIT_PAUSE` seconds)
+      * safety-filter refusal (no candidates returned)
+      * HTTP != 200
+      * network / JSON errors
+
+    The caller decides whether to retry — this function does not loop."""
+    return _call(prompt, key, timeout)

--- a/scripts/generate-film-descriptions-prehrajto.py
+++ b/scripts/generate-film-descriptions-prehrajto.py
@@ -9,10 +9,10 @@ en-US `.overview`). This script runs them through Gemma 4 (Gemini API) to
 produce unique 150–400 char Czech paraphrases for SEO — avoiding duplicate
 TMDB content across multiple Czech film sites.
 
-Reuses the 4-key rotation + prompt builder from `generate-film-descriptions.py`
-so we don't diverge on prompt tuning, and writes to `generated_description`
-only (NOT also to `description` — the film-detail template already prefers
-`generated_description` when set).
+Reuses `scripts/auto_import/gemma_writer.py` for prompt + API logic so the
+Gemini call surface stays in one place. That module's `_load_keys()` accepts
+either a single `GEMINI_API_KEY` (production cron) or parallel dev keys
+`GEMINI_API_KEY_1..4` (this script fans out across all of them).
 
 Usage:
     python3 scripts/generate-film-descriptions-prehrajto.py --dry-run --limit 5
@@ -23,7 +23,6 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import importlib.util
 import os
 import sys
 import time
@@ -32,19 +31,24 @@ from pathlib import Path
 
 import psycopg2
 
-# Reuse GEMINI_KEYS, build_prompt, call_gemma, PAUSE_BETWEEN_BATCHES from the
-# existing batch script. Import via importlib because the filename has hyphens
-# and isn't a valid module name for a plain `import`.
-_HERE = Path(__file__).resolve().parent
-_spec = importlib.util.spec_from_file_location(
-    "gen", _HERE / "generate-film-descriptions.py"
+# auto_import is a proper package at scripts/auto_import. Import gemma_writer
+# for prompt + Gemini API logic (no duplication vs other Gemma consumers in
+# the codebase). The underscore-prefixed names are treated as internal API
+# by callers within the same project; external users should go through the
+# `generate_unique_cs(...)` facade instead.
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _SCRIPTS_DIR.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+from scripts.auto_import.gemma_writer import (  # noqa: E402
+    _build_prompt_film,
+    _call,
+    _load_keys,
 )
-gen = importlib.util.module_from_spec(_spec)
-_spec.loader.exec_module(gen)
 
-DB_URL = os.environ.get(
-    "DATABASE_URL", "postgres://cr_dev_user:cr_dev_2026@localhost/cr_dev"
-)
+# Pause between batches gives Gemini's per-key rate limiter time to reset.
+# Matches the cadence in other bulk Gemma jobs in this repo.
+PAUSE_BETWEEN_BATCHES = 3
 
 
 COHORT_WHERE = (
@@ -70,18 +74,31 @@ def fetch_cohort(conn, limit: int) -> list[tuple[int, str, int, str]]:
     return cur.fetchall()
 
 
-def process_batch(batch, conn, dry_run: bool) -> tuple[int, int]:
+def generate_one(title: str, year: int, desc: str,
+                 key: str) -> tuple[str | None, int, str | None]:
+    """Thin wrapper around gemma_writer._call — returns (text, ms, err)."""
+    prompt = _build_prompt_film(title, year, [("TMDB", desc)])
+    start = time.time()
+    try:
+        text = _call(prompt, key)
+    except Exception as e:  # noqa: BLE001 — per-film isolation, logged upstream
+        return None, int((time.time() - start) * 1000), str(e)
+    duration_ms = int((time.time() - start) * 1000)
+    if not text:
+        return None, duration_ms, "No text (safety filter / rate limit / HTTP error)"
+    return text, duration_ms, None
+
+
+def process_batch(batch, keys, conn, dry_run: bool) -> tuple[int, int]:
     """Fire one Gemma call per row on its own worker key. Returns (ok, fail)."""
     ok = 0
     fail = 0
     cur = conn.cursor()
-    keys = gen.GEMINI_KEYS
     with ThreadPoolExecutor(max_workers=len(keys)) as ex:
         futures = {}
         for i, (fid, title, year, desc) in enumerate(batch):
-            sources = [("TMDB", desc)]
-            prompt = gen.build_prompt(title, year, sources)
-            futures[ex.submit(gen.call_gemma, prompt, i)] = (fid, title, year)
+            key = keys[i % len(keys)]
+            futures[ex.submit(generate_one, title, year, desc, key)] = (fid, title, year)
 
         for fut in as_completed(futures):
             fid, title, year = futures[fut]
@@ -117,11 +134,18 @@ def main() -> int:
                     help="Don't write to DB — print generated text instead")
     args = ap.parse_args()
 
-    if not gen.GEMINI_KEYS:
-        print("ERROR: No GEMINI_API_KEY_* set in .env", file=sys.stderr)
+    db_url = os.environ.get("DATABASE_URL", "").strip()
+    if not db_url:
+        print("ERROR: DATABASE_URL env var required", file=sys.stderr)
         return 2
 
-    conn = psycopg2.connect(DB_URL)
+    keys = _load_keys()
+    if not keys:
+        print("ERROR: No Gemini API key configured; set GEMINI_API_KEY or "
+              "GEMINI_API_KEY_1..4 in .env", file=sys.stderr)
+        return 2
+
+    conn = psycopg2.connect(db_url)
     try:
         rows = fetch_cohort(conn, args.limit)
         total = len(rows)
@@ -131,12 +155,11 @@ def main() -> int:
                   "`generated_description`.")
             return 0
 
-        keys = gen.GEMINI_KEYS
         est_batches = (total + len(keys) - 1) // len(keys)
-        est_sec = est_batches * gen.PAUSE_BETWEEN_BATCHES
+        est_sec = est_batches * PAUSE_BETWEEN_BATCHES
         print(f"Cohort size: {total}")
         print(f"API keys: {len(keys)}")
-        print(f"Batch size: {len(keys)}, pause: {gen.PAUSE_BETWEEN_BATCHES}s")
+        print(f"Batch size: {len(keys)}, pause: {PAUSE_BETWEEN_BATCHES}s")
         print(f"Estimated floor time: {est_sec // 3600}h "
               f"{(est_sec % 3600) // 60}m (excluding per-call latency)")
 
@@ -145,7 +168,7 @@ def main() -> int:
         start = time.time()
         for batch_start in range(0, total, len(keys)):
             batch = rows[batch_start:batch_start + len(keys)]
-            ok, fail = process_batch(batch, conn, args.dry_run)
+            ok, fail = process_batch(batch, keys, conn, args.dry_run)
             ok_total += ok
             fail_total += fail
 
@@ -159,7 +182,7 @@ def main() -> int:
                     flush=True,
                 )
             if batch_start + len(keys) < total:
-                time.sleep(gen.PAUSE_BETWEEN_BATCHES)
+                time.sleep(PAUSE_BETWEEN_BATCHES)
 
         elapsed = time.time() - start
         print(f"\nDone in {elapsed:.0f}s ({elapsed / 60:.1f}m). "

--- a/scripts/generate-film-descriptions-prehrajto.py
+++ b/scripts/generate-film-descriptions-prehrajto.py
@@ -5,14 +5,15 @@ Target cohort (from #524): films whose `sktorrent_video_id` is NULL, have a
 `prehrajto_primary_upload_id`, and whose `generated_description` is still NULL.
 These are the ~8 784 new films created by `scripts/import-prehrajto-new-films.py`
 with `description` copied verbatim from TMDB (cs-CZ `.overview` or fallback
-en-US `.overview`). This script runs them through Gemma 4 (Gemini API) to
-produce unique 150–400 char Czech paraphrases for SEO — avoiding duplicate
-TMDB content across multiple Czech film sites.
+en-US `.overview`). This script runs them through the shared Gemini integration
+(`scripts/auto_import/gemma_writer.py`, currently configured for
+`gemma-3-27b-it`) to produce unique 150–400 char Czech paraphrases for SEO —
+avoiding duplicate TMDB content across multiple Czech film sites.
 
-Reuses `scripts/auto_import/gemma_writer.py` for prompt + API logic so the
-Gemini call surface stays in one place. That module's `_load_keys()` accepts
-either a single `GEMINI_API_KEY` (production cron) or parallel dev keys
-`GEMINI_API_KEY_1..4` (this script fans out across all of them).
+Uses `gemma_writer`'s public API (`build_prompt_film`, `call_gemma`,
+`load_keys`) so the Gemini call surface stays in one place. `load_keys()`
+accepts either a single `GEMINI_API_KEY` (production cron) or parallel dev
+keys `GEMINI_API_KEY_1..4` (this script fans out across all of them).
 
 Usage:
     python3 scripts/generate-film-descriptions-prehrajto.py --dry-run --limit 5
@@ -31,24 +32,29 @@ from pathlib import Path
 
 import psycopg2
 
-# auto_import is a proper package at scripts/auto_import. Import gemma_writer
-# for prompt + Gemini API logic (no duplication vs other Gemma consumers in
-# the codebase). The underscore-prefixed names are treated as internal API
-# by callers within the same project; external users should go through the
-# `generate_unique_cs(...)` facade instead.
+# auto_import is a proper package at scripts/auto_import. The public
+# `build_prompt_film` / `call_gemma` / `load_keys` aliases in gemma_writer
+# exist for this kind of external batch job that drives its own key rotation
+# and retry policy (the `generate_unique_cs(...)` facade hides both).
 _SCRIPTS_DIR = Path(__file__).resolve().parent
 _REPO_ROOT = _SCRIPTS_DIR.parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 from scripts.auto_import.gemma_writer import (  # noqa: E402
-    _build_prompt_film,
-    _call,
-    _load_keys,
+    build_prompt_film,
+    call_gemma,
+    load_keys,
 )
 
 # Pause between batches gives Gemini's per-key rate limiter time to reset.
 # Matches the cadence in other bulk Gemma jobs in this repo.
 PAUSE_BETWEEN_BATCHES = 3
+
+# `call_gemma` returns None for transient (HTTP 429, network blip) AND
+# permanent (safety filter, HTTP 4xx) failures. We can't tell them apart
+# from the return value alone, so retry a bounded number of times — most
+# transient failures self-heal after the rate-limit sleep inside call_gemma.
+MAX_PER_FILM_RETRIES = 3
 
 
 COHORT_WHERE = (
@@ -76,17 +82,33 @@ def fetch_cohort(conn, limit: int) -> list[tuple[int, str, int, str]]:
 
 def generate_one(title: str, year: int, desc: str,
                  key: str) -> tuple[str | None, int, str | None]:
-    """Thin wrapper around gemma_writer._call — returns (text, ms, err)."""
-    prompt = _build_prompt_film(title, year, [("TMDB", desc)])
+    """Wrapper around `gemma_writer.call_gemma` with bounded retry.
+
+    `call_gemma` returns None both for transient problems (HTTP 429 after
+    internal sleep, network hiccup) and for permanent ones (safety filter,
+    HTTP 4xx). Retrying cheaply recovers the transient cases without a
+    special code path for 429. Caps at `MAX_PER_FILM_RETRIES` so a truly
+    refused prompt doesn't loop forever.
+    """
+    prompt = build_prompt_film(title, year, [("TMDB", desc)])
     start = time.time()
-    try:
-        text = _call(prompt, key)
-    except Exception as e:  # noqa: BLE001 — per-film isolation, logged upstream
-        return None, int((time.time() - start) * 1000), str(e)
-    duration_ms = int((time.time() - start) * 1000)
-    if not text:
-        return None, duration_ms, "No text (safety filter / rate limit / HTTP error)"
-    return text, duration_ms, None
+    last_err: str | None = None
+    for attempt in range(MAX_PER_FILM_RETRIES):
+        try:
+            text = call_gemma(prompt, key)
+        except Exception as e:  # noqa: BLE001 — per-film isolation, logged upstream
+            last_err = str(e)
+            text = None
+        if text:
+            return text, int((time.time() - start) * 1000), None
+        if attempt == 0:
+            # Preserve context for the log even if subsequent attempts
+            # succeed-but-empty (safety filter); surface the first failure
+            # reason we know about.
+            last_err = last_err or "call returned None (rate limit / safety / HTTP)"
+    return None, int((time.time() - start) * 1000), (
+        last_err or f"no text after {MAX_PER_FILM_RETRIES} attempts"
+    )
 
 
 def process_batch(batch, keys, conn, dry_run: bool) -> tuple[int, int]:
@@ -139,7 +161,7 @@ def main() -> int:
         print("ERROR: DATABASE_URL env var required", file=sys.stderr)
         return 2
 
-    keys = _load_keys()
+    keys = load_keys()
     if not keys:
         print("ERROR: No Gemini API key configured; set GEMINI_API_KEY or "
               "GEMINI_API_KEY_1..4 in .env", file=sys.stderr)


### PR DESCRIPTION
<!-- claude-session: 74da902e-6000-4680-8b0a-b1bb3db8128b -->

Follow-up to #539 (merged). Part of epic #518.

Three Copilot comments, all addressed:

1. **Critical — broken import** of `scripts/generate-film-descriptions.py`: that file was untracked in my local checkout and is NOT committed to the repo, so the original script would have crashed at startup (`FileNotFoundError` via `importlib.spec_from_file_location`) for anyone else. Now imports `scripts/auto_import/gemma_writer` directly — that's a proper package module already used by the auto-import pipeline.

2. **Hardcoded DB credentials** in `DB_URL` default: removed. Now strictly reads `DATABASE_URL` env var; prints error + exits 2 if unset. Matches `scripts/import-prehrajto-new-films.py`.

3. **Mismatched env-var surface**: old error message only mentioned `GEMINI_API_KEY_*`. `gemma_writer._load_keys()` already accepts either a single `GEMINI_API_KEY` (production) or `GEMINI_API_KEY_1..4` (dev). Message now lists both.

## Verification
- `python3 scripts/generate-film-descriptions-prehrajto.py --help` renders cleanly
- `--dry-run --limit 3` against cr_dev → "Nothing to do — cohort empty" (cohort = empty until #524 finishes, currently in flight)
- `gemma_writer._call` / `_build_prompt_film` / `_load_keys` all import cleanly

## Test plan
- [x] Syntax + `--help` render
- [x] Cohort-empty path exits 0
- [ ] After #524 import finishes, run `--dry-run --limit 5` and spot-check generated text
- [ ] Full `--limit 0` run against `cr_dev` (~11 h projected)