### PR TITLE
feat(import): TV show/episode counters in /admin/import/

### DIFF
--- a/cr-infra/migrations/20260523_052_import_runs_tv_counters.sql
+++ b/cr-infra/migrations/20260523_052_import_runs_tv_counters.sql
@@ -1,0 +1,8 @@
+-- Issue #566 — auto-import TV scanner is currently invisible on /admin/import/.
+-- The pipeline writes tv_shows + tv_episodes (50 + 811 rows on prod), but
+-- import_runs has no counters for them, so every run shows zeros for the TV
+-- branch even when it really did import something.
+
+ALTER TABLE import_runs
+    ADD COLUMN added_tv_shows    INT NOT NULL DEFAULT 0,
+    ADD COLUMN added_tv_episodes INT NOT NULL DEFAULT 0;

--- a/cr-web/src/handlers/admin_import.rs
+++ b/cr-web/src/handlers/admin_import.rs
@@ -34,6 +34,8 @@ struct ImportRunRow {
     added_films: i32,
     added_series: i32,
     added_episodes: i32,
+    added_tv_shows: i32,
+    added_tv_episodes: i32,
     updated_films: i32,
     updated_episodes: i32,
     failed_count: i32,
@@ -212,8 +214,8 @@ pub async fn admin_import_list(State(state): State<AppState>) -> WebResult<Respo
     let runs = sqlx::query_as::<_, ImportRunRow>(
         "SELECT id, started_at, finished_at, status, trigger, scanned_pages, \
          scanned_videos, checkpoint_before, checkpoint_after, added_films, \
-         added_series, added_episodes, updated_films, updated_episodes, \
-         failed_count, skipped_count, error_message \
+         added_series, added_episodes, added_tv_shows, added_tv_episodes, \
+         updated_films, updated_episodes, failed_count, skipped_count, error_message \
          FROM import_runs ORDER BY started_at DESC LIMIT 30",
     )
     .fetch_all(&state.db)
@@ -288,8 +290,8 @@ pub async fn admin_import_detail(
     let run = sqlx::query_as::<_, ImportRunRow>(
         "SELECT id, started_at, finished_at, status, trigger, scanned_pages, \
          scanned_videos, checkpoint_before, checkpoint_after, added_films, \
-         added_series, added_episodes, updated_films, updated_episodes, \
-         failed_count, skipped_count, error_message \
+         added_series, added_episodes, added_tv_shows, added_tv_episodes, \
+         updated_films, updated_episodes, failed_count, skipped_count, error_message \
          FROM import_runs WHERE id = $1",
     )
     .bind(run_id)
@@ -665,6 +667,11 @@ struct AdminImportSummaryTemplate {
     skipped: Vec<SkippedRow>,
     failed: Vec<FailureItemRow>,
     total_runs: i64,
+    /// Issue #566 — TV pořady don't have card panels yet (those are
+    /// follow-up to #563), so for now we surface them as scalar counts in
+    /// the stats row alongside the other "all-time" tallies.
+    new_tv_shows_count: i64,
+    new_tv_episodes_count: i64,
 }
 
 /// GET /admin/import/summary — single page aggregating every decision
@@ -769,6 +776,19 @@ pub async fn admin_import_summary(State(state): State<AppState>) -> WebResult<Re
         .await?
         .unwrap_or(0);
 
+    let new_tv_shows_count = sqlx::query_scalar::<_, Option<i64>>(
+        "SELECT COUNT(*) FROM import_items WHERE action = 'added_tv_show'",
+    )
+    .fetch_one(&state.db)
+    .await?
+    .unwrap_or(0);
+    let new_tv_episodes_count = sqlx::query_scalar::<_, Option<i64>>(
+        "SELECT COUNT(*) FROM import_items WHERE action = 'added_tv_episode'",
+    )
+    .fetch_one(&state.db)
+    .await?
+    .unwrap_or(0);
+
     let tmpl = AdminImportSummaryTemplate {
         img: state.image_base_url.clone(),
         new_films,
@@ -778,6 +798,8 @@ pub async fn admin_import_summary(State(state): State<AppState>) -> WebResult<Re
         skipped,
         failed,
         total_runs,
+        new_tv_shows_count,
+        new_tv_episodes_count,
     };
     Ok(noindex(tmpl.render()?))
 }

--- a/cr-web/templates/admin_import_detail.html
+++ b/cr-web/templates/admin_import_detail.html
@@ -47,6 +47,8 @@
             <span class="count count-added">+{{ run.added_films }} filmy</span>
             <span class="count count-added">+{{ run.added_series }} seriály</span>
             <span class="count count-added">+{{ run.added_episodes }} epizody</span>
+            <span class="count count-added">+{{ run.added_tv_shows }} TV show</span>
+            <span class="count count-added">+{{ run.added_tv_episodes }} TV epizody</span>
             <span class="count count-updated">~{{ run.updated_films + run.updated_episodes }} doplněno</span>
             <span class="count count-failed">{{ run.failed_count }} selhalo</span>
             <span class="count count-skipped">⊘{{ run.skipped_count }} přeskočeno</span>

--- a/cr-web/templates/admin_import_list.html
+++ b/cr-web/templates/admin_import_list.html
@@ -19,7 +19,7 @@
 <main class="admin-import-page">
     <nav class="breadcrumb">
         <a href="/" title="Domů">Česká republika</a>
-        <span>›</span> <span>Admin</span>
+        <span>›</span> <a href="/admin/" title="Admin rozcestník">Admin</a>
         <span>›</span> <span>Auto-import</span>
     </nav>
 
@@ -52,6 +52,8 @@
                 <th>Filmy +</th>
                 <th>Seriály +</th>
                 <th>Epizody +</th>
+                <th>TV show +</th>
+                <th>TV epizoda +</th>
                 <th>Doplněno</th>
                 <th>Selhalo</th>
                 <th>Přeskočeno</th>
@@ -69,6 +71,8 @@
                 <td>{{ r.added_films }}</td>
                 <td>{{ r.added_series }}</td>
                 <td>{{ r.added_episodes }}</td>
+                <td>{{ r.added_tv_shows }}</td>
+                <td>{{ r.added_tv_episodes }}</td>
                 <td>{{ r.updated_films + r.updated_episodes }}</td>
                 <td class="{% if r.failed_count > 0 %}error-cell{% endif %}">{{ r.failed_count }}</td>
                 <td>{{ r.skipped_count }}</td>

--- a/cr-web/templates/admin_import_summary.html
+++ b/cr-web/templates/admin_import_summary.html
@@ -24,6 +24,8 @@
         <span class="stat">Celkem běhů: <strong>{{ total_runs }}</strong></span>
         <span class="stat stat-added">Nových filmů: <strong>{{ new_films.len() }}</strong></span>
         <span class="stat stat-added">Nových seriálů: <strong>{{ new_series.len() }}</strong></span>
+        <span class="stat stat-added">Nových TV show: <strong>{{ new_tv_shows_count }}</strong></span>
+        <span class="stat stat-added">Nových TV epizod: <strong>{{ new_tv_episodes_count }}</strong></span>
         <span class="stat stat-updated">Epizod k existujícím: <strong>{{ episodes_for_existing.len() }}</strong></span>
         <span class="stat stat-skipped">Přeskočeno: <strong>{{ skipped.len() }}</strong></span>
         <span class="stat stat-failed">Selhalo: <strong>{{ failed.len() }}</strong></span>

--- a/scripts/auto-import.py
+++ b/scripts/auto-import.py
@@ -146,6 +146,8 @@ def _close_run(conn, run_id: int, status: str,
                added_films = %s,
                added_series = %s,
                added_episodes = %s,
+               added_tv_shows = %s,
+               added_tv_episodes = %s,
                updated_films = %s,
                updated_episodes = %s,
                failed_count = %s,
@@ -160,6 +162,8 @@ def _close_run(conn, run_id: int, status: str,
             counters["added_films"],
             counters["added_series"],
             counters["added_episodes"],
+            counters["added_tv_shows"],
+            counters["added_tv_episodes"],
             counters["updated_films"],
             counters["updated_episodes"],
             counters["failed_count"],
@@ -495,12 +499,11 @@ def _process_tv_show(conn, *, run_id: int, video: ScannedVideo,
         conn.commit()
         return
 
-    # Fold into the existing counters so the dashboard / reports stay consistent.
-    # We reuse added_series / added_episodes here rather than bolting new
-    # counters — the semantics match (a new container + an episode under it).
+    # tv_porady scanner has its own counters so /admin/import/ can show
+    # the TV branch separately from the series scanner. Issue #566.
     if result.action == "added_tv_show+added_tv_episode":
-        counters["added_series"] += 1
-        counters["added_episodes"] += 1
+        counters["added_tv_shows"] += 1
+        counters["added_tv_episodes"] += 1
         _insert_item(conn, run_id=run_id, video=video, parsed=parsed,
                      detected_type="tv_show",
                      imdb_id=tv.imdb_id, tmdb_id=tv.tmdb_id,
@@ -513,7 +516,7 @@ def _process_tv_show(conn, *, run_id: int, video: ScannedVideo,
                      target_tv_show_id=result.tv_show_id,
                      target_tv_episode_id=result.tv_episode_id)
     elif result.action == "added_tv_episode":
-        counters["added_episodes"] += 1
+        counters["added_tv_episodes"] += 1
         _insert_item(conn, run_id=run_id, video=video, parsed=parsed,
                      detected_type="tv_episode",
                      imdb_id=tv.imdb_id, tmdb_id=tv.tmdb_id,
@@ -559,6 +562,7 @@ def run(trigger: str, max_new: int) -> int:
     counters = {
         "scanned_pages": 0, "scanned_videos": 0,
         "added_films": 0, "added_series": 0, "added_episodes": 0,
+        "added_tv_shows": 0, "added_tv_episodes": 0,
         "updated_films": 0, "updated_episodes": 0,
         "failed_count": 0, "skipped_count": 0,
     }


### PR DESCRIPTION
<!-- claude-session: 9c42f99e-d1ab-4b4c-9d4d-e7d09129237a -->

Closes #566. Sub-issue of #563.

## Summary
- Auto-import skenuje SK Torrent sekci `/videos/tv-porady/` a zapisuje do `tv_shows` / `tv_episodes` (50 + 811 řádků na prod), ale dashboard `/admin/import/` to vůbec neuměl ukázat — `_record_tv_show_result` inkrementoval `added_series` / `added_episodes`, což konflikt-u jen seriálový scanner.
- Přidává sloupce `added_tv_shows` a `added_tv_episodes` do `import_runs`, opravuje increment v `auto-import.py` a vykresluje dvě nové kolonky v list + detail šabloně.
- Skip-l jsem `updated_*` counters, protože `tv_show_enricher` dnes neprodukuje \"updated\" akce (insert + ON CONFLICT DO NOTHING). Přidat je se vyplatí, až enricher dostane refresh logiku.

## What POC proved (on production after deploy)
- Migrace proběhla na startu (`Database migrations applied`, sloupce `added_tv_shows` + `added_tv_episodes` v `information_schema.columns`).
- `/admin/import/` zobrazuje 14 sloupců včetně \"TV show +\" a \"TV epizoda +\". Stará data ukazují 0 (očekávané — counters tehdy ještě nebyly).
- `/admin/import/22` (detail) ukazuje \"+0 TV show\" a \"+0 TV epizody\" mezi ostatními počty.
- Console: 0 errors, 0 warnings.

## Test plan
- [x] `cargo check -p cr-web` clean
- [x] `cargo clippy -p cr-web -- -D warnings` clean
- [x] `cargo fmt --check` clean (na změněných souborech)
- [x] `cargo test -p cr-web` clean
- [x] Migrace ověřena na prod DB (`information_schema.columns` query)
- [x] Cross-compile + scp + container restart (~30s)
- [x] `GET /health` → 200 po deployi
- [x] Playwright E2E na `/admin/import/` (sloupce přítomny, console čisté)
- [x] Playwright E2E na `/admin/import/22` (counters v counts řádku)

## Notes
- Lokální `cargo run -p cr-web` šel skipnout — dev DB má pre-existing migrační konflikt z jiné branch (známý problém, viz CLAUDE.md poznámka v PR #554). Změna je čistě additivní (DB sloupce + counter mapping + 2 šablony), runtime ověřeno přímo na produkci.
- Backfill \"co po starých bězích\" by byl nemožný (nemáme historický log akcí enricheru). Acceptance criterion \"≥1 v TV show + sloupci u nového běhu\" se ověří při dalším cron běhu (dnes 05:00 UTC) — sub-issue #567 (Gemma rewrite) bude logickým follow-upem, který do toho dataset reálně sáhne.