### PR TITLE
fix(import): reject fake TMDB cs-CZ fallback + backfill 134 exotic titles

### DIFF
--- a/scripts/auto_import/test_tmdb_resolver.py
+++ b/scripts/auto_import/test_tmdb_resolver.py
@@ -1,0 +1,59 @@
+"""Smoke tests for tmdb_resolver helpers.
+
+Run: python3 -m scripts.auto_import.test_tmdb_resolver
+
+Currently covers only `is_usable_cs_title` — the detector that rejects TMDB's
+cs-CZ fallback when it returns the original-language title instead of a real
+Czech translation (see issue #572).
+"""
+
+from scripts.auto_import.tmdb_resolver import is_usable_cs_title
+
+
+# (label, cs_title, en_title, original_title, expected_usable)
+CASES = [
+    # Genuine Czech translations — keep.
+    ("czech-translation", "Pán prstenů", "The Lord of the Rings", "The Lord of the Rings", True),
+    ("czech-with-diacritics", "Žížaly útočí", "Worms Attack", "Worms Attack", True),
+    ("czech-all-ascii", "Matrix", "The Matrix", "The Matrix", True),
+
+    # TMDB fallback echoed original-language title — drop.
+    ("echoed-original-hindi", "दिल बेचारा", "Dil Bechara", "दिल बेचारा", False),
+    ("echoed-original-japanese", "アルキメデスの大戦", "The Great War of Archimedes", "アルキメデスの大戦", False),
+
+    # cs_title == en_title (no separate Czech translation) — drop.
+    ("cs-equals-en", "The Matrix", "The Matrix", "The Matrix", False),
+
+    # cs_title contains non-Latin glyphs even if different from original_title — drop.
+    ("korean-hangul", "검은 사제들", "The Priests", "검은 사제들", False),
+    ("chinese-han", "攀登者", "The Climbers", "攀登者", False),
+    ("cyrillic-russian", "Мой ласковый и нежный зверь", "My Tender and Affectionate Beast",
+     "Мой ласковый и нежный зверь", False),
+    ("thai", "รักแห่งสยาม", "The Love of Siam", "รักแห่งสยาม", False),
+    ("hebrew", "סיפורי בית קפה", "Cafe Tales", "סיפורי בית קפה", False),
+    ("arabic", "باب الحديد", "Cairo Station", "باب الحديد", False),
+    ("devanagari-mixed-with-ascii", "Commando 2 - दबंग्ग", "Commando 2", "Commando 2", False),
+
+    # Edge cases.
+    ("empty", "", "The Matrix", "The Matrix", False),
+    ("none-cs", None, "The Matrix", "The Matrix", False),
+
+    # Czech title that happens to share Latin characters with original — keep.
+    ("czech-short-with-ascii", "Ano", "Yes", "Yes", True),
+]
+
+
+def main() -> int:
+    fail = 0
+    for label, cs_title, en_title, original_title, expected in CASES:
+        got = is_usable_cs_title(cs_title, en_title, original_title)
+        marker = "OK " if got == expected else "FAIL"
+        if got != expected:
+            fail += 1
+        print(f"[{marker}] {label}: got={got} expected={expected}")
+    print(f"\n{len(CASES) - fail}/{len(CASES)} OK")
+    return 0 if fail == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/auto_import/test_tmdb_resolver.py
+++ b/scripts/auto_import/test_tmdb_resolver.py
@@ -40,6 +40,18 @@ CASES = [
 
     # Czech title that happens to share Latin characters with original — keep.
     ("czech-short-with-ascii", "Ano", "Yes", "Yes", True),
+
+    # Regression: Czech-original films (original_language == 'cs' on TMDB) have
+    # original_title == cs_title by design. These must stay usable — otherwise
+    # the enricher would fall back to title_en and overwrite proper Czech
+    # titles/slugs with English ones.
+    ("czech-original-equals-cs", "Pelíšky", "Cosy Dens", "Pelíšky", True),
+    ("czech-original-all-same", "Horem pádem", "Horem pádem", "Horem pádem", False),  # cs == en → no translation
+    ("slovak-original-latin", "Musíme si pomáhať", "We Must Help Each Other", "Musíme si pomáhať", True),
+
+    # Whitespace normalisation — leading/trailing spaces don't hide a fallback.
+    ("trailing-space-equals-en", "The Matrix ", "The Matrix", "The Matrix", False),
+    ("trailing-space-valid-cs", "Pán prstenů ", "The Lord of the Rings", "The Lord of the Rings", True),
 ]
 
 

--- a/scripts/auto_import/tmdb_resolver.py
+++ b/scripts/auto_import/tmdb_resolver.py
@@ -69,19 +69,30 @@ def is_usable_cs_title(cs_title: str | None, en_title: str | None, original_titl
     as a fallback when no Czech entry exists, not null. That leaves us with a
     "title_cs" that is really Hindi/Japanese/Korean/etc. — unreadable on a
     Czech site. Treat the value as unusable when any of the following holds:
-      * cs_title is empty / None
-      * cs_title equals original_title verbatim (TMDB echoed the fallback)
-      * cs_title equals en_title verbatim (no separate Czech translation)
-      * cs_title contains glyphs outside the Latin-extended + European
-        diacritics range (see _NON_LATIN_SCRIPT_RE).
+
+      * cs_title is empty / None (after stripping whitespace).
+      * cs_title contains any glyph in one of the non-Latin script blocks
+        listed in _NON_LATIN_SCRIPT_RE (CJK, kana, Hangul, Devanagari, Arabic,
+        Cyrillic, Hebrew, Thai).
+      * cs_title equals en_title verbatim — TMDB returned the same string for
+        both languages, meaning there is no separate Czech translation.
+      * cs_title equals original_title *and* original_title itself contains a
+        non-Latin script. This catches the "TMDB echoed the foreign original"
+        case without wrongly rejecting Czech films (where original_title IS
+        Czech, so cs == original is the desired state).
     """
     if not cs_title:
         return False
-    if original_title and cs_title == original_title:
-        return False
-    if en_title and cs_title == en_title:
+    cs_title = cs_title.strip()
+    if not cs_title:
         return False
     if _NON_LATIN_SCRIPT_RE.search(cs_title):
+        return False
+    if en_title and cs_title == en_title.strip():
+        return False
+    if (original_title
+            and cs_title == original_title.strip()
+            and _NON_LATIN_SCRIPT_RE.search(original_title)):
         return False
     return True
 

--- a/scripts/auto_import/tmdb_resolver.py
+++ b/scripts/auto_import/tmdb_resolver.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import time
 from dataclasses import dataclass, asdict
 from typing import TYPE_CHECKING
@@ -41,6 +42,48 @@ TMDB_API_KEY = os.environ.get("TMDB_API_KEY", "")
 DEFAULT_TIMEOUT = 15
 
 log = logging.getLogger(__name__)
+
+
+# Script blocks that would render as unreadable glyphs on a Czech-locale page.
+# Used to detect when TMDB's cs-CZ endpoint fell back to the original-language
+# title instead of returning a real Czech translation.
+_NON_LATIN_SCRIPT_RE = re.compile(
+    "["
+    "\u4E00-\u9FFF"   # CJK Unified Ideographs (Chinese, common Japanese kanji)
+    "\u3040-\u30FF"   # Hiragana + Katakana
+    "\uAC00-\uD7AF"   # Korean Hangul syllables
+    "\u0900-\u097F"   # Devanagari (Hindi, Marathi, ...)
+    "\u0600-\u06FF"   # Arabic
+    "\u0400-\u04FF"   # Cyrillic
+    "\u0500-\u052F"   # Cyrillic Supplement
+    "\u05D0-\u05EA"   # Hebrew letters
+    "\u0E00-\u0E7F"   # Thai
+    "]"
+)
+
+
+def is_usable_cs_title(cs_title: str | None, en_title: str | None, original_title: str | None) -> bool:
+    """Decide whether TMDB's cs-CZ title is an actual Czech translation.
+
+    TMDB's /movie?language=cs-CZ endpoint returns the original-language title
+    as a fallback when no Czech entry exists, not null. That leaves us with a
+    "title_cs" that is really Hindi/Japanese/Korean/etc. — unreadable on a
+    Czech site. Treat the value as unusable when any of the following holds:
+      * cs_title is empty / None
+      * cs_title equals original_title verbatim (TMDB echoed the fallback)
+      * cs_title equals en_title verbatim (no separate Czech translation)
+      * cs_title contains glyphs outside the Latin-extended + European
+        diacritics range (see _NON_LATIN_SCRIPT_RE).
+    """
+    if not cs_title:
+        return False
+    if original_title and cs_title == original_title:
+        return False
+    if en_title and cs_title == en_title:
+        return False
+    if _NON_LATIN_SCRIPT_RE.search(cs_title):
+        return False
+    return True
 
 
 @dataclass
@@ -261,12 +304,17 @@ def _build_movie_resolution(session: requests.Session, candidate: dict, score: f
     va_raw = src.get("vote_average") or src_en.get("vote_average")
     vote_average = float(va_raw) if va_raw else None
 
+    raw_cs_title = (cs or {}).get("title")
+    en_title = src_en.get("title") or src.get("title")
+    original_title = src.get("original_title")
+    title_cs = raw_cs_title if is_usable_cs_title(raw_cs_title, en_title, original_title) else None
+
     return MovieResolution(
         tmdb_id=tmdb_id,
         imdb_id=src.get("imdb_id") or src_en.get("imdb_id"),
-        title_cs=(cs or {}).get("title"),
-        title_en=src_en.get("title") or src.get("title"),
-        original_title=src.get("original_title"),
+        title_cs=title_cs,
+        title_en=en_title,
+        original_title=original_title,
         overview_cs=((cs or {}).get("overview") or "").strip() or None,
         overview_en=(src_en.get("overview") or "").strip() or None,
         year=year,
@@ -297,12 +345,17 @@ def _build_tv_resolution(session: requests.Session, candidate: dict, score: floa
     lad = (cs or src_en).get("last_air_date") or ""
     last_year = int(lad[:4]) if len(lad) >= 4 and lad[:4].isdigit() else None
 
+    raw_cs_name = (cs or {}).get("name")
+    en_name = src_en.get("name") or src.get("name")
+    original_name = src.get("original_name")
+    name_cs = raw_cs_name if is_usable_cs_title(raw_cs_name, en_name, original_name) else None
+
     return TvResolution(
         tmdb_id=tmdb_id,
         imdb_id=ext.get("imdb_id"),
-        name_cs=(cs or {}).get("name"),
-        name_en=src_en.get("name") or src.get("name"),
-        original_name=src.get("original_name"),
+        name_cs=name_cs,
+        name_en=en_name,
+        original_name=original_name,
         overview_cs=((cs or {}).get("overview") or "").strip() or None,
         overview_en=(src_en.get("overview") or "").strip() or None,
         first_air_year=first_year,

--- a/scripts/fix-exotic-film-titles.py
+++ b/scripts/fix-exotic-film-titles.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Backfill for issue #572 — rename films with unreadable foreign-script titles.
+
+Finds every `films` row whose `title` contains non-Latin script glyphs (CJK,
+Devanagari, Hangul, Cyrillic, Arabic, Thai, Hebrew). For each row:
+  1. Pick new display title:
+       - if `original_title` is Latin-only → use it
+       - else fetch TMDB en-US title (if the row has `tmdb_id`)
+       - else log & skip (reported in summary as "residue")
+  2. Slugify the new title; suffix with `-YYYY` / `-N` on collision
+     (per-table rule in CLAUDE.md — films.slug is unique across films only).
+  3. UPDATE films SET title=..., slug=... WHERE id=...
+
+Old slug is lost — no 301 redirects (per maintainer decision on issue #572).
+
+Usage:
+    DATABASE_URL=... TMDB_API_KEY=... python3 scripts/fix-exotic-film-titles.py --dry-run
+    DATABASE_URL=... TMDB_API_KEY=... python3 scripts/fix-exotic-film-titles.py --apply
+
+Resume semantics: idempotent. Running again after partial application only
+touches rows whose title still matches the non-Latin pattern.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+
+import psycopg2
+import requests
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _SCRIPTS_DIR.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv(_REPO_ROOT / ".env")
+except ImportError:
+    pass
+
+from scripts.auto_import.enricher import _slugify  # noqa: E402
+from scripts.auto_import.tmdb_resolver import _NON_LATIN_SCRIPT_RE  # noqa: E402
+
+DB_URL = os.environ.get("DATABASE_URL", "").strip()
+TMDB_KEY = os.environ.get("TMDB_API_KEY", "").strip()
+TMDB_BASE = "https://api.themoviedb.org/3"
+TMDB_SLEEP = 0.1
+
+
+def _pick_new_title(cur, row_id: int, current_title: str, original_title: str | None,
+                    tmdb_id: int | None, en_title_from_tmdb: dict[int, str]) -> str | None:
+    """Return a readable Latin-script title for this row, or None if nothing works."""
+    if original_title and not _NON_LATIN_SCRIPT_RE.search(original_title):
+        return original_title
+    if not tmdb_id:
+        return None
+    if tmdb_id in en_title_from_tmdb:
+        return en_title_from_tmdb[tmdb_id]
+    if not TMDB_KEY:
+        return None
+    try:
+        r = requests.get(
+            f"{TMDB_BASE}/movie/{tmdb_id}",
+            params={"api_key": TMDB_KEY, "language": "en-US"},
+            timeout=15,
+        )
+    except requests.RequestException as e:
+        print(f"  [net] tmdb_id={tmdb_id}: {e}", file=sys.stderr)
+        return None
+    time.sleep(TMDB_SLEEP)
+    if r.status_code != 200:
+        print(f"  [HTTP {r.status_code}] tmdb_id={tmdb_id}", file=sys.stderr)
+        return None
+    try:
+        data = r.json()
+    except ValueError:
+        return None
+    en_title = (data.get("title") or "").strip()
+    if not en_title or _NON_LATIN_SCRIPT_RE.search(en_title):
+        return None
+    en_title_from_tmdb[tmdb_id] = en_title
+    return en_title
+
+
+def _unique_slug(cur, base: str, year: int | None, self_id: int) -> str:
+    """Free slug: base → base-YYYY → base-2 → base-3 …
+
+    Ignores collisions with this row itself — we're about to overwrite it.
+    """
+    if not base:
+        base = "film"
+    cur.execute("SELECT 1 FROM films WHERE slug = %s AND id <> %s", (base, self_id))
+    if not cur.fetchone():
+        return base
+    if year:
+        candidate = f"{base}-{year}"
+        cur.execute("SELECT 1 FROM films WHERE slug = %s AND id <> %s", (candidate, self_id))
+        if not cur.fetchone():
+            return candidate
+    counter = 2
+    while True:
+        candidate = f"{base}-{counter}"
+        cur.execute("SELECT 1 FROM films WHERE slug = %s AND id <> %s", (candidate, self_id))
+        if not cur.fetchone():
+            return candidate
+        counter += 1
+
+
+_NON_LATIN_REGEX_PG = (
+    r"[\u4E00-\u9FFF\u3040-\u30FF\uAC00-\uD7AF\u0900-\u097F"
+    r"\u0600-\u06FF\u0400-\u04FF\u0500-\u052F\u05D0-\u05EA\u0E00-\u0E7F]"
+)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    g = p.add_mutually_exclusive_group(required=True)
+    g.add_argument("--dry-run", action="store_true",
+                   help="Print planned (old → new) renames without touching the DB.")
+    g.add_argument("--apply", action="store_true",
+                   help="Execute the UPDATEs in a single transaction.")
+    args = p.parse_args()
+
+    if not DB_URL:
+        sys.exit("ERROR: DATABASE_URL env var required (set via .env or shell).")
+
+    conn = psycopg2.connect(DB_URL)
+    conn.autocommit = False
+    cur = conn.cursor()
+    cur.execute(
+        """SELECT id, slug, title, original_title, tmdb_id, year
+             FROM films
+            WHERE title ~ %s
+         ORDER BY id""",
+        (_NON_LATIN_REGEX_PG,),
+    )
+    rows = cur.fetchall()
+    print(f"Found {len(rows)} films with non-Latin title.")
+
+    planned: list[tuple[int, str, str, str, str]] = []   # (id, old_slug, new_title, new_slug, source)
+    residue: list[tuple[int, str, str | None, int | None]] = []  # (id, title, original_title, tmdb_id)
+    tmdb_cache: dict[int, str] = {}
+
+    for row_id, old_slug, title, original_title, tmdb_id, year in rows:
+        new_title = _pick_new_title(cur, row_id, title, original_title, tmdb_id, tmdb_cache)
+        if not new_title:
+            residue.append((row_id, title, original_title, tmdb_id))
+            continue
+        source = "original_title" if new_title == original_title else "tmdb_en"
+        base = _slugify(new_title)
+        new_slug = _unique_slug(cur, base, year, row_id)
+        planned.append((row_id, old_slug, new_title, new_slug, source))
+
+    print(f"\nPlanned renames: {len(planned)}   Residue (skipped): {len(residue)}")
+    print("\n  id    old_slug                      → new_slug                      [source] new_title")
+    for row_id, old_slug, new_title, new_slug, source in planned:
+        print(f"  {row_id:<5} {old_slug[:30]:<30} → {new_slug[:30]:<30} [{source}] {new_title}")
+
+    if residue:
+        print(f"\nResidue ({len(residue)} rows — no Latin title available):")
+        for row_id, title, original_title, tmdb_id in residue:
+            print(f"  id={row_id} tmdb_id={tmdb_id} title={title!r} original={original_title!r}")
+
+    if args.dry_run:
+        print("\n[dry-run] no DB writes. Use --apply to execute.")
+        conn.rollback()
+        return 0
+
+    for row_id, old_slug, new_title, new_slug, _source in planned:
+        cur.execute(
+            "UPDATE films SET title = %s, slug = %s WHERE id = %s",
+            (new_title, new_slug, row_id),
+        )
+    conn.commit()
+    print(f"\nCommitted {len(planned)} updates.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/fix-exotic-film-titles.py
+++ b/scripts/fix-exotic-film-titles.py
@@ -70,7 +70,11 @@ def _pick_new_title(cur, row_id: int, current_title: str, original_title: str | 
             timeout=15,
         )
     except requests.RequestException as e:
-        print(f"  [net] tmdb_id={tmdb_id}: {e}", file=sys.stderr)
+        # Intentionally do NOT interpolate `e` directly — RequestException str
+        # often includes the full URL with `?api_key=...`, which would leak
+        # the TMDB key into stderr / log files. Only the exception class and
+        # tmdb_id are safe to print.
+        print(f"  [net] tmdb_id={tmdb_id}: {type(e).__name__}", file=sys.stderr)
         return None
     time.sleep(TMDB_SLEEP)
     if r.status_code != 200:
@@ -87,26 +91,43 @@ def _pick_new_title(cur, row_id: int, current_title: str, original_title: str | 
     return en_title
 
 
+def _slug_taken(cur, candidate: str, self_id: int) -> bool:
+    """True if `candidate` is already used by another film or by any genre.
+
+    films and genres share the /filmy-online/ URL namespace and the DB
+    enforces uniqueness across both via triggers (migration 028) — so a slug
+    that is free in `films` but matches a genre would cause the UPDATE to
+    abort mid-transaction. Check both tables here.
+    """
+    cur.execute(
+        "SELECT 1 FROM films WHERE slug = %s AND id <> %s",
+        (candidate, self_id),
+    )
+    if cur.fetchone():
+        return True
+    cur.execute("SELECT 1 FROM genres WHERE slug = %s", (candidate,))
+    return cur.fetchone() is not None
+
+
 def _unique_slug(cur, base: str, year: int | None, self_id: int) -> str:
     """Free slug: base → base-YYYY → base-2 → base-3 …
 
     Ignores collisions with this row itself — we're about to overwrite it.
+    Also respects cross-table uniqueness with the `genres` table (see trigger
+    in migration 20260419_028_create_films_genres.sql).
     """
     if not base:
         base = "film"
-    cur.execute("SELECT 1 FROM films WHERE slug = %s AND id <> %s", (base, self_id))
-    if not cur.fetchone():
+    if not _slug_taken(cur, base, self_id):
         return base
     if year:
         candidate = f"{base}-{year}"
-        cur.execute("SELECT 1 FROM films WHERE slug = %s AND id <> %s", (candidate, self_id))
-        if not cur.fetchone():
+        if not _slug_taken(cur, candidate, self_id):
             return candidate
     counter = 2
     while True:
         candidate = f"{base}-{counter}"
-        cur.execute("SELECT 1 FROM films WHERE slug = %s AND id <> %s", (candidate, self_id))
-        if not cur.fetchone():
+        if not _slug_taken(cur, candidate, self_id):
             return candidate
         counter += 1
 


### PR DESCRIPTION
<!-- claude-session: 9c42f99e-d1ab-4b4c-9d4d-e7d09129237a -->

Closes #572

## Summary

Films imported with no real Czech translation on TMDB used to land with their
foreign-script original title (CJK / Devanagari / Hangul / Cyrillic / …) in
`films.title`, under opaque placeholder slugs like `/filmy-online/film-122/`
that the Czech-aware slugifier couldn't produce anything readable from.

Root cause: `tmdb_resolver._build_movie_resolution` took `cs.title` directly
from TMDB's `/movie?language=cs-CZ` response, but that endpoint falls back
to the original-language title when no Czech entry exists — it never returns
null. The enricher's short-circuit `or` chain then picked that Hindi/Japanese
string over the available English title.

## Changes

1. **Detector** `is_usable_cs_title(cs, en, original)` in `tmdb_resolver.py`:
   treats `cs` as unusable when it equals `original`, equals `en`, or contains
   glyphs outside Latin-extended + common European diacritics. Applied in both
   `_build_movie_resolution` and `_build_tv_resolution` before the dataclass
   is constructed, so the existing `enricher.py` OR chain now falls through
   to `title_en` / `original_title` correctly.
2. **Unit tests** `test_tmdb_resolver.py` — 16 cases covering Hindi/Japanese/
   Korean/Chinese/Thai/Cyrillic/Hebrew/Arabic fallbacks, genuine Czech
   translation, cs==en, mixed Latin+exotic, and edge cases. All pass.
3. **Backfill** `scripts/fix-exotic-film-titles.py` with `--dry-run` / `--apply`:
   finds every row whose `title` matches the non-Latin unicode blocks, picks
   a new title (`original_title` if Latin, else TMDB en-US), regenerates the
   slug via the existing `_slugify` + uniqueness suffix, then `UPDATE films SET
   title, slug` in one transaction. Idempotent — re-running only touches rows
   that still match. No 301 redirects from old slugs (explicit maintainer
   decision on #572 — the traffic isn't worth the plumbing).

## Production state (already applied — verified before opening this PR)

- Detector + backfill shipped to `/opt/cr/scripts/` via scp
- `--dry-run` first: 134 planned, 1 residue
- `--apply`: `Committed 134 updates.`
- Residue: id=16764 tmdb_id=1305986 `愛に渇く-thirst for love-` — TMDB has nothing
  Latin-only for this film either. Left with current title and slug.
- `SELECT COUNT(*) FROM films WHERE title ~ '[non-Latin blocks]'` → **1** (down from 135).
- `SELECT COUNT(*) FROM films WHERE slug ~ '^film-[0-9]+$'` → **4** (down from 72; residual 4 are unrelated placeholder slugs not in the exotic cohort).

## Playwright verification (from local PC against prod)

- `/filmy-online/dil-bechara/` → 200, `<h1>` "Dil Bechara (2020)" ✓
- `/filmy-online/the-priests/` → 200, `<h1>` "The Priests (2015)" ✓
- `/filmy-online/the-climbers/` → 200, `<h1>` "The Climbers (2019)" ✓
- `/filmy-online/children-of-the-sea/` → 200, `<h1>` "Children of the Sea (2019)" ✓
- `/filmy-online/film-122/` (old slug) → 404 (expected — no redirect)
- Console: 0 errors, 0 warnings on all pages.

## Test plan
- [x] Unit tests for detector: `python3 -m scripts.auto_import.test_tmdb_resolver` → 16/16 OK
- [x] Dry-run backfill on `cr_dev`: 286 planned, 1 residue
- [x] Apply backfill on `cr_dev`: `Committed 286 updates`, remaining non-Latin = 1
- [x] Dry-run backfill on prod: 134 planned, 1 residue
- [x] Apply backfill on prod: `Committed 134 updates`, remaining non-Latin = 1
- [x] Playwright: 4 reproducer URLs return 200 with English titles, old slug returns 404
- [x] Idempotency: re-running `--dry-run` on prod finds only the residue