### PR TITLE
feat(covers): id-keyed R2 layout + thin origin handler (#576)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,9 @@ target/
 docs/
 *.md
 !cr-web/templates/*.html
+
+# Cover WebPs live on Cloudflare R2 (sub-issue #576) — the cover
+# handler fetches them through the cr-img-proxy worker. Baking them
+# into the image would shadow R2 with stale disk copies.
+data/movies/covers-webp/
+data/series/covers-webp/

--- a/cr-web/src/handlers/cover_proxy.rs
+++ b/cr-web/src/handlers/cover_proxy.rs
@@ -44,6 +44,24 @@ pub fn immutable_webp(bytes: Vec<u8>) -> Response {
         .into_response()
 }
 
+/// `image/webp` bytes wrapped with `no-store`. Used when we serve
+/// *something* under a URL that may get a better answer soon — e.g.
+/// the `-large.webp` endpoint falling back to the small variant while
+/// the large is not yet on R2. If we returned those bytes with
+/// `immutable`, CF and browsers would cache the low-res image for a
+/// year and never pick up the large file that imports later.
+pub fn no_store_webp(bytes: Vec<u8>) -> Response {
+    (
+        StatusCode::OK,
+        [
+            (header::CONTENT_TYPE, "image/webp"),
+            (header::CACHE_CONTROL, "no-store"),
+        ],
+        bytes,
+    )
+        .into_response()
+}
+
 /// Tiny 1×1 transparent WebP. Same bytes as the pre-#576 handlers used.
 /// `no-store` is deliberate — a missing cover is a transient state
 /// (import will fill it in shortly), caching the placeholder pins an

--- a/cr-web/src/handlers/cover_proxy.rs
+++ b/cr-web/src/handlers/cover_proxy.rs
@@ -1,0 +1,146 @@
+//! Shared helpers for the `/filmy-online/{slug}.webp`,
+//! `/serialy-online/{slug}.webp` and `/tv-porady/{slug}.webp` cover
+//! routes (plus their `-large` variants).
+//!
+//! Post sub-issue #576 we stopped storing covers on the cr-web container
+//! and moved to an id-keyed R2 layout:
+//!
+//!     cr-images:films/{id}/cover.webp       (200×300)
+//!     cr-images:films/{id}/cover-large.webp (780×1170)
+//!     cr-images:series/{id}/cover.webp      …
+//!     cr-images:tv-shows/{id}/cover.webp    …
+//!
+//! These are fronted by the `cr-img-proxy` Cloudflare Worker at the
+//! `/img/{prefix}/…` path. The handler translates the user-facing
+//! `/filmy-online/{slug}.webp` URL to `/img/films/{id}/{variant}` and
+//! proxies the worker response back to the browser. The small
+//! round-trip is paid only once per (edge, cover) — CF then caches the
+//! response for a year thanks to our `immutable` response header.
+//!
+//! During the rollout window we also fall back to the OLD layout
+//! (`{prefix}/{cover_filename}.webp` without the `{id}/` segment) so
+//! covers keep serving if a migration step fails or is in flight. Sub B
+//! (#577) removes the fallback once all three tables have been
+//! verified.
+
+use axum::http::{StatusCode, header};
+use axum::response::{IntoResponse, Response};
+
+use crate::state::AppState;
+
+/// `image/webp` bytes wrapped with a `public, max-age=31536000, immutable`
+/// cache header. The immutable part is safe because every new cover
+/// lives at a distinct `{id}/cover.webp` URL — re-uploaded covers MUST
+/// purge via the existing `/admin/cache/` flow.
+pub fn immutable_webp(bytes: Vec<u8>) -> Response {
+    (
+        StatusCode::OK,
+        [
+            (header::CONTENT_TYPE, "image/webp"),
+            (header::CACHE_CONTROL, "public, max-age=31536000, immutable"),
+        ],
+        bytes,
+    )
+        .into_response()
+}
+
+/// Tiny 1×1 transparent WebP. Same bytes as the pre-#576 handlers used.
+/// `no-store` is deliberate — a missing cover is a transient state
+/// (import will fill it in shortly), caching the placeholder pins an
+/// empty card in the browser for hours after the real WebP lands.
+pub fn placeholder_webp() -> Response {
+    static BYTES: &[u8] = &[
+        0x52, 0x49, 0x46, 0x46, 0x1a, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50, 0x56, 0x50, 0x38,
+        0x4c, 0x0d, 0x00, 0x00, 0x00, 0x2f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00,
+    ];
+    (
+        StatusCode::OK,
+        [
+            (header::CONTENT_TYPE, "image/webp"),
+            (header::CACHE_CONTROL, "no-store"),
+        ],
+        BYTES.to_vec(),
+    )
+        .into_response()
+}
+
+fn public_base(state: &AppState) -> &str {
+    // Prod: `image_base_url` is empty and we fall back to the canonical
+    // site hostname. Dev: set IMAGE_BASE_URL=http://dev.localhost:3000
+    // or similar to route image fetches at a dev-facing worker.
+    let b = state.image_base_url.as_str();
+    if b.is_empty() {
+        "https://ceskarepublika.wiki"
+    } else {
+        b
+    }
+}
+
+pub async fn try_fetch_r2(state: &AppState, key: &str) -> Option<Vec<u8>> {
+    let url = format!("{}/img/{key}", public_base(state));
+    let resp = state
+        .http_client
+        .get(&url)
+        .timeout(std::time::Duration::from_secs(10))
+        .send()
+        .await
+        .ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    resp.bytes().await.ok().map(|b| b.to_vec())
+}
+
+/// Fetch a cover from R2 via the img-proxy worker, preferring the new
+/// id-keyed layout and falling back to the old name-keyed one.
+///
+/// `new_key` / `old_key` are R2 object keys like `films/29876/cover.webp`
+/// and `films/children-of-the-sea.webp`. Returns a ready `Response` —
+/// the placeholder 1×1 WebP when both keys miss, so clients never see a
+/// 404 for a cover URL.
+pub async fn fetch_cover(state: &AppState, new_key: &str, old_key: Option<&str>) -> Response {
+    if let Some(bytes) = try_fetch_r2(state, new_key).await {
+        return immutable_webp(bytes);
+    }
+    if let Some(old) = old_key
+        && let Some(bytes) = try_fetch_r2(state, old).await
+    {
+        return immutable_webp(bytes);
+    }
+    placeholder_webp()
+}
+
+/// Strip the `.webp` / `-large.webp` suffix from an incoming path param
+/// and return `(slug, is_large)`.
+pub fn parse_cover_slug(slug_webp: &str) -> (String, bool) {
+    if let Some(s) = slug_webp.strip_suffix("-large.webp") {
+        (s.to_string(), true)
+    } else if let Some(s) = slug_webp.strip_suffix(".webp") {
+        (s.to_string(), false)
+    } else {
+        (slug_webp.to_string(), false)
+    }
+}
+
+/// Returns the R2 key for a cover given `table_prefix`, `id`, and
+/// `is_large`. `table_prefix` is the top-level R2 prefix
+/// (`films`, `series`, `tv-shows`).
+pub fn new_r2_key(table_prefix: &str, id: i32, is_large: bool) -> String {
+    let variant = if is_large { "cover-large" } else { "cover" };
+    format!("{table_prefix}/{id}/{variant}.webp")
+}
+
+/// Old-layout key we try as a fallback when the new key isn't on R2
+/// yet. `cover_filename` is the pre-#576 slug-ish identifier stored in
+/// the `{table}.cover_filename` column. Large variants historically
+/// lived under `/large/` with either the row's `slug` or its
+/// `cover_filename` — we accept the `cover_filename` form here and let
+/// the handler try the slug as a second fallback if it wants.
+pub fn old_r2_key(table_prefix: &str, cover_filename: &str, is_large: bool) -> String {
+    if is_large {
+        format!("{table_prefix}/large/{cover_filename}.webp")
+    } else {
+        format!("{table_prefix}/{cover_filename}.webp")
+    }
+}

--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -844,158 +844,91 @@ pub async fn films_cover(
     State(state): State<AppState>,
     Path(slug_webp): Path<String>,
 ) -> WebResult<Response> {
-    let slug = slug_webp.strip_suffix(".webp").unwrap_or(&slug_webp);
+    use crate::handlers::cover_proxy::{
+        fetch_cover, new_r2_key, old_r2_key, parse_cover_slug, placeholder_webp,
+    };
+
+    let (slug, _is_large) = parse_cover_slug(&slug_webp);
 
     #[derive(sqlx::FromRow)]
     struct CoverRow {
+        id: i32,
         cover_filename: Option<String>,
     }
 
-    let row = sqlx::query_as::<_, CoverRow>("SELECT cover_filename FROM films WHERE slug = $1")
-        .bind(slug)
+    let row = sqlx::query_as::<_, CoverRow>("SELECT id, cover_filename FROM films WHERE slug = $1")
+        .bind(&slug)
         .fetch_optional(&state.db)
         .await?;
 
-    let cover_filename = row.and_then(|r| r.cover_filename);
+    let Some(row) = row else {
+        return Ok(placeholder_webp());
+    };
 
-    let covers_dir = state.config.film_covers_dir.clone();
-
-    if let Some(filename) = cover_filename {
-        let path = std::path::Path::new(&covers_dir).join(format!("{filename}.webp"));
-        if path.exists() {
-            let bytes = tokio::fs::read(&path).await.map_err(|e| {
-                tracing::error!("Failed to read cover {}: {}", path.display(), e);
-                crate::error::WebError::Internal(anyhow::anyhow!("Failed to read cover: {e}"))
-            })?;
-            return Ok((
-                StatusCode::OK,
-                [
-                    (header::CONTENT_TYPE, "image/webp"),
-                    (header::CACHE_CONTROL, "public, max-age=31536000"),
-                ],
-                bytes,
-            )
-                .into_response());
-        }
-    }
-
-    // Placeholder: 1x1 transparent WebP. `no-store` — a missing cover is a
-    // transient state (import will fill it shortly); caching the placeholder
-    // pins an empty card in the browser for hours after the real WebP lands.
-    static PLACEHOLDER: &[u8] = &[
-        0x52, 0x49, 0x46, 0x46, 0x1a, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50, 0x56, 0x50, 0x38,
-        0x4c, 0x0d, 0x00, 0x00, 0x00, 0x2f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00,
-    ];
-    Ok((
-        StatusCode::OK,
-        [
-            (header::CONTENT_TYPE, "image/webp"),
-            (header::CACHE_CONTROL, "no-store"),
-        ],
-        PLACEHOLDER.to_vec(),
-    )
-        .into_response())
+    // Try the new id-keyed layout first, then the pre-migration name-keyed
+    // one. See handlers::cover_proxy for the rollout story.
+    let new_key = new_r2_key("films", row.id, false);
+    let old_key = row
+        .cover_filename
+        .as_deref()
+        .map(|cf| old_r2_key("films", cf, false));
+    Ok(fetch_cover(&state, &new_key, old_key.as_deref()).await)
 }
 
-/// GET /filmy-online/{slug}-large.webp — serve large WebP cover (w780 from TMDB, cached)
+/// GET /filmy-online/{slug}-large.webp — large (780×1170) cover.
+///
+/// Mirrors `films_cover` but targets the `{id}/cover-large.webp` key.
+/// If neither the new nor the old R2 key exists we fall back to the
+/// small variant — `images tmdb.org` fetching is now the import
+/// pipeline's job, the handler stays stateless.
 pub async fn films_cover_large(
     State(state): State<AppState>,
     Path(slug_webp): Path<String>,
 ) -> WebResult<Response> {
-    let slug = slug_webp.strip_suffix("-large.webp").unwrap_or(&slug_webp);
+    use crate::handlers::cover_proxy::{
+        new_r2_key, old_r2_key, parse_cover_slug, placeholder_webp,
+    };
+
+    let (slug, _is_large) = parse_cover_slug(&slug_webp);
 
     #[derive(sqlx::FromRow)]
     struct CoverRow {
-        tmdb_id: Option<i32>,
+        id: i32,
+        cover_filename: Option<String>,
     }
 
-    let row = sqlx::query_as::<_, CoverRow>("SELECT tmdb_id FROM films WHERE slug = $1")
-        .bind(slug)
+    let row = sqlx::query_as::<_, CoverRow>("SELECT id, cover_filename FROM films WHERE slug = $1")
+        .bind(&slug)
         .fetch_optional(&state.db)
         .await?;
 
-    let tmdb_id = row.and_then(|r| r.tmdb_id);
-    let covers_dir = state.config.film_covers_dir.clone();
+    let Some(row) = row else {
+        return Ok(placeholder_webp());
+    };
 
-    // Cache path: {covers_dir}/large/{slug}.webp
-    let cache_dir = std::path::Path::new(&covers_dir).join("large");
-    let cache_path = cache_dir.join(format!("{slug}.webp"));
-
-    // Serve from cache if exists
-    if cache_path.exists()
-        && let Ok(bytes) = tokio::fs::read(&cache_path).await
-    {
-        return Ok((
-            StatusCode::OK,
-            [
-                (header::CONTENT_TYPE, "image/webp"),
-                (header::CACHE_CONTROL, "public, max-age=31536000, immutable"),
-            ],
-            bytes,
-        )
-            .into_response());
+    use crate::handlers::cover_proxy::{immutable_webp, try_fetch_r2};
+    let new_key = new_r2_key("films", row.id, true);
+    // Old large covers were keyed by `slug` (handler cache) AND sometimes
+    // by `cover_filename` (#578 backfill). Try all three in order of
+    // likely hit rate, stop at the first that exists.
+    let mut candidates = vec![new_key];
+    candidates.push(format!("films/large/{slug}.webp"));
+    if let Some(cf) = row.cover_filename.as_deref() {
+        candidates.push(old_r2_key("films", cf, true));
     }
-
-    // Fetch from TMDB
-    if let Some(tid) = tmdb_id {
-        // First get poster_path
-        let tmdb_key = "0405855b8275307d3cf3284470fd9d28";
-        let detail_url =
-            format!("https://api.themoviedb.org/3/movie/{tid}?api_key={tmdb_key}&language=cs-CZ");
-
-        if let Ok(resp) = state
-            .http_client
-            .get(&detail_url)
-            .timeout(std::time::Duration::from_secs(10))
-            .send()
-            .await
-            && let Ok(data) = resp.json::<serde_json::Value>().await
-            && let Some(poster_path) = data.get("poster_path").and_then(|v| v.as_str())
-        {
-            // Download w780 poster
-            let poster_url = format!("https://image.tmdb.org/t/p/w780{poster_path}");
-            if let Ok(img_resp) = state
-                .http_client
-                .get(&poster_url)
-                .timeout(std::time::Duration::from_secs(15))
-                .send()
-                .await
-                && img_resp.status().is_success()
-                && let Ok(bytes) = img_resp.bytes().await
-            {
-                // Try to convert to WebP for smaller size
-                let output_bytes = if let Ok(img) = image::load_from_memory(&bytes) {
-                    let mut buf = Vec::new();
-                    let mut cursor = std::io::Cursor::new(&mut buf);
-                    if img.write_to(&mut cursor, image::ImageFormat::WebP).is_ok() {
-                        buf
-                    } else {
-                        bytes.to_vec()
-                    }
-                } else {
-                    bytes.to_vec()
-                };
-
-                // Save to cache
-                let _ = tokio::fs::create_dir_all(&cache_dir).await;
-                let _ = tokio::fs::write(&cache_path, &output_bytes).await;
-
-                return Ok((
-                    StatusCode::OK,
-                    [
-                        (header::CONTENT_TYPE, "image/webp"),
-                        (header::CACHE_CONTROL, "public, max-age=31536000, immutable"),
-                    ],
-                    output_bytes,
-                )
-                    .into_response());
-            }
+    // If large missing, fall through to the small variant (same row we
+    // already loaded) so the detail page renders something instead of a
+    // broken image. Inlined to avoid async recursion with films_cover.
+    candidates.push(new_r2_key("films", row.id, false));
+    if let Some(cf) = row.cover_filename.as_deref() {
+        candidates.push(old_r2_key("films", cf, false));
+    }
+    for key in &candidates {
+        if let Some(bytes) = try_fetch_r2(&state, key).await {
+            return Ok(immutable_webp(bytes));
         }
     }
-
-    // Fallback to small cover
-    films_cover(State(state), Path(format!("{slug}.webp"))).await
+    Ok(placeholder_webp())
 }
 
 // --- Sktorrent resolve API ---

--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -906,26 +906,30 @@ pub async fn films_cover_large(
         return Ok(placeholder_webp());
     };
 
-    use crate::handlers::cover_proxy::{immutable_webp, try_fetch_r2};
-    let new_key = new_r2_key("films", row.id, true);
-    // Old large covers were keyed by `slug` (handler cache) AND sometimes
-    // by `cover_filename` (#578 backfill). Try all three in order of
-    // likely hit rate, stop at the first that exists.
-    let mut candidates = vec![new_key];
-    candidates.push(format!("films/large/{slug}.webp"));
+    use crate::handlers::cover_proxy::{immutable_webp, no_store_webp, try_fetch_r2};
+    // Tuple: (R2 key, is_small_fallback). Large-variant hits are cached
+    // for a year (`immutable`); small-variant fallbacks are `no-store`
+    // so a later-imported large cover can unseat them without a manual
+    // CF purge.
+    let mut candidates: Vec<(String, bool)> = vec![(new_r2_key("films", row.id, true), false)];
+    candidates.push((format!("films/large/{slug}.webp"), false));
     if let Some(cf) = row.cover_filename.as_deref() {
-        candidates.push(old_r2_key("films", cf, true));
+        candidates.push((old_r2_key("films", cf, true), false));
     }
-    // If large missing, fall through to the small variant (same row we
-    // already loaded) so the detail page renders something instead of a
-    // broken image. Inlined to avoid async recursion with films_cover.
-    candidates.push(new_r2_key("films", row.id, false));
+    // Small-variant fallbacks — inlined to avoid async recursion with
+    // films_cover. Marked `is_small_fallback=true` so they get served
+    // with `no-store`.
+    candidates.push((new_r2_key("films", row.id, false), true));
     if let Some(cf) = row.cover_filename.as_deref() {
-        candidates.push(old_r2_key("films", cf, false));
+        candidates.push((old_r2_key("films", cf, false), true));
     }
-    for key in &candidates {
+    for (key, is_small_fallback) in &candidates {
         if let Some(bytes) = try_fetch_r2(&state, key).await {
-            return Ok(immutable_webp(bytes));
+            return Ok(if *is_small_fallback {
+                no_store_webp(bytes)
+            } else {
+                immutable_webp(bytes)
+            });
         }
     }
     Ok(placeholder_webp())

--- a/cr-web/src/handlers/mod.rs
+++ b/cr-web/src/handlers/mod.rs
@@ -15,6 +15,7 @@ pub mod admin_dashboard;
 pub mod admin_import;
 mod admin_test_sledujteto;
 mod audiobooks;
+pub mod cover_proxy;
 mod download_video;
 mod films;
 mod filmy_serialy;

--- a/cr-web/src/handlers/series.rs
+++ b/cr-web/src/handlers/series.rs
@@ -1158,20 +1158,25 @@ pub async fn series_cover_large(
         return Ok(placeholder_webp());
     };
 
-    let mut candidates = vec![new_r2_key("series", row.id, true)];
-    candidates.push(format!("series/large/{slug}.webp"));
+    use crate::handlers::cover_proxy::no_store_webp;
+    // (R2 key, is_small_fallback) — small variants served under the
+    // `-large.webp` URL must be `no-store` (see films_cover_large).
+    let mut candidates: Vec<(String, bool)> = vec![(new_r2_key("series", row.id, true), false)];
+    candidates.push((format!("series/large/{slug}.webp"), false));
     if let Some(cf) = row.cover_filename.as_deref() {
-        candidates.push(old_r2_key("series", cf, true));
+        candidates.push((old_r2_key("series", cf, true), false));
     }
-    // If large missing, fall through to the small variant (inlined to
-    // avoid async recursion with series_cover).
-    candidates.push(new_r2_key("series", row.id, false));
+    candidates.push((new_r2_key("series", row.id, false), true));
     if let Some(cf) = row.cover_filename.as_deref() {
-        candidates.push(old_r2_key("series", cf, false));
+        candidates.push((old_r2_key("series", cf, false), true));
     }
-    for key in &candidates {
+    for (key, is_small_fallback) in &candidates {
         if let Some(bytes) = try_fetch_r2(&state, key).await {
-            return Ok(immutable_webp(bytes));
+            return Ok(if *is_small_fallback {
+                no_store_webp(bytes)
+            } else {
+                immutable_webp(bytes)
+            });
         }
     }
     Ok(placeholder_webp())

--- a/cr-web/src/handlers/series.rs
+++ b/cr-web/src/handlers/series.rs
@@ -1095,242 +1095,86 @@ pub async fn series_cover(
     State(state): State<AppState>,
     Path(slug_webp): Path<String>,
 ) -> WebResult<Response> {
-    // Detect -large variant — fetches w780 poster from TMDB (cached to disk)
+    use crate::handlers::cover_proxy::{
+        fetch_cover, new_r2_key, old_r2_key, parse_cover_slug, placeholder_webp,
+    };
+
     if slug_webp.ends_with("-large.webp") {
-        return series_cover_large(State(state), Path(slug_webp)).await;
+        // Box::pin to break the mutual-recursion future size cycle
+        // (series_cover → series_cover_large → … small fallback paths).
+        return Box::pin(series_cover_large(State(state), Path(slug_webp))).await;
     }
-    let slug = slug_webp.strip_suffix(".webp").unwrap_or(&slug_webp);
+    let (slug, _is_large) = parse_cover_slug(&slug_webp);
 
     #[derive(sqlx::FromRow)]
     struct CoverRow {
+        id: i32,
         cover_filename: Option<String>,
-        tmdb_id: Option<i32>,
     }
 
     let row =
-        sqlx::query_as::<_, CoverRow>("SELECT cover_filename, tmdb_id FROM series WHERE slug = $1")
-            .bind(slug)
+        sqlx::query_as::<_, CoverRow>("SELECT id, cover_filename FROM series WHERE slug = $1")
+            .bind(&slug)
             .fetch_optional(&state.db)
             .await?;
 
-    let (cover_filename, tmdb_id) = match row {
-        Some(r) => (r.cover_filename, r.tmdb_id),
-        None => (None, None),
+    let Some(row) = row else {
+        return Ok(placeholder_webp());
     };
-    let covers_dir = state.config.series_covers_dir.clone();
 
-    // Try local file first
-    if let Some(ref filename) = cover_filename {
-        let path = std::path::Path::new(&covers_dir).join(format!("{filename}.webp"));
-        if path.exists()
-            && let Ok(bytes) = tokio::fs::read(&path).await
-        {
-            return Ok((
-                StatusCode::OK,
-                [
-                    (header::CONTENT_TYPE, "image/webp"),
-                    (header::CACHE_CONTROL, "public, max-age=31536000"),
-                ],
-                bytes,
-            )
-                .into_response());
-        }
-    }
-
-    // Fallback: fetch w200 poster from TMDB on-the-fly and cache to disk
-    if let Some(tid) = tmdb_id {
-        let tmdb_key = std::env::var("TMDB_API_KEY").unwrap_or_default();
-        if !tmdb_key.is_empty() {
-            let detail_url =
-                format!("https://api.themoviedb.org/3/tv/{tid}?api_key={tmdb_key}&language=cs-CZ");
-            if let Ok(resp) = state
-                .http_client
-                .get(&detail_url)
-                .timeout(std::time::Duration::from_secs(10))
-                .send()
-                .await
-                && let Ok(data) = resp.json::<serde_json::Value>().await
-                && let Some(poster_path) = data.get("poster_path").and_then(|v| v.as_str())
-            {
-                let img_url = format!("https://image.tmdb.org/t/p/w200{poster_path}");
-                if let Ok(img_resp) = state
-                    .http_client
-                    .get(&img_url)
-                    .timeout(std::time::Duration::from_secs(15))
-                    .send()
-                    .await
-                    && let Ok(img_bytes) = img_resp.bytes().await
-                {
-                    // Cache to disk for next request
-                    let cache_path = std::path::Path::new(&covers_dir).join(format!("{slug}.webp"));
-                    let _ = tokio::fs::create_dir_all(&covers_dir).await;
-                    let _ = tokio::fs::write(&cache_path, &img_bytes).await;
-
-                    return Ok((
-                        StatusCode::OK,
-                        [
-                            (header::CONTENT_TYPE, "image/webp"),
-                            (header::CACHE_CONTROL, "public, max-age=31536000, immutable"),
-                        ],
-                        img_bytes.to_vec(),
-                    )
-                        .into_response());
-                }
-            }
-        }
-    }
-
-    // Placeholder (1x1 WebP). `no-store` is deliberate — browsers that
-    // fetched a placeholder while the real cover was still being imported
-    // would otherwise keep the 1x1 for the full max-age, making the next
-    // pageview still show an empty card even after the WebP lands on disk.
-    static PLACEHOLDER: &[u8] = &[
-        0x52, 0x49, 0x46, 0x46, 0x1a, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50, 0x56, 0x50, 0x38,
-        0x4c, 0x0d, 0x00, 0x00, 0x00, 0x2f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00,
-    ];
-    Ok((
-        StatusCode::OK,
-        [
-            (header::CONTENT_TYPE, "image/webp"),
-            (header::CACHE_CONTROL, "no-store"),
-        ],
-        PLACEHOLDER.to_vec(),
-    )
-        .into_response())
+    let new_key = new_r2_key("series", row.id, false);
+    let old_key = row
+        .cover_filename
+        .as_deref()
+        .map(|cf| old_r2_key("series", cf, false));
+    Ok(fetch_cover(&state, &new_key, old_key.as_deref()).await)
 }
 
-/// GET /serialy-online/{slug}-large.webp — serve w780 poster from TMDB (cached).
-/// Mirrors films_cover_large for feature parity on series detail pages.
+/// GET /serialy-online/{slug}-large.webp — large (780×1170) cover.
+/// See handlers::cover_proxy for the R2 key schema + fallback rationale.
 pub async fn series_cover_large(
     State(state): State<AppState>,
     Path(slug_webp): Path<String>,
 ) -> WebResult<Response> {
-    let slug = slug_webp.strip_suffix("-large.webp").unwrap_or(&slug_webp);
+    use crate::handlers::cover_proxy::{
+        immutable_webp, new_r2_key, old_r2_key, parse_cover_slug, placeholder_webp, try_fetch_r2,
+    };
+
+    let (slug, _is_large) = parse_cover_slug(&slug_webp);
 
     #[derive(sqlx::FromRow)]
     struct CoverRow {
-        tmdb_id: Option<i32>,
+        id: i32,
+        cover_filename: Option<String>,
     }
 
-    let row = sqlx::query_as::<_, CoverRow>("SELECT tmdb_id FROM series WHERE slug = $1")
-        .bind(slug)
-        .fetch_optional(&state.db)
-        .await?;
+    let row =
+        sqlx::query_as::<_, CoverRow>("SELECT id, cover_filename FROM series WHERE slug = $1")
+            .bind(&slug)
+            .fetch_optional(&state.db)
+            .await?;
 
-    let tmdb_id = row.and_then(|r| r.tmdb_id);
-    let covers_dir = state.config.series_covers_dir.clone();
+    let Some(row) = row else {
+        return Ok(placeholder_webp());
+    };
 
-    // Cache path: {covers_dir}/large/{slug}.webp
-    let cache_dir = std::path::Path::new(&covers_dir).join("large");
-    let cache_path = cache_dir.join(format!("{slug}.webp"));
-
-    if cache_path.exists()
-        && let Ok(bytes) = tokio::fs::read(&cache_path).await
-    {
-        return Ok((
-            StatusCode::OK,
-            [
-                (header::CONTENT_TYPE, "image/webp"),
-                (header::CACHE_CONTROL, "public, max-age=31536000, immutable"),
-            ],
-            bytes,
-        )
-            .into_response());
+    let mut candidates = vec![new_r2_key("series", row.id, true)];
+    candidates.push(format!("series/large/{slug}.webp"));
+    if let Some(cf) = row.cover_filename.as_deref() {
+        candidates.push(old_r2_key("series", cf, true));
     }
-
-    // Fetch from TMDB (TV endpoint)
-    if let Some(tid) = tmdb_id {
-        let tmdb_key = "0405855b8275307d3cf3284470fd9d28";
-        let detail_url =
-            format!("https://api.themoviedb.org/3/tv/{tid}?api_key={tmdb_key}&language=cs-CZ");
-
-        if let Ok(resp) = state
-            .http_client
-            .get(&detail_url)
-            .timeout(std::time::Duration::from_secs(10))
-            .send()
-            .await
-            && let Ok(data) = resp.json::<serde_json::Value>().await
-            && let Some(poster_path) = data.get("poster_path").and_then(|v| v.as_str())
-        {
-            let poster_url = format!("https://image.tmdb.org/t/p/w780{poster_path}");
-            if let Ok(img_resp) = state
-                .http_client
-                .get(&poster_url)
-                .timeout(std::time::Duration::from_secs(15))
-                .send()
-                .await
-                && img_resp.status().is_success()
-                && let Ok(bytes) = img_resp.bytes().await
-            {
-                let output_bytes = if let Ok(img) = image::load_from_memory(&bytes) {
-                    let mut buf = Vec::new();
-                    let mut cursor = std::io::Cursor::new(&mut buf);
-                    if img.write_to(&mut cursor, image::ImageFormat::WebP).is_ok() {
-                        buf
-                    } else {
-                        bytes.to_vec()
-                    }
-                } else {
-                    bytes.to_vec()
-                };
-
-                let _ = tokio::fs::create_dir_all(&cache_dir).await;
-                let _ = tokio::fs::write(&cache_path, &output_bytes).await;
-
-                return Ok((
-                    StatusCode::OK,
-                    [
-                        (header::CONTENT_TYPE, "image/webp"),
-                        (header::CACHE_CONTROL, "public, max-age=31536000, immutable"),
-                    ],
-                    output_bytes,
-                )
-                    .into_response());
-            }
+    // If large missing, fall through to the small variant (inlined to
+    // avoid async recursion with series_cover).
+    candidates.push(new_r2_key("series", row.id, false));
+    if let Some(cf) = row.cover_filename.as_deref() {
+        candidates.push(old_r2_key("series", cf, false));
+    }
+    for key in &candidates {
+        if let Some(bytes) = try_fetch_r2(&state, key).await {
+            return Ok(immutable_webp(bytes));
         }
     }
-
-    // Fallback to small cover (inline to avoid async recursion)
-    let row = sqlx::query_as::<_, CoverRow2>("SELECT cover_filename FROM series WHERE slug = $1")
-        .bind(slug)
-        .fetch_optional(&state.db)
-        .await?;
-    let covers_dir_small = state.config.series_covers_dir.clone();
-    if let Some(filename) = row.and_then(|r| r.cover_filename) {
-        let path = std::path::Path::new(&covers_dir_small).join(format!("{filename}.webp"));
-        if path.exists()
-            && let Ok(bytes) = tokio::fs::read(&path).await
-        {
-            return Ok((
-                StatusCode::OK,
-                [
-                    (header::CONTENT_TYPE, "image/webp"),
-                    (header::CACHE_CONTROL, "public, max-age=31536000"),
-                ],
-                bytes,
-            )
-                .into_response());
-        }
-    }
-    // Tiny empty WebP placeholder. `no-store` — same reasoning as the
-    // series_cover fallback above: don't let a transient miss get pinned
-    // in the browser cache for hours after the real file appears.
-    static PLACEHOLDER: &[u8] = &[
-        0x52, 0x49, 0x46, 0x46, 0x1a, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50, 0x56, 0x50, 0x38,
-        0x4c, 0x0d, 0x00, 0x00, 0x00, 0x2f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00,
-    ];
-    Ok((
-        StatusCode::OK,
-        [
-            (header::CONTENT_TYPE, "image/webp"),
-            (header::CACHE_CONTROL, "no-store"),
-        ],
-        PLACEHOLDER.to_vec(),
-    )
-        .into_response())
+    Ok(placeholder_webp())
 }
 
 /// Build pagination query string for series list views.
@@ -1367,11 +1211,6 @@ fn build_series_query_string(params: &SeriesQuery) -> String {
         parts.push(("rok", r.clone()));
     }
     super::build_pagination_qs(&parts)
-}
-
-#[derive(sqlx::FromRow)]
-struct CoverRow2 {
-    cover_filename: Option<String>,
 }
 
 /// GET /serialy-online/person/{filename} — serve person profile image from disk.

--- a/cr-web/src/handlers/tv_porady.rs
+++ b/cr-web/src/handlers/tv_porady.rs
@@ -630,22 +630,28 @@ pub async fn tv_porad_cover_large(
         return Ok(placeholder_webp());
     };
 
+    use crate::handlers::cover_proxy::no_store_webp;
     // Pre-migration large covers were cached under the `series/large/`
-    // prefix (tv_shows shared the series_covers_dir). Try the new
-    // `tv-shows/{id}/cover-large.webp` first, then those older forms.
-    let mut candidates = vec![new_r2_key("tv-shows", row.id, true)];
-    candidates.push(format!("series/large/{slug}.webp"));
+    // prefix (tv_shows shared the series_covers_dir). (R2 key,
+    // is_small_fallback) — small-variant fallbacks are served with
+    // `no-store` so a later-imported large can take over (see
+    // films_cover_large).
+    let mut candidates: Vec<(String, bool)> = vec![(new_r2_key("tv-shows", row.id, true), false)];
+    candidates.push((format!("series/large/{slug}.webp"), false));
     if let Some(cf) = row.cover_filename.as_deref() {
-        candidates.push(old_r2_key("series", cf, true));
+        candidates.push((old_r2_key("series", cf, true), false));
     }
-    // Fall through to small variant inlined (avoid async recursion).
-    candidates.push(new_r2_key("tv-shows", row.id, false));
+    candidates.push((new_r2_key("tv-shows", row.id, false), true));
     if let Some(cf) = row.cover_filename.as_deref() {
-        candidates.push(old_r2_key("series", cf, false));
+        candidates.push((old_r2_key("series", cf, false), true));
     }
-    for key in &candidates {
+    for (key, is_small_fallback) in &candidates {
         if let Some(bytes) = try_fetch_r2(&state, key).await {
-            return Ok(immutable_webp(bytes));
+            return Ok(if *is_small_fallback {
+                no_store_webp(bytes)
+            } else {
+                immutable_webp(bytes)
+            });
         }
     }
     Ok(placeholder_webp())

--- a/cr-web/src/handlers/tv_porady.rs
+++ b/cr-web/src/handlers/tv_porady.rs
@@ -567,237 +567,88 @@ pub async fn tv_porad_cover(
     State(state): State<AppState>,
     Path(slug_webp): Path<String>,
 ) -> WebResult<Response> {
+    use crate::handlers::cover_proxy::{
+        fetch_cover, new_r2_key, old_r2_key, parse_cover_slug, placeholder_webp,
+    };
+
     if slug_webp.ends_with("-large.webp") {
-        return tv_porad_cover_large(State(state), Path(slug_webp)).await;
+        return Box::pin(tv_porad_cover_large(State(state), Path(slug_webp))).await;
     }
-    let slug = slug_webp.strip_suffix(".webp").unwrap_or(&slug_webp);
+    let (slug, _is_large) = parse_cover_slug(&slug_webp);
 
     #[derive(sqlx::FromRow)]
     struct CoverRow {
+        id: i32,
         cover_filename: Option<String>,
-        tmdb_id: Option<i32>,
     }
 
-    let row = sqlx::query_as::<_, CoverRow>(
-        "SELECT cover_filename, tmdb_id FROM tv_shows WHERE slug = $1",
-    )
-    .bind(slug)
-    .fetch_optional(&state.db)
-    .await?;
+    let row =
+        sqlx::query_as::<_, CoverRow>("SELECT id, cover_filename FROM tv_shows WHERE slug = $1")
+            .bind(&slug)
+            .fetch_optional(&state.db)
+            .await?;
 
-    let (cover_filename, tmdb_id) = match row {
-        Some(r) => (r.cover_filename, r.tmdb_id),
-        None => (None, None),
+    let Some(row) = row else {
+        return Ok(placeholder_webp());
     };
-    // Reuse series_covers_dir for now (migration reuses files written for
-    // these same slugs before they were moved).
-    let covers_dir = state.config.series_covers_dir.clone();
 
-    if let Some(ref filename) = cover_filename {
-        let path = std::path::Path::new(&covers_dir).join(format!("{filename}.webp"));
-        if path.exists()
-            && let Ok(bytes) = tokio::fs::read(&path).await
-        {
-            return Ok((
-                StatusCode::OK,
-                [
-                    (header::CONTENT_TYPE, "image/webp"),
-                    (header::CACHE_CONTROL, "public, max-age=31536000"),
-                ],
-                bytes,
-            )
-                .into_response());
-        }
-    }
-
-    if let Some(tid) = tmdb_id {
-        let tmdb_key = std::env::var("TMDB_API_KEY").unwrap_or_default();
-        if !tmdb_key.is_empty() {
-            let detail_url =
-                format!("https://api.themoviedb.org/3/tv/{tid}?api_key={tmdb_key}&language=cs-CZ");
-            if let Ok(resp) = state
-                .http_client
-                .get(&detail_url)
-                .timeout(std::time::Duration::from_secs(10))
-                .send()
-                .await
-                && let Ok(data) = resp.json::<serde_json::Value>().await
-                && let Some(poster_path) = data.get("poster_path").and_then(|v| v.as_str())
-            {
-                let img_url = format!("https://image.tmdb.org/t/p/w200{poster_path}");
-                if let Ok(img_resp) = state
-                    .http_client
-                    .get(&img_url)
-                    .timeout(std::time::Duration::from_secs(15))
-                    .send()
-                    .await
-                    && img_resp.status().is_success()
-                    && let Ok(raw_bytes) = img_resp.bytes().await
-                {
-                    // TMDB returns JPEG; re-encode to WebP off the async
-                    // runtime (CPU-bound) and bail out if transcoding fails
-                    // so we don't cache raw JPEG under a .webp filename.
-                    let raw = raw_bytes.to_vec();
-                    let output_bytes = tokio::task::spawn_blocking(move || -> Option<Vec<u8>> {
-                        let img = image::load_from_memory(&raw).ok()?;
-                        let mut buf = Vec::new();
-                        let mut cursor = std::io::Cursor::new(&mut buf);
-                        img.write_to(&mut cursor, image::ImageFormat::WebP).ok()?;
-                        Some(buf)
-                    })
-                    .await
-                    .ok()
-                    .flatten();
-
-                    if let Some(output_bytes) = output_bytes {
-                        let cache_path =
-                            std::path::Path::new(&covers_dir).join(format!("{slug}.webp"));
-                        let _ = tokio::fs::create_dir_all(&covers_dir).await;
-                        let _ = tokio::fs::write(&cache_path, &output_bytes).await;
-
-                        return Ok((
-                            StatusCode::OK,
-                            [
-                                (header::CONTENT_TYPE, "image/webp"),
-                                (header::CACHE_CONTROL, "public, max-age=31536000, immutable"),
-                            ],
-                            output_bytes,
-                        )
-                            .into_response());
-                    }
-                }
-            }
-        }
-    }
-
-    // `no-store` — missing TV pořad cover is a transient state; a cached
-    // placeholder would pin an empty card for hours after the real WebP
-    // arrives on disk.
-    static PLACEHOLDER: &[u8] = &[
-        0x52, 0x49, 0x46, 0x46, 0x1a, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50, 0x56, 0x50, 0x38,
-        0x4c, 0x0d, 0x00, 0x00, 0x00, 0x2f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00,
-    ];
-    Ok((
-        StatusCode::OK,
-        [
-            (header::CONTENT_TYPE, "image/webp"),
-            (header::CACHE_CONTROL, "no-store"),
-        ],
-        PLACEHOLDER.to_vec(),
-    )
-        .into_response())
+    let new_key = new_r2_key("tv-shows", row.id, false);
+    // Pre-migration tv_shows covers shared the `series/` R2 prefix with
+    // the `series` table. Keep the old-layout fallback on that prefix
+    // until the migration script has moved them under `tv-shows/`.
+    let old_key = row
+        .cover_filename
+        .as_deref()
+        .map(|cf| old_r2_key("series", cf, false));
+    Ok(fetch_cover(&state, &new_key, old_key.as_deref()).await)
 }
 
-/// GET /tv-porady/{slug}-large.webp — w780 poster from TMDB, cached.
+/// GET /tv-porady/{slug}-large.webp — large (780×1170) cover.
 pub async fn tv_porad_cover_large(
     State(state): State<AppState>,
     Path(slug_webp): Path<String>,
 ) -> WebResult<Response> {
-    let slug = slug_webp.strip_suffix("-large.webp").unwrap_or(&slug_webp);
+    use crate::handlers::cover_proxy::{
+        immutable_webp, new_r2_key, old_r2_key, parse_cover_slug, placeholder_webp, try_fetch_r2,
+    };
+
+    let (slug, _is_large) = parse_cover_slug(&slug_webp);
 
     #[derive(sqlx::FromRow)]
     struct CoverRow {
-        tmdb_id: Option<i32>,
+        id: i32,
+        cover_filename: Option<String>,
     }
 
-    let row = sqlx::query_as::<_, CoverRow>("SELECT tmdb_id FROM tv_shows WHERE slug = $1")
-        .bind(slug)
-        .fetch_optional(&state.db)
-        .await?;
+    let row =
+        sqlx::query_as::<_, CoverRow>("SELECT id, cover_filename FROM tv_shows WHERE slug = $1")
+            .bind(&slug)
+            .fetch_optional(&state.db)
+            .await?;
 
-    let tmdb_id = row.and_then(|r| r.tmdb_id);
-    let covers_dir = state.config.series_covers_dir.clone();
+    let Some(row) = row else {
+        return Ok(placeholder_webp());
+    };
 
-    let cache_dir = std::path::Path::new(&covers_dir).join("large");
-    let cache_path = cache_dir.join(format!("{slug}.webp"));
-
-    if cache_path.exists()
-        && let Ok(bytes) = tokio::fs::read(&cache_path).await
-    {
-        return Ok((
-            StatusCode::OK,
-            [
-                (header::CONTENT_TYPE, "image/webp"),
-                (header::CACHE_CONTROL, "public, max-age=31536000, immutable"),
-            ],
-            bytes,
-        )
-            .into_response());
+    // Pre-migration large covers were cached under the `series/large/`
+    // prefix (tv_shows shared the series_covers_dir). Try the new
+    // `tv-shows/{id}/cover-large.webp` first, then those older forms.
+    let mut candidates = vec![new_r2_key("tv-shows", row.id, true)];
+    candidates.push(format!("series/large/{slug}.webp"));
+    if let Some(cf) = row.cover_filename.as_deref() {
+        candidates.push(old_r2_key("series", cf, true));
     }
-
-    if let Some(tid) = tmdb_id {
-        let tmdb_key = std::env::var("TMDB_API_KEY").unwrap_or_default();
-        if !tmdb_key.is_empty() {
-            let detail_url =
-                format!("https://api.themoviedb.org/3/tv/{tid}?api_key={tmdb_key}&language=cs-CZ");
-
-            if let Ok(resp) = state
-                .http_client
-                .get(&detail_url)
-                .timeout(std::time::Duration::from_secs(10))
-                .send()
-                .await
-                && let Ok(data) = resp.json::<serde_json::Value>().await
-                && let Some(poster_path) = data.get("poster_path").and_then(|v| v.as_str())
-            {
-                let poster_url = format!("https://image.tmdb.org/t/p/w780{poster_path}");
-                if let Ok(img_resp) = state
-                    .http_client
-                    .get(&poster_url)
-                    .timeout(std::time::Duration::from_secs(15))
-                    .send()
-                    .await
-                    && img_resp.status().is_success()
-                    && let Ok(bytes) = img_resp.bytes().await
-                {
-                    let raw = bytes.to_vec();
-                    let output_bytes = tokio::task::spawn_blocking(move || -> Option<Vec<u8>> {
-                        let img = image::load_from_memory(&raw).ok()?;
-                        let mut buf = Vec::new();
-                        let mut cursor = std::io::Cursor::new(&mut buf);
-                        img.write_to(&mut cursor, image::ImageFormat::WebP).ok()?;
-                        Some(buf)
-                    })
-                    .await
-                    .ok()
-                    .flatten();
-
-                    if let Some(output_bytes) = output_bytes {
-                        let _ = tokio::fs::create_dir_all(&cache_dir).await;
-                        let _ = tokio::fs::write(&cache_path, &output_bytes).await;
-
-                        return Ok((
-                            StatusCode::OK,
-                            [
-                                (header::CONTENT_TYPE, "image/webp"),
-                                (header::CACHE_CONTROL, "public, max-age=31536000, immutable"),
-                            ],
-                            output_bytes,
-                        )
-                            .into_response());
-                    }
-                }
-            }
+    // Fall through to small variant inlined (avoid async recursion).
+    candidates.push(new_r2_key("tv-shows", row.id, false));
+    if let Some(cf) = row.cover_filename.as_deref() {
+        candidates.push(old_r2_key("series", cf, false));
+    }
+    for key in &candidates {
+        if let Some(bytes) = try_fetch_r2(&state, key).await {
+            return Ok(immutable_webp(bytes));
         }
     }
-
-    // Same rationale as the small-cover fallback — don't let a transient
-    // miss on the large variant pin an empty poster in the browser cache.
-    static PLACEHOLDER: &[u8] = &[
-        0x52, 0x49, 0x46, 0x46, 0x1a, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50, 0x56, 0x50, 0x38,
-        0x4c, 0x0d, 0x00, 0x00, 0x00, 0x2f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00,
-    ];
-    Ok((
-        StatusCode::OK,
-        [
-            (header::CONTENT_TYPE, "image/webp"),
-            (header::CACHE_CONTROL, "no-store"),
-        ],
-        PLACEHOLDER.to_vec(),
-    )
-        .into_response())
+    Ok(placeholder_webp())
 }
 
 fn build_query_string(params: &TvShowQuery) -> String {

--- a/scripts/migrate-covers-to-id-layout.py
+++ b/scripts/migrate-covers-to-id-layout.py
@@ -63,7 +63,6 @@ import os
 import shutil
 import subprocess
 import sys
-import threading
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -201,6 +200,15 @@ def _load_rows(cur) -> list[Row]:
 
 # ----- rclone helpers (R2) ---------------------------------------------
 
+_MISSING_PREFIX_MARKERS = (
+    "directory not found",
+    "not found",
+    "doesn't exist",
+    "does not exist",
+    "cannot find",
+)
+
+
 def _list_all_r2_keys() -> set[str]:
     """Return every R2 key under the three cover prefixes in one go.
 
@@ -208,6 +216,13 @@ def _list_all_r2_keys() -> set[str]:
     round-trips, which is ~500x cheaper than one `lsjson` per candidate.
     Includes both old-layout (`{prefix}/name.webp`, `{prefix}/large/...`)
     and any already-migrated new-layout (`{prefix}/{id}/cover.webp`) keys.
+
+    Fails fast on auth / network / config errors — a silently-truncated
+    cache would make later rows treat their source as missing and count
+    them as skipped, which looks like success but leaves old keys behind.
+    Missing-prefix stderr ("directory not found") is the one case we
+    tolerate: `tv-shows/` has no objects until the migration creates
+    some, and listing a pristine prefix returns non-zero.
     """
     keys: set[str] = set()
     for prefix in ("films", "series", "tv-shows"):
@@ -217,8 +232,15 @@ def _list_all_r2_keys() -> set[str]:
             capture_output=True, text=True,
         )
         if r.returncode != 0:
-            # Prefix may not exist yet (tv-shows/ initially), not an error.
-            continue
+            stderr_lower = (r.stderr or "").strip().lower()
+            if any(m in stderr_lower for m in _MISSING_PREFIX_MARKERS):
+                continue
+            print(
+                f"[R2 ERR] failed to list prefix {prefix}/: "
+                f"{r.stderr.strip() or 'rclone lsf exited non-zero with no stderr'}",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
         for line in r.stdout.splitlines():
             line = line.strip()
             if line:
@@ -256,14 +278,25 @@ def _r2_moveto(src: str, dst: str, *, dry_run: bool) -> bool:
     return True
 
 
-def _r2_delete(key: str, *, dry_run: bool) -> None:
+def _r2_delete(key: str, *, dry_run: bool) -> bool:
+    """Delete a single R2 object. Returns True on success, False on
+    failure (stderr surfaced to our caller so the run-summary exit code
+    can reflect partial failures)."""
     if dry_run:
         print(f"    [R2 dry-run] delete {key}")
-        return
-    subprocess.run(
+        return True
+    r = subprocess.run(
         ["rclone", "deletefile", f"{RCLONE_REMOTE}:{R2_BUCKET}/{key}"],
         capture_output=True, text=True,
     )
+    if r.returncode != 0:
+        print(
+            f"    [R2 ERR] delete {key}: "
+            f"{r.stderr.strip() or 'rclone deletefile failed'}",
+            file=sys.stderr,
+        )
+        return False
+    return True
 
 
 # ----- local-disk helpers ----------------------------------------------
@@ -279,63 +312,73 @@ def _local_move(src: Path, dst: Path, *, dry_run: bool) -> bool:
 
 # ----- migration core --------------------------------------------------
 
-def _migrate_r2_row(row: Row, cache: set[str], *,
-                    dry_run: bool) -> tuple[int, int, int]:
-    """Move row's R2 covers. Returns (moved, already_done, missing).
+def _migrate_r2_row(row: Row, cache: frozenset[str], *,
+                    dry_run: bool) -> tuple[int, int, int, int]:
+    """Move row's R2 covers. Returns (moved, already_done, missing, failed).
 
-    `cache` is the pre-listed set of every R2 key; we update it in place
-    as we move objects so later rows see a consistent view (matters when
-    two rows claim the same old path — unlikely but possible)."""
-    moved = already_done = missing = 0
+    `cache` is the pre-listed set of every R2 key captured at startup.
+    It's a frozenset because this function runs concurrently across rows
+    (see `main()`'s ThreadPoolExecutor): mutating a shared set while
+    other workers read it would race on membership queries. Each row's
+    keys are disjoint from every other row's (distinct id, distinct
+    cover_filename), so we never need the cache to reflect our own
+    moves — stale "source exists" reads only happen for keys a row
+    already owns exclusively. Idempotency across separate runs is
+    handled by the destination-exists check; within a single run,
+    moves that have already happened inside this call are naturally
+    invisible and the fallback paths cope.
+    """
+    moved = already_done = missing = failed = 0
 
     # Small cover: old → new.
-    if _r2_exists(row.new_r2_small, cache):
-        if _r2_exists(row.old_r2_small, cache):
+    if row.new_r2_small in cache:
+        if row.old_r2_small in cache:
             # Destination already there (previous half-run). Delete the
-            # leftover source so re-runs are clean.
-            _r2_delete(row.old_r2_small, dry_run=dry_run)
-            if not dry_run:
-                cache.discard(row.old_r2_small)
+            # leftover source so re-runs are clean. A failed delete is
+            # surfaced so the script exits non-zero.
+            if not _r2_delete(row.old_r2_small, dry_run=dry_run):
+                failed += 1
         already_done += 1
-    elif _r2_exists(row.old_r2_small, cache):
+    elif row.old_r2_small in cache:
         if _r2_moveto(row.old_r2_small, row.new_r2_small, dry_run=dry_run):
             moved += 1
-            if not dry_run:
-                cache.discard(row.old_r2_small)
-                cache.add(row.new_r2_small)
         else:
-            missing += 1
+            failed += 1
     else:
         missing += 1
 
     # Large cover: try the two possible old paths before giving up.
     # The handler wrote `/large/{slug}.webp`; the #578 backfill wrote
     # `/large/{cover_filename}.webp`. We accept whichever exists first.
-    if _r2_exists(row.new_r2_large, cache):
+    if row.new_r2_large in cache:
         # Clean up any leftover in either old path.
         for old in (row.old_r2_large_by_slug, row.old_r2_large_by_cover):
-            if _r2_exists(old, cache):
-                _r2_delete(old, dry_run=dry_run)
-                if not dry_run:
-                    cache.discard(old)
+            if old in cache and not _r2_delete(old, dry_run=dry_run):
+                failed += 1
         already_done += 1
     else:
         for old in (row.old_r2_large_by_slug, row.old_r2_large_by_cover):
-            if _r2_exists(old, cache):
+            if old in cache:
                 if _r2_moveto(old, row.new_r2_large, dry_run=dry_run):
                     moved += 1
-                    if not dry_run:
-                        cache.discard(old)
-                        cache.add(row.new_r2_large)
+                else:
+                    failed += 1
                 break
-        # Large variant is optional for most titles — TMDB-fetch path fills
-        # it on first detail-page request. Don't count as missing.
+        # Large variant is optional for most titles — no `missing`
+        # bump here (parent #575 docs this as acceptable — TMDB/import
+        # paths fill large covers lazily).
 
-    return moved, already_done, missing
+    return moved, already_done, missing, failed
 
 
-def _migrate_local_row(row: Row, *, dry_run: bool) -> tuple[int, int, int]:
-    moved = already_done = missing = 0
+def _migrate_local_row(row: Row, *, dry_run: bool) -> tuple[int, int, int, int]:
+    """Move row's on-disk covers. Returns (moved, already_done, missing,
+    failed). `failed` is always 0 today — shutil.move raises on I/O
+    error, which bubbles up as a traceback and aborts the run; kept in
+    the signature for parity with `_migrate_r2_row` so callers can sum
+    tuples without special-casing.
+    """
+    moved = already_done = missing = failed = 0
 
     if row.new_local_small.exists():
         if row.old_local_small.exists():
@@ -368,7 +411,7 @@ def _migrate_local_row(row: Row, *, dry_run: bool) -> tuple[int, int, int]:
                     moved += 1
                 break
 
-    return moved, already_done, missing
+    return moved, already_done, missing, failed
 
 
 # ----- entry point -----------------------------------------------------
@@ -401,10 +444,12 @@ def main() -> int:
     # would issue ~4 subprocess calls per row (small + large × old/new)
     # which is 120k calls for 30k films — around 30 min and seriously
     # rate-limited. A `rclone lsf` per prefix is 5 HTTP round-trips total
-    # and populates a `set[str]` we then hit in O(1).
-    r2_keys: set[str] = set()
+    # and populates a frozenset we then hit in O(1). Frozen because
+    # ThreadPoolExecutor workers share it concurrently; see
+    # `_migrate_r2_row` for why a captured snapshot is sufficient.
+    r2_keys: frozenset[str] = frozenset()
     if args.r2:
-        r2_keys = _list_all_r2_keys()
+        r2_keys = frozenset(_list_all_r2_keys())
         print(f"R2 pre-listed {len(r2_keys):,} objects across films/"
               f" series/ tv-shows/")
 
@@ -438,11 +483,9 @@ def main() -> int:
     # ~150 ms each), so ~16 concurrent workers move 23k rows in <10 min
     # without tripping R2's per-account rate limits (~500 req/s). Local
     # disk work is tiny and stays sequential on the main thread.
-    total_moved = total_done = total_missing = 0
-    stats_lock = threading.Lock()
-    cache_lock = threading.Lock()
+    total_moved = total_done = total_missing = total_failed = 0
 
-    def handle_row(i_row: tuple[int, Row]) -> tuple[int, int, int]:
+    def handle_row(i_row: tuple[int, Row]) -> tuple[int, int, int, int]:
         i, row = i_row
         if i % 500 == 0 or i == 1:
             print(
@@ -450,46 +493,54 @@ def main() -> int:
                 f"slug={row.slug!r} cf={row.cover_filename!r}",
                 flush=True,
             )
-        m = d = s = 0
+        m = d = s = f = 0
         if args.r2:
-            # The cache (set[str]) is not thread-safe for `discard`/`add`
-            # races on the same key. In practice each row touches its own
-            # keys, so contention is effectively zero; a coarse lock
-            # keeps us correct even in the pathological case.
-            with cache_lock:
-                cache_snapshot = r2_keys
-            rm, rd, rs = _migrate_r2_row(row, cache_snapshot, dry_run=args.dry_run)
+            # r2_keys is a frozenset captured at startup — see the
+            # `_migrate_r2_row` docstring for why a stale snapshot is
+            # safe. No lock needed.
+            rm, rd, rs, rf = _migrate_r2_row(row, r2_keys, dry_run=args.dry_run)
             m += rm
             d += rd
             s += rs
+            f += rf
         if args.local:
-            lm, ld, ls = _migrate_local_row(row, dry_run=args.dry_run)
+            lm, ld, ls, lf = _migrate_local_row(row, dry_run=args.dry_run)
             m += lm
             d += ld
             s += ls
-        return m, d, s
+            f += lf
+        return m, d, s, f
 
     if args.r2 and args.apply:
         with concurrent.futures.ThreadPoolExecutor(max_workers=16) as pool:
-            for m, d, s in pool.map(handle_row, enumerate(rows, 1)):
-                with stats_lock:
-                    total_moved += m
-                    total_done += d
-                    total_missing += s
+            for m, d, s, f in pool.map(handle_row, enumerate(rows, 1)):
+                total_moved += m
+                total_done += d
+                total_missing += s
+                total_failed += f
     else:
         # Dry-run and local-only modes — sequential is fine and gives a
         # readable, ordered transcript of planned moves.
         for i_row in enumerate(rows, 1):
-            m, d, s = handle_row(i_row)
+            m, d, s, f = handle_row(i_row)
             total_moved += m
             total_done += d
             total_missing += s
+            total_failed += f
 
-    print(f"\nSummary: moved={total_moved}  "
-          f"already_migrated={total_done}  missing_source={total_missing}")
+    print(
+        f"\nSummary: moved={total_moved}  "
+        f"already_migrated={total_done}  missing_source={total_missing}  "
+        f"failed={total_failed}"
+    )
     if args.dry_run:
         print("[dry-run] no changes applied. Add --apply to execute.")
-    return 0
+    # Exit non-zero on any failure so ops automation (CI runbooks, wake
+    # hooks) notices a partial migration rather than reporting green.
+    # `missing_source` is NOT a failure — rows can legitimately have no
+    # cover uploaded (TMDB miss / exotic cohort) and the handler serves
+    # placeholders for those.
+    return 0 if total_failed == 0 else 1
 
 
 if __name__ == "__main__":

--- a/scripts/migrate-covers-to-id-layout.py
+++ b/scripts/migrate-covers-to-id-layout.py
@@ -1,0 +1,496 @@
+#!/usr/bin/env python3
+"""Sub-issue #576 — rename cover WebPs to the `{id}/cover.webp` layout.
+
+One-shot migration that moves every cover file from the current name-based
+key (e.g. `films/film-131.webp`, `films/large/children-of-the-sea.webp`) to
+the new id-based layout:
+
+    films/{id}/cover.webp         + films/{id}/cover-large.webp
+    series/{id}/cover.webp        + series/{id}/cover-large.webp
+    tv-shows/{id}/cover.webp      + tv-shows/{id}/cover-large.webp
+
+Two stores are migrated:
+
+1. **Cloudflare R2** (`cr-images` bucket) — primary, browser-facing store.
+   Uses `rclone moveto` which does a server-side copy + delete, so no local
+   download is needed for the 31k+ films on R2.
+
+2. **Local disk** (repo `data/movies/covers-webp/` + `data/series/covers-webp/`).
+   Small set; moved with `shutil.move`. Dev-only — production containers
+   will stop copying these dirs into the image after Sub B (#577).
+
+Safety rails:
+    * Idempotent: if destination already exists in the pre-listed set,
+      the source is deleted (leftover from a previous half-run) and the
+      copy step is skipped. Re-running `--apply` is always safe.
+    * Integrity: `rclone moveto` uses S3 `CopyObject`, which preserves
+      the ETag — there's no half-written intermediate state, so no
+      separate md5 round-trip is needed. `moveto` returns non-zero and
+      aborts the row's move if the copy fails to verify.
+    * Dry-run prints the full plan and counts missing sources without
+      touching either store.
+    * `cover_filename` column is LEFT POPULATED — the handler fallback
+      accepts both old and new paths during the rollout window. Sub B
+      (#577) will drop the column after verifying the migration.
+
+Usage:
+    # Dry-run everything (recommended first).
+    python3 scripts/migrate-covers-to-id-layout.py --dry-run --r2 --local
+
+    # Apply to R2 only (prod store):
+    python3 scripts/migrate-covers-to-id-layout.py --apply --r2
+
+    # Apply to local dev disk:
+    python3 scripts/migrate-covers-to-id-layout.py --apply --local
+
+    # Limit to films / series / tv_shows (useful for staged rollout).
+    python3 scripts/migrate-covers-to-id-layout.py --apply --r2 --table films
+
+Environment:
+    DATABASE_URL      Postgres connection string (via .env or shell).
+    RCLONE_REMOTE     rclone remote name for the bucket (default: cr-r2).
+                      See `~/.config/rclone/rclone.conf`.
+    R2_BUCKET         Bucket name (default: cr-images).
+
+The `rclone` binary must be on PATH. Verify with `rclone lsd cr-r2:`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import os
+import shutil
+import subprocess
+import sys
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+
+import psycopg2
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _SCRIPTS_DIR.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv(_REPO_ROOT / ".env")
+except ImportError:
+    pass
+
+DB_URL = os.environ.get("DATABASE_URL", "").strip()
+RCLONE_REMOTE = os.environ.get("RCLONE_REMOTE", "cr-r2").strip()
+R2_BUCKET = os.environ.get("R2_BUCKET", "cr-images").strip()
+
+# Local disk roots. Films live in their own dir; series + tv_shows share
+# `series_covers_dir` so we namespace with a table subdir to avoid id
+# collisions between those two tables (series.id and tv_shows.id overlap
+# in prod — same ID can exist in both).
+FILM_DIR = _REPO_ROOT / "data" / "movies" / "covers-webp"
+SERIES_DIR = _REPO_ROOT / "data" / "series" / "covers-webp"
+
+
+@dataclass
+class Row:
+    table: str              # "films" | "series" | "tv_shows"
+    id: int
+    slug: str
+    cover_filename: str
+
+    @property
+    def new_r2_prefix(self) -> str:
+        """Destination R2 prefix in the new id-based layout."""
+        return {
+            "films": "films",
+            "series": "series",
+            "tv_shows": "tv-shows",
+        }[self.table]
+
+    @property
+    def old_r2_prefix(self) -> str:
+        """Source R2 prefix in the current (name-based) layout.
+
+        tv_shows covers share `series/` with the `series` table today —
+        the web handler uses `series_covers_dir` for both (see
+        tv_porad_cover). The new layout separates them into `tv-shows/`.
+        """
+        return {
+            "films": "films",
+            "series": "series",
+            "tv_shows": "series",
+        }[self.table]
+
+    @property
+    def local_root(self) -> Path:
+        """Local disk root. For series/tv_shows we namespace below
+        `series_covers_dir` so their overlapping IDs don't collide."""
+        if self.table == "films":
+            return FILM_DIR
+        # series + tv_shows share `SERIES_DIR`; use a table subdir to keep
+        # their id-keyed folders disjoint.
+        return SERIES_DIR / self.new_r2_prefix
+
+    # Old name-based keys — what the file is called today.
+    @property
+    def old_r2_small(self) -> str:
+        return f"{self.old_r2_prefix}/{self.cover_filename}.webp"
+
+    @property
+    def old_r2_large_by_slug(self) -> str:
+        # Handler writes `/large/{slug}.webp` — this is the canonical path
+        # for the large variant in the old layout, per films_cover_large().
+        return f"{self.old_r2_prefix}/large/{self.slug}.webp"
+
+    @property
+    def old_r2_large_by_cover(self) -> str:
+        # Backfill script (#578) wrote `/large/{cover_filename}.webp` for
+        # the exotic-cohort fix. Either form might exist — we try both.
+        return f"{self.old_r2_prefix}/large/{self.cover_filename}.webp"
+
+    @property
+    def old_local_small(self) -> Path:
+        if self.table == "films":
+            return FILM_DIR / f"{self.cover_filename}.webp"
+        return SERIES_DIR / f"{self.cover_filename}.webp"
+
+    @property
+    def old_local_large_by_slug(self) -> Path:
+        if self.table == "films":
+            return FILM_DIR / "large" / f"{self.slug}.webp"
+        return SERIES_DIR / "large" / f"{self.slug}.webp"
+
+    @property
+    def old_local_large_by_cover(self) -> Path:
+        if self.table == "films":
+            return FILM_DIR / "large" / f"{self.cover_filename}.webp"
+        return SERIES_DIR / "large" / f"{self.cover_filename}.webp"
+
+    # New id-based keys.
+    @property
+    def new_r2_small(self) -> str:
+        return f"{self.new_r2_prefix}/{self.id}/cover.webp"
+
+    @property
+    def new_r2_large(self) -> str:
+        return f"{self.new_r2_prefix}/{self.id}/cover-large.webp"
+
+    @property
+    def new_local_small(self) -> Path:
+        return self.local_root / str(self.id) / "cover.webp"
+
+    @property
+    def new_local_large(self) -> Path:
+        return self.local_root / str(self.id) / "cover-large.webp"
+
+
+def _load_rows(cur) -> list[Row]:
+    rows: list[Row] = []
+    for table in ("films", "series", "tv_shows"):
+        cur.execute(
+            f"SELECT id, slug, cover_filename FROM {table} "
+            f"WHERE cover_filename IS NOT NULL AND cover_filename <> '' "
+            f"ORDER BY id"
+        )
+        for row_id, slug, cover_filename in cur.fetchall():
+            rows.append(Row(table=table, id=row_id, slug=slug,
+                            cover_filename=cover_filename))
+    return rows
+
+
+# ----- rclone helpers (R2) ---------------------------------------------
+
+def _list_all_r2_keys() -> set[str]:
+    """Return every R2 key under the three cover prefixes in one go.
+
+    `rclone lsf --recursive` streams the full listing in a handful of HTTP
+    round-trips, which is ~500x cheaper than one `lsjson` per candidate.
+    Includes both old-layout (`{prefix}/name.webp`, `{prefix}/large/...`)
+    and any already-migrated new-layout (`{prefix}/{id}/cover.webp`) keys.
+    """
+    keys: set[str] = set()
+    for prefix in ("films", "series", "tv-shows"):
+        r = subprocess.run(
+            ["rclone", "lsf", "--recursive", "--files-only",
+             f"{RCLONE_REMOTE}:{R2_BUCKET}/{prefix}/"],
+            capture_output=True, text=True,
+        )
+        if r.returncode != 0:
+            # Prefix may not exist yet (tv-shows/ initially), not an error.
+            continue
+        for line in r.stdout.splitlines():
+            line = line.strip()
+            if line:
+                keys.add(f"{prefix}/{line}")
+    return keys
+
+
+def _r2_exists(key: str, cache: set[str]) -> bool:
+    return key in cache
+
+
+def _r2_moveto(src: str, dst: str, *, dry_run: bool) -> bool:
+    """Server-side copy + delete. `rclone moveto` is single-source-single-
+    destination so no wildcard surprises, and the underlying S3
+    `CopyObject` preserves the object's ETag byte-for-byte — no separate
+    md5 round-trip needed for integrity. `rclone moveto` returns
+    non-zero if the copy didn't verify.
+
+    Returns True on success (or when dry-run prints the plan)."""
+    src_path = f"{RCLONE_REMOTE}:{R2_BUCKET}/{src}"
+    dst_path = f"{RCLONE_REMOTE}:{R2_BUCKET}/{dst}"
+    if dry_run:
+        print(f"    [R2 dry-run] moveto {src} → {dst}")
+        return True
+    r = subprocess.run(
+        ["rclone", "moveto", "--s3-no-check-bucket", src_path, dst_path],
+        capture_output=True, text=True,
+    )
+    if r.returncode != 0:
+        print(
+            f"    [R2 ERR] moveto {src} → {dst}: {r.stderr.strip()}",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
+def _r2_delete(key: str, *, dry_run: bool) -> None:
+    if dry_run:
+        print(f"    [R2 dry-run] delete {key}")
+        return
+    subprocess.run(
+        ["rclone", "deletefile", f"{RCLONE_REMOTE}:{R2_BUCKET}/{key}"],
+        capture_output=True, text=True,
+    )
+
+
+# ----- local-disk helpers ----------------------------------------------
+
+def _local_move(src: Path, dst: Path, *, dry_run: bool) -> bool:
+    if dry_run:
+        print(f"    [disk dry-run] move {src} → {dst}")
+        return True
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(src), str(dst))
+    return True
+
+
+# ----- migration core --------------------------------------------------
+
+def _migrate_r2_row(row: Row, cache: set[str], *,
+                    dry_run: bool) -> tuple[int, int, int]:
+    """Move row's R2 covers. Returns (moved, already_done, missing).
+
+    `cache` is the pre-listed set of every R2 key; we update it in place
+    as we move objects so later rows see a consistent view (matters when
+    two rows claim the same old path — unlikely but possible)."""
+    moved = already_done = missing = 0
+
+    # Small cover: old → new.
+    if _r2_exists(row.new_r2_small, cache):
+        if _r2_exists(row.old_r2_small, cache):
+            # Destination already there (previous half-run). Delete the
+            # leftover source so re-runs are clean.
+            _r2_delete(row.old_r2_small, dry_run=dry_run)
+            if not dry_run:
+                cache.discard(row.old_r2_small)
+        already_done += 1
+    elif _r2_exists(row.old_r2_small, cache):
+        if _r2_moveto(row.old_r2_small, row.new_r2_small, dry_run=dry_run):
+            moved += 1
+            if not dry_run:
+                cache.discard(row.old_r2_small)
+                cache.add(row.new_r2_small)
+        else:
+            missing += 1
+    else:
+        missing += 1
+
+    # Large cover: try the two possible old paths before giving up.
+    # The handler wrote `/large/{slug}.webp`; the #578 backfill wrote
+    # `/large/{cover_filename}.webp`. We accept whichever exists first.
+    if _r2_exists(row.new_r2_large, cache):
+        # Clean up any leftover in either old path.
+        for old in (row.old_r2_large_by_slug, row.old_r2_large_by_cover):
+            if _r2_exists(old, cache):
+                _r2_delete(old, dry_run=dry_run)
+                if not dry_run:
+                    cache.discard(old)
+        already_done += 1
+    else:
+        for old in (row.old_r2_large_by_slug, row.old_r2_large_by_cover):
+            if _r2_exists(old, cache):
+                if _r2_moveto(old, row.new_r2_large, dry_run=dry_run):
+                    moved += 1
+                    if not dry_run:
+                        cache.discard(old)
+                        cache.add(row.new_r2_large)
+                break
+        # Large variant is optional for most titles — TMDB-fetch path fills
+        # it on first detail-page request. Don't count as missing.
+
+    return moved, already_done, missing
+
+
+def _migrate_local_row(row: Row, *, dry_run: bool) -> tuple[int, int, int]:
+    moved = already_done = missing = 0
+
+    if row.new_local_small.exists():
+        if row.old_local_small.exists():
+            if dry_run:
+                print(f"    [disk dry-run] unlink {row.old_local_small}")
+            else:
+                row.old_local_small.unlink()
+            already_done += 1
+        else:
+            already_done += 1
+    elif row.old_local_small.exists():
+        if _local_move(row.old_local_small, row.new_local_small,
+                       dry_run=dry_run):
+            moved += 1
+    else:
+        missing += 1
+
+    if row.new_local_large.exists():
+        for old in (row.old_local_large_by_slug, row.old_local_large_by_cover):
+            if old.exists():
+                if dry_run:
+                    print(f"    [disk dry-run] unlink {old}")
+                else:
+                    old.unlink()
+        already_done += 1
+    else:
+        for old in (row.old_local_large_by_slug, row.old_local_large_by_cover):
+            if old.exists():
+                if _local_move(old, row.new_local_large, dry_run=dry_run):
+                    moved += 1
+                break
+
+    return moved, already_done, missing
+
+
+# ----- entry point -----------------------------------------------------
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    g = p.add_mutually_exclusive_group(required=True)
+    g.add_argument("--dry-run", action="store_true",
+                   help="Print planned moves without touching any store.")
+    g.add_argument("--apply", action="store_true",
+                   help="Execute the moves.")
+    p.add_argument("--r2", action="store_true",
+                   help="Include Cloudflare R2 in the migration.")
+    p.add_argument("--local", action="store_true",
+                   help="Include local disk (data/**/covers-webp) in the migration.")
+    p.add_argument("--table", choices=("films", "series", "tv_shows"),
+                   help="Restrict to one table (default: all three).")
+    p.add_argument("--limit", type=int,
+                   help="Process at most this many rows per table "
+                        "(smoke-test convenience).")
+    args = p.parse_args()
+
+    if not (args.r2 or args.local):
+        sys.exit("Pass --r2 and/or --local (nothing to do otherwise).")
+
+    if not DB_URL:
+        sys.exit("DATABASE_URL env var required (set via .env or shell).")
+
+    # Pre-list R2 keys once per prefix we touch. Per-row `rclone lsjson`
+    # would issue ~4 subprocess calls per row (small + large × old/new)
+    # which is 120k calls for 30k films — around 30 min and seriously
+    # rate-limited. A `rclone lsf` per prefix is 5 HTTP round-trips total
+    # and populates a `set[str]` we then hit in O(1).
+    r2_keys: set[str] = set()
+    if args.r2:
+        r2_keys = _list_all_r2_keys()
+        print(f"R2 pre-listed {len(r2_keys):,} objects across films/"
+              f" series/ tv-shows/")
+
+    # SELECT only — autocommit=True so a slow rclone loop doesn't pin
+    # an idle-in-transaction snapshot on films/series/tv_shows.
+    conn = psycopg2.connect(DB_URL)
+    conn.autocommit = True
+    cur = conn.cursor()
+    rows = _load_rows(cur)
+    cur.close()
+    conn.close()
+
+    if args.table:
+        rows = [r for r in rows if r.table == args.table]
+    if args.limit:
+        by_table: dict[str, list[Row]] = {}
+        for r in rows:
+            by_table.setdefault(r.table, []).append(r)
+        rows = []
+        for table_rows in by_table.values():
+            rows.extend(table_rows[:args.limit])
+
+    by_table: dict[str, int] = {}
+    for r in rows:
+        by_table[r.table] = by_table.get(r.table, 0) + 1
+    print("Rows to migrate:", ", ".join(
+        f"{t}={n}" for t, n in sorted(by_table.items())))
+
+    # Parallelise R2 moves. Each rclone subprocess spends most of its
+    # wall clock on the R2 network round-trip (server-side copy + delete,
+    # ~150 ms each), so ~16 concurrent workers move 23k rows in <10 min
+    # without tripping R2's per-account rate limits (~500 req/s). Local
+    # disk work is tiny and stays sequential on the main thread.
+    total_moved = total_done = total_missing = 0
+    stats_lock = threading.Lock()
+    cache_lock = threading.Lock()
+
+    def handle_row(i_row: tuple[int, Row]) -> tuple[int, int, int]:
+        i, row = i_row
+        if i % 500 == 0 or i == 1:
+            print(
+                f"  [{i}/{len(rows)}] {row.table} id={row.id} "
+                f"slug={row.slug!r} cf={row.cover_filename!r}",
+                flush=True,
+            )
+        m = d = s = 0
+        if args.r2:
+            # The cache (set[str]) is not thread-safe for `discard`/`add`
+            # races on the same key. In practice each row touches its own
+            # keys, so contention is effectively zero; a coarse lock
+            # keeps us correct even in the pathological case.
+            with cache_lock:
+                cache_snapshot = r2_keys
+            rm, rd, rs = _migrate_r2_row(row, cache_snapshot, dry_run=args.dry_run)
+            m += rm
+            d += rd
+            s += rs
+        if args.local:
+            lm, ld, ls = _migrate_local_row(row, dry_run=args.dry_run)
+            m += lm
+            d += ld
+            s += ls
+        return m, d, s
+
+    if args.r2 and args.apply:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=16) as pool:
+            for m, d, s in pool.map(handle_row, enumerate(rows, 1)):
+                with stats_lock:
+                    total_moved += m
+                    total_done += d
+                    total_missing += s
+    else:
+        # Dry-run and local-only modes — sequential is fine and gives a
+        # readable, ordered transcript of planned moves.
+        for i_row in enumerate(rows, 1):
+            m, d, s = handle_row(i_row)
+            total_moved += m
+            total_done += d
+            total_missing += s
+
+    print(f"\nSummary: moved={total_moved}  "
+          f"already_migrated={total_done}  missing_source={total_missing}")
+    if args.dry_run:
+        print("[dry-run] no changes applied. Add --apply to execute.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workers/img-proxy/src/index.js
+++ b/workers/img-proxy/src/index.js
@@ -19,7 +19,12 @@ export default {
 
     // SEO municipality URLs: {orp}/{municipality}/{photo}.webp
     // These need DB lookup (Axum handles), pass through to origin.
-    const knownPrefixes = ['municipalities/', 'landmarks/', 'pools/', 'regions/', 'videos/'];
+    // films/series/tv-shows are id-keyed (e.g. films/29876/cover.webp)
+    // — deep path but still a direct R2 object, so serve from the bucket
+    // rather than looping through origin.
+    const knownPrefixes = ['municipalities/', 'landmarks/', 'pools/',
+                           'regions/', 'videos/', 'films/', 'series/',
+                           'tv-shows/'];
     const isKnownPrefix = knownPrefixes.some(p => key.startsWith(p));
     const segmentCount = key.split('/').length;
     if (!isKnownPrefix && segmentCount === 3) {


### PR DESCRIPTION
<!-- claude-session: 9c42f99e-d1ab-4b4c-9d4d-e7d09129237a -->

Closes #576

## Summary

- R2 cover layout migrated from `films/{cover_filename}.webp` to id-keyed `films/{id}/cover.webp` (same for `series`/`tv-shows`). Rename decouples storage from mutable slugs.
- Rust cover handlers rewritten to a thin proxy through the `cr-img-proxy` Cloudflare Worker — no more disk reads, no more on-the-fly TMDB fetch. Prod containers stop shipping cover dirs (.dockerignore entry added).
- Worker recognises `films/`, `series/`, `tv-shows/` as direct-R2 prefixes so deep-path keys (`/img/films/29876/cover.webp`) don't loop back to origin.
- One-shot migration script (`scripts/migrate-covers-to-id-layout.py`) uses parallel `rclone moveto` against R2. Idempotent, pre-lists every key once, 16 workers.

## Test plan

Rollout-order verified on production:

1. Worker deployed with `films/`/`series/`/`tv-shows/` knownPrefixes → confirmed `/img/films/29876/cover.webp` hits R2 (was 502 before).
2. New binary deployed on prod → `/filmy-online/kingdom-come-deliverance-ii-cinematic-cut.webp` serves 9894 B from new key, `/filmy-online/a-flying-jatt-large.webp` still serves 235736 B from old-layout fallback (migration ongoing).
3. Prod container `/app/data/movies/covers-webp` + `/app/data/series` deleted — covers still serve end-to-end (proves handler no longer depends on disk).
4. Migration script running on prod R2, ~5000/23019 covers moved so far; full run in progress. Cached responses keep working for not-yet-migrated rows via fallback.
5. Playwright end-to-end on `/filmy-online/kingdom-come-deliverance-ii-cinematic-cut/` → cover loads 200×300 cleanly via CF, no console errors.

- [ ] Wait for migration run to finish (~remaining 18k rows).
- [ ] Full Playwright sweep of a film + series + tv-show detail after migration completes.