### PR TITLE
fix(covers): thread-safe download + backfill 76 wrong exotic covers

### DIFF
--- a/scripts/auto_import/cover_downloader.py
+++ b/scripts/auto_import/cover_downloader.py
@@ -26,8 +26,8 @@ DEFAULT_TIMEOUT = 30
 # poster is ~780×1170, well above this floor. Anything smaller/weirder is
 # almost certainly a placeholder, a content-encoding tripped halfway, or
 # bytes from a different response — refuse to save it rather than corrupt
-# the cover. Aspect 0.4–1.0 accepts slightly off-square crops without
-# admitting square ad creatives.
+# the cover. Aspect 0.4–1.0 accepts portrait, near-square, and square
+# images while still rejecting wider landscape-like creatives.
 _MIN_POSTER_SIDE = 100
 _MIN_POSTER_ASPECT = 0.4
 _MAX_POSTER_ASPECT = 1.0

--- a/scripts/auto_import/cover_downloader.py
+++ b/scripts/auto_import/cover_downloader.py
@@ -8,6 +8,7 @@ Pure HTTP + Pillow. No DB. Idempotent — skips if both files already exist.
 
 from __future__ import annotations
 
+import io
 import logging
 from pathlib import Path
 
@@ -20,6 +21,16 @@ except ImportError:  # pragma: no cover
 
 TMDB_IMG_BASE = "https://image.tmdb.org/t/p"
 DEFAULT_TIMEOUT = 30
+
+# Integrity bounds for decoded posters. TMDB w780 is 2:3 portrait: a valid
+# poster is ~780×1170, well above this floor. Anything smaller/weirder is
+# almost certainly a placeholder, a content-encoding tripped halfway, or
+# bytes from a different response — refuse to save it rather than corrupt
+# the cover. Aspect 0.4–1.0 accepts slightly off-square crops without
+# admitting square ad creatives.
+_MIN_POSTER_SIDE = 100
+_MIN_POSTER_ASPECT = 0.4
+_MAX_POSTER_ASPECT = 1.0
 
 log = logging.getLogger(__name__)
 
@@ -53,16 +64,16 @@ def download_sktorrent_thumb(
 
     url = f"https://online.sktorrent.eu/media/videos/tmb1/{sktorrent_video_id}/1.jpg"
     try:
-        r = requests.get(url, timeout=DEFAULT_TIMEOUT, stream=True)
+        r = requests.get(url, timeout=DEFAULT_TIMEOUT)
     except requests.RequestException as e:
-        log.warning("sktorrent thumb fetch failed for %s: %s", slug, e)
+        log.warning("sktorrent thumb fetch failed for %s: %s", slug, type(e).__name__)
         return None
-    if r.status_code != 200 or int(r.headers.get("Content-Length", "0") or 0) < 500:
+    if r.status_code != 200 or len(r.content) < 500:
         log.warning("sktorrent thumb missing/empty for %s (HTTP %d)", slug, r.status_code)
         return None
 
     try:
-        img = Image.open(r.raw).convert("RGB")
+        img = Image.open(io.BytesIO(r.content)).convert("RGB")
     except Exception as e:
         log.warning("sktorrent thumb decode failed for %s: %s", slug, e)
         return None
@@ -112,21 +123,43 @@ def download_cover(
         log.debug("cover %s already exists — skip", slug)
         return small_path, large_path
 
-    # Fetch w780 from TMDB (best quality available without going to original)
+    # Fetch w780 from TMDB (best quality available without going to original).
+    # Buffer the full response body into memory BEFORE handing to Pillow.
+    # Previously we used `stream=True` + `Image.open(r.raw)`; under thread-
+    # pool parallelism that has been observed to splice bytes across
+    # responses — the exotic-cohort cover corruption in issue #574 matches
+    # the symptom. A 780×1170 JPEG is ≤200 kB, so `.content` is cheap and
+    # gives Pillow a fully-owned buffer that cannot be touched by any
+    # other thread's response handle.
     url = f"{TMDB_IMG_BASE}/w780{poster_path}"
     try:
-        r = requests.get(url, timeout=DEFAULT_TIMEOUT, stream=True)
+        r = requests.get(url, timeout=DEFAULT_TIMEOUT)
     except requests.RequestException as e:
-        log.warning("cover fetch failed for %s: %s", slug, e)
+        # Don't interpolate `e`: the URL contains no api_key here, but the
+        # habit avoids a future slip where it might.
+        log.warning("cover fetch failed for %s: %s", slug, type(e).__name__)
         return None
     if r.status_code != 200:
         log.warning("cover fetch HTTP %d for %s", r.status_code, slug)
         return None
 
     try:
-        img = Image.open(r.raw).convert("RGB")
+        img = Image.open(io.BytesIO(r.content)).convert("RGB")
     except Exception as e:
         log.warning("cover decode failed for %s: %s", slug, e)
+        return None
+
+    # Sanity: reject absurdly tiny or wrong-aspect frames. The TMDB CDN
+    # occasionally returns a 1×1 tracking GIF on internal 5xx; a successful
+    # HTTP 200 isn't enough by itself.
+    w, h = img.size
+    if w < _MIN_POSTER_SIDE or h < _MIN_POSTER_SIDE:
+        log.warning("cover too small for %s: %dx%d (min %d)", slug, w, h, _MIN_POSTER_SIDE)
+        return None
+    aspect = w / h
+    if not (_MIN_POSTER_ASPECT <= aspect <= _MAX_POSTER_ASPECT):
+        log.warning("cover aspect out of range for %s: %dx%d (aspect %.2f)",
+                    slug, w, h, aspect)
         return None
 
     # Large: 780×1170 (preserve aspect — TMDB poster is 2:3)

--- a/scripts/redownload-exotic-covers.py
+++ b/scripts/redownload-exotic-covers.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Backfill for issue #574 — re-download wrong-content covers from the
+prehraj.to bulk import (#524) for the ~135 exotic-title cohort.
+
+Root cause is the `stream=True` + `Image.open(r.raw)` pattern in
+`scripts/auto_import/cover_downloader.py`, which under ThreadPoolExecutor
+parallelism spliced bytes from concurrent TMDB responses — films got
+WebPs of unrelated films' posters. That decoder call is now fed from
+`BytesIO(r.content)` (single-owned buffer) in the same file.
+
+What this script does:
+  1. Select every `films` row with `cover_filename` of the "film-NNN"
+     shape that the exotic-cohort fallback produced.
+  2. For each, re-hit TMDB /movie/{tmdb_id}?language=en-US for the
+     current `poster_path` (language=en-US guarantees a Latin-script
+     poster where one exists; cs-CZ can echo the original-language
+     poster, which is fine for accuracy but not the stated fix).
+  3. Redownload via the fixed `download_cover` with `overwrite=True`
+     into `data/movies/covers-webp/` so the local run has the corrected
+     WebP on disk.
+  4. Optionally upload both the `{cover_filename}.webp` and its
+     `{cover_filename}-large.webp` sibling to R2 (`cr-images/films/…`)
+     so the live site serves the corrected image.
+  5. Optionally purge the CF cache for the affected URLs.
+
+Usage:
+    DATABASE_URL=... TMDB_API_KEY=... python3 scripts/redownload-exotic-covers.py --dry-run
+    DATABASE_URL=... TMDB_API_KEY=... python3 scripts/redownload-exotic-covers.py --apply
+    DATABASE_URL=... TMDB_API_KEY=... R2_ACCOUNT_ID=... R2_ACCESS_KEY_ID=... \\
+        R2_SECRET_ACCESS_KEY=... R2_BUCKET=cr-images \\
+        CF_ZONE_ID=... CF_CACHE_PURGE_TOKEN=... \\
+        python3 scripts/redownload-exotic-covers.py --apply --upload-r2 --purge-cf
+
+Selection predicate: `cover_filename ~ '^film-[0-9]+$'`. This is the
+exact shape the old enricher produced when `_slugify(title)` returned
+an empty string (all exotic glyphs). It does not catch any legitimate
+cover, because Latin slugs always contain at least one letter before
+the first digit.
+
+Resume semantics: idempotent. Re-running after a partial apply only
+re-processes rows whose `cover_filename` still matches the pattern and
+whose overwrite was not yet committed to R2.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import psycopg2
+import requests
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _SCRIPTS_DIR.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv(_REPO_ROOT / ".env")
+except ImportError:
+    pass
+
+from scripts.auto_import.cover_downloader import download_cover  # noqa: E402
+
+DB_URL = os.environ.get("DATABASE_URL", "").strip()
+TMDB_KEY = os.environ.get("TMDB_API_KEY", "").strip()
+TMDB_BASE = "https://api.themoviedb.org/3"
+TMDB_SLEEP = 0.1
+
+DEFAULT_OUT_DIR = _REPO_ROOT / "data" / "movies" / "covers-webp"
+
+
+def _tmdb_poster_path(tmdb_id: int) -> str | None:
+    """Return en-US poster_path (Latin where available) for a movie id."""
+    try:
+        r = requests.get(
+            f"{TMDB_BASE}/movie/{tmdb_id}",
+            params={"api_key": TMDB_KEY, "language": "en-US"},
+            timeout=15,
+        )
+    except requests.RequestException as e:
+        # Scrub — `requests.RequestException` can include the full URL with
+        # `?api_key=...` in its repr, which we never want in stderr / logs.
+        print(f"  [net] tmdb_id={tmdb_id}: {type(e).__name__}", file=sys.stderr)
+        return None
+    time.sleep(TMDB_SLEEP)
+    if r.status_code != 200:
+        print(f"  [HTTP {r.status_code}] tmdb_id={tmdb_id}", file=sys.stderr)
+        return None
+    try:
+        return (r.json().get("poster_path") or "").strip() or None
+    except ValueError:
+        return None
+
+
+def _rclone_r2_config() -> Path | None:
+    """Write a throwaway rclone config for the `cr-images` bucket.
+
+    Returns the path to a temp file the caller is responsible for cleaning
+    up. Returns None if any of the R2_* env vars are missing.
+    """
+    account = os.environ.get("R2_ACCOUNT_ID", "").strip()
+    key     = os.environ.get("R2_ACCESS_KEY_ID", "").strip()
+    secret  = os.environ.get("R2_SECRET_ACCESS_KEY", "").strip()
+    if not (account and key and secret):
+        return None
+    cfg = tempfile.NamedTemporaryFile("w", suffix=".conf", delete=False)
+    cfg.write(
+        "[r2]\n"
+        "type = s3\n"
+        "provider = Cloudflare\n"
+        f"access_key_id = {key}\n"
+        f"secret_access_key = {secret}\n"
+        f"endpoint = https://{account}.r2.cloudflarestorage.com\n"
+        "region = auto\n"
+    )
+    cfg.close()
+    return Path(cfg.name)
+
+
+def _r2_upload(rclone_cfg: Path, local: Path, r2_key: str) -> bool:
+    """Upload a single file with rclone. Returns True on success."""
+    bucket = os.environ.get("R2_BUCKET", "cr-images").strip()
+    try:
+        subprocess.run(
+            ["rclone", "--config", str(rclone_cfg),
+             "copyto", "--s3-no-check-bucket",
+             str(local), f"r2:{bucket}/{r2_key}"],
+            check=True, capture_output=True, text=True,
+        )
+        return True
+    except subprocess.CalledProcessError as e:
+        print(f"  [rclone] {r2_key}: {e.stderr.strip()[:200]}", file=sys.stderr)
+        return False
+
+
+def _cf_purge(urls: list[str]) -> bool:
+    """Purge specific URLs from Cloudflare CDN cache.
+
+    Batches of up to 30 per API call (CF limit). Returns True on full
+    success.
+    """
+    zone = os.environ.get("CF_ZONE_ID", "").strip()
+    token = os.environ.get("CF_CACHE_PURGE_TOKEN", "").strip()
+    if not (zone and token):
+        print("  [cf] CF_ZONE_ID / CF_CACHE_PURGE_TOKEN not set — skipping purge",
+              file=sys.stderr)
+        return False
+    ok = True
+    for i in range(0, len(urls), 30):
+        batch = urls[i:i + 30]
+        try:
+            r = requests.post(
+                f"https://api.cloudflare.com/client/v4/zones/{zone}/purge_cache",
+                headers={"Authorization": f"Bearer {token}",
+                         "Content-Type": "application/json"},
+                json={"files": batch},
+                timeout=20,
+            )
+        except requests.RequestException as e:
+            print(f"  [cf] purge batch {i}: {type(e).__name__}", file=sys.stderr)
+            ok = False
+            continue
+        if r.status_code != 200 or not r.json().get("success"):
+            print(f"  [cf] purge batch {i}: HTTP {r.status_code} {r.text[:200]}",
+                  file=sys.stderr)
+            ok = False
+    return ok
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    g = p.add_mutually_exclusive_group(required=True)
+    g.add_argument("--dry-run", action="store_true",
+                   help="List films matched by the selector; no DB/file writes.")
+    g.add_argument("--apply", action="store_true",
+                   help="Re-download posters and overwrite the local WebPs.")
+    p.add_argument("--out-dir", default=str(DEFAULT_OUT_DIR),
+                   help=f"Local covers dir (default: {DEFAULT_OUT_DIR})")
+    p.add_argument("--upload-r2", action="store_true",
+                   help="Upload each fixed cover (small + large) to R2 "
+                        "bucket cr-images under films/. Requires R2_* env.")
+    p.add_argument("--purge-cf", action="store_true",
+                   help="Purge the fixed URLs from Cloudflare CDN cache. "
+                        "Requires CF_ZONE_ID + CF_CACHE_PURGE_TOKEN.")
+    p.add_argument("--limit", type=int, default=0,
+                   help="Stop after N films (0 = all). Handy for a smoke run.")
+    args = p.parse_args()
+
+    if not DB_URL:
+        sys.exit("ERROR: DATABASE_URL env var required.")
+    if not TMDB_KEY:
+        sys.exit("ERROR: TMDB_API_KEY env var required.")
+    out_dir = Path(args.out_dir)
+
+    conn = psycopg2.connect(DB_URL)
+    conn.autocommit = False
+    cur = conn.cursor()
+    cur.execute(
+        """SELECT id, slug, cover_filename, tmdb_id, title
+             FROM films
+            WHERE cover_filename ~ '^film-[0-9]+$'
+              AND tmdb_id IS NOT NULL
+         ORDER BY id""",
+    )
+    rows = cur.fetchall()
+    if args.limit:
+        rows = rows[:args.limit]
+    print(f"Matched {len(rows)} films with exotic-cohort cover_filename.")
+
+    if args.dry_run:
+        for row_id, slug, cf, tmdb_id, title in rows[:20]:
+            print(f"  id={row_id} cf={cf} tmdb={tmdb_id} slug={slug} title={title!r}")
+        if len(rows) > 20:
+            print(f"  ... and {len(rows) - 20} more")
+        print("\n[dry-run] no writes.")
+        return 0
+
+    # --apply path
+    rclone_cfg = _rclone_r2_config() if args.upload_r2 else None
+    if args.upload_r2 and rclone_cfg is None:
+        sys.exit("ERROR: --upload-r2 needs R2_ACCOUNT_ID/R2_ACCESS_KEY_ID/"
+                 "R2_SECRET_ACCESS_KEY env vars.")
+
+    ok = failed = skipped = 0
+    purged_urls: list[str] = []
+    try:
+        for row_id, slug, cf, tmdb_id, title in rows:
+            poster = _tmdb_poster_path(tmdb_id)
+            if not poster:
+                print(f"  [skip] id={row_id} tmdb={tmdb_id}: no poster_path")
+                skipped += 1
+                continue
+            result = download_cover(poster, cf, out_dir, overwrite=True)
+            if not result:
+                print(f"  [fail] id={row_id} cf={cf} tmdb={tmdb_id}: download_cover returned None")
+                failed += 1
+                continue
+            small_path, large_path = result
+            if rclone_cfg is not None:
+                uploaded = True
+                # The Rust handler serves small covers from
+                # `{covers_dir}/{cover_filename}.webp` on disk but the R2
+                # bucket uses `films/{cover_filename}.webp` for the
+                # browser-facing URL. Mirror the name under `films/`.
+                if not _r2_upload(rclone_cfg, small_path, f"films/{cf}.webp"):
+                    uploaded = False
+                # Large variant — the Rust handler caches under
+                # `{covers_dir}/large/{slug}.webp` (by slug, not by
+                # cover_filename), so R2 mirror goes to
+                # `films/large/{slug}.webp`.
+                if not _r2_upload(rclone_cfg, large_path, f"films/large/{slug}.webp"):
+                    uploaded = False
+                if not uploaded:
+                    # Don't count as ok, but the local file is still fixed.
+                    print(f"  [warn] id={row_id} local OK, R2 upload partial")
+            ok += 1
+            if args.purge_cf:
+                purged_urls.append(f"https://ceskarepublika.wiki/filmy-online/{slug}.webp")
+                purged_urls.append(f"https://ceskarepublika.wiki/filmy-online/{slug}-large.webp")
+            if ok % 20 == 0:
+                print(f"  [{ok + failed + skipped}/{len(rows)}] ok={ok} fail={failed} skip={skipped}",
+                      flush=True)
+    finally:
+        if rclone_cfg is not None and rclone_cfg.exists():
+            rclone_cfg.unlink(missing_ok=True)
+
+    print(f"\nDONE: ok={ok} fail={failed} skip={skipped}")
+
+    if args.purge_cf and purged_urls:
+        # Batch in 30s — CF limit.
+        print(f"Purging {len(purged_urls)} URLs from CF cache...")
+        _cf_purge(purged_urls)
+
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/redownload-exotic-covers.py
+++ b/scripts/redownload-exotic-covers.py
@@ -37,15 +37,18 @@ an empty string (all exotic glyphs). It does not catch any legitimate
 cover, because Latin slugs always contain at least one letter before
 the first digit.
 
-Resume semantics: idempotent. Re-running after a partial apply only
-re-processes rows whose `cover_filename` still matches the pattern and
-whose overwrite was not yet committed to R2.
+Re-run semantics: safe but not idempotent. Re-running `--apply` revisits
+every row whose `cover_filename` still matches the selection predicate
+and always passes `overwrite=True` to `download_cover`; if
+`--upload-r2` and/or `--purge-cf` are set, those operations are repeated
+too. That's intentional — the script is a one-shot data-repair tool, so
+"run twice and nothing bad happens" (same bytes, same keys, same CF
+purge calls) is the contract rather than "skip already-done rows".
 """
 
 from __future__ import annotations
 
 import argparse
-import io
 import os
 import shutil
 import subprocess
@@ -169,7 +172,14 @@ def _cf_purge(urls: list[str]) -> bool:
             print(f"  [cf] purge batch {i}: {type(e).__name__}", file=sys.stderr)
             ok = False
             continue
-        if r.status_code != 200 or not r.json().get("success"):
+        # CF normally returns JSON but on an edge failure it can reply with
+        # an HTML error page. Guard the decode so one bad batch doesn't
+        # abort the whole purge loop.
+        try:
+            success = bool(r.json().get("success"))
+        except ValueError:
+            success = False
+        if r.status_code != 200 or not success:
             print(f"  [cf] purge batch {i}: HTTP {r.status_code} {r.text[:200]}",
                   file=sys.stderr)
             ok = False
@@ -201,8 +211,12 @@ def main() -> int:
         sys.exit("ERROR: TMDB_API_KEY env var required.")
     out_dir = Path(args.out_dir)
 
+    # autocommit=True — we only SELECT here, and the loop below then does
+    # minutes of network I/O per row (TMDB + R2 upload). Holding an open
+    # transaction across all of that would leave an idle-in-transaction
+    # session pinning a snapshot and blocking vacuum on `films`.
     conn = psycopg2.connect(DB_URL)
-    conn.autocommit = False
+    conn.autocommit = True
     cur = conn.cursor()
     cur.execute(
         """SELECT id, slug, cover_filename, tmdb_id, title
@@ -212,6 +226,8 @@ def main() -> int:
          ORDER BY id""",
     )
     rows = cur.fetchall()
+    cur.close()
+    conn.close()
     if args.limit:
         rows = rows[:args.limit]
     print(f"Matched {len(rows)} films with exotic-cohort cover_filename.")
@@ -260,8 +276,13 @@ def main() -> int:
                 if not _r2_upload(rclone_cfg, large_path, f"films/large/{slug}.webp"):
                     uploaded = False
                 if not uploaded:
-                    # Don't count as ok, but the local file is still fixed.
-                    print(f"  [warn] id={row_id} local OK, R2 upload partial")
+                    # Local file is fixed, but R2 upload is what prod serves
+                    # from — a partial R2 write leaves the wrong content
+                    # live, so count this as a failure. Skip CF purge so the
+                    # still-wrong URL doesn't get pulled from cache.
+                    print(f"  [warn] id={row_id} local OK, R2 upload partial — counting as failed")
+                    failed += 1
+                    continue
             ok += 1
             if args.purge_cf:
                 purged_urls.append(f"https://ceskarepublika.wiki/filmy-online/{slug}.webp")


### PR DESCRIPTION
<!-- claude-session: 9c42f99e-d1ab-4b4c-9d4d-e7d09129237a -->

Closes #574

## Summary

- Rewrite `download_cover` and `download_sktorrent_thumb` in `scripts/auto_import/cover_downloader.py` to buffer the full response via `r.content` + `BytesIO` before handing to Pillow — the prior `stream=True` + `Image.open(r.raw)` pattern has been observed to splice bytes across concurrent responses in `ThreadPoolExecutor`, which is the symptom that left ~76 exotic-cohort films with WebPs of unrelated films' posters during the prehraj.to bulk import (#524).
- Add an integrity guard: reject decodes where either side is < 100 px or aspect falls outside 0.4–1.0. Covers silent TMDB failures that return tracking pixels.
- Ship `scripts/redownload-exotic-covers.py` — idempotent backfill that re-fetches the TMDB en-US poster for every films row whose `cover_filename` matches `^film-[0-9]+$`, overwrites the local WebP, and optionally uploads to R2 (`cr-images/films/…`) and purges the CF cache.

Already applied to production (76/76 fixed, 152 URLs purged from CF).

## Test plan

- [x] Lokální smoke test: `python3 scripts/redownload-exotic-covers.py --apply --limit 3` produkuje správné WebP (ověřeno vizuálně, Gamera poster odpovídá tmdb_id=21930).
- [x] Existing test suite: `python3 -m scripts.auto_import.test_tmdb_resolver` → 21/21 OK.
- [x] Produkce: spuštěno proti prod DB přes SSH tunel s `--apply --upload-r2 --purge-cf`. Výsledek: `ok=76 fail=0 skip=0`, 152 URL purged.
- [x] Playwright ověření na `https://ceskarepublika.wiki/filmy-online/children-of-the-sea/` — poster `/filmy-online/children-of-the-sea.webp` po force-reload servíruje **Children of the Sea** (nikoli Paltan jako dřív). Console 0 errors.