### PR TITLE
fix(ui): relabel rating badge from IMDB to TMDB

### DIFF
--- a/cr-web/templates/episode_detail.html
+++ b/cr-web/templates/episode_detail.html
@@ -648,7 +648,7 @@ function doSearch() {
                                 : '<div class="si-placeholder"></div>';
                             var yr = r.year ? ' (' + r.year + ')' : '';
                             var rat = r.imdb_rating ? ' — TMDB ' + r.imdb_rating : '';
-                            return '<a href="/serialy-online/' + r.slug + '/" class="search-item" alt="' + r.title + '" title="' + r.title + '">'
+                            return '<a href="/serialy-online/' + r.slug + '/" class="search-item" title="' + r.title + '" aria-label="' + r.title + '">'
                                 + cover + '<div class="si-info"><span class="si-title">' + r.title + yr + '</span>'
                                 + '<span class="si-meta">' + rat + '</span></div></a>';
                         }).join('');

--- a/cr-web/templates/episode_detail.html
+++ b/cr-web/templates/episode_detail.html
@@ -647,7 +647,7 @@ function doSearch() {
                                 ? '<img src="/serialy-online/' + r.slug + '.webp" alt="' + r.title + '" title="' + r.title + '">'
                                 : '<div class="si-placeholder"></div>';
                             var yr = r.year ? ' (' + r.year + ')' : '';
-                            var rat = r.imdb_rating ? ' — IMDB ' + r.imdb_rating : '';
+                            var rat = r.imdb_rating ? ' — TMDB ' + r.imdb_rating : '';
                             return '<a href="/serialy-online/' + r.slug + '/" class="search-item" alt="' + r.title + '" title="' + r.title + '">'
                                 + cover + '<div class="si-info"><span class="si-title">' + r.title + yr + '</span>'
                                 + '<span class="si-meta">' + rat + '</span></div></a>';

--- a/cr-web/templates/film_detail.html
+++ b/cr-web/templates/film_detail.html
@@ -159,7 +159,7 @@
             <div class="meta-row">
                 {% match film.imdb_rating %}
                 {% when Some with (r) %}
-                <span class="meta-badge imdb">IMDB {{ r }}</span>
+                <span class="meta-badge imdb" title="TMDB hodnocení">TMDB {{ r }}</span>
                 {% when None %}
                 {% endmatch %}
 
@@ -943,7 +943,7 @@ function doSearch() {
                                 ? '<img src="/filmy-online/' + r.slug + '.webp" alt="">'
                                 : '<div class="si-placeholder"></div>';
                             var yr = r.year ? ' (' + r.year + ')' : '';
-                            var rat = r.imdb_rating ? ' — IMDB ' + r.imdb_rating : '';
+                            var rat = r.imdb_rating ? ' — TMDB ' + r.imdb_rating : '';
                             return '<a href="/filmy-online/' + r.slug + '/" class="search-item">'
                                 + cover + '<div class="si-info"><span class="si-title">' + r.title + yr + '</span>'
                                 + '<span class="si-meta">' + rat + '</span></div></a>';

--- a/cr-web/templates/films_list.html
+++ b/cr-web/templates/films_list.html
@@ -88,7 +88,7 @@
                         <option value="rok:desc">Od nejnovějších</option>
                         <option value="rok:asc">Od nejstarších</option>
                     </optgroup>
-                    <optgroup label="Podle hodnocení IMDB">
+                    <optgroup label="Podle hodnocení TMDB">
                         <option value="imdb:desc">Nejlépe hodnocené první</option>
                         <option value="imdb:asc">Nejhůře hodnocené první</option>
                     </optgroup>
@@ -192,7 +192,7 @@
                 <div class="rating-badges">
                     {% match f.imdb_rating %}
                     {% when Some with (r) %}
-                    <span class="rating-badge imdb" title="IMDB hodnocení">{{ r }}</span>
+                    <span class="rating-badge imdb" title="TMDB hodnocení">{{ r }}</span>
                     {% when None %}
                     {% endmatch %}
                     {% match f.csfd_rating %}
@@ -215,7 +215,7 @@
                 </div>
                 <div class="film-list-extra">
                     <div class="film-ratings">
-                        {% match f.imdb_rating %}{% when Some with (r) %}<span class="badge imdb">IMDB {{ r }}</span>{% when None %}{% endmatch %}
+                        {% match f.imdb_rating %}{% when Some with (r) %}<span class="badge imdb">TMDB {{ r }}</span>{% when None %}{% endmatch %}
                         {% match f.csfd_rating %}{% when Some with (r) %}<span class="badge csfd">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
                         {% match f.runtime_min %}{% when Some with (m) %}<span class="badge runtime">{{ m }} min</span>{% when None %}{% endmatch %}
                         {% for fg in self.film_genres(f.id) %}<span class="genre-tag">{{ fg.name_cs }}</span>{% endfor %}
@@ -756,7 +756,7 @@ function doSearch() {
                                 ? '<img src="/filmy-online/' + r.slug + '.webp" alt="">'
                                 : '<div class="si-placeholder"></div>';
                             var yr = r.year ? ' (' + r.year + ')' : '';
-                            var rat = r.imdb_rating ? ' — IMDB ' + r.imdb_rating : '';
+                            var rat = r.imdb_rating ? ' — TMDB ' + r.imdb_rating : '';
                             return '<a href="/filmy-online/' + r.slug + '/" class="search-item">'
                                 + cover + '<div class="si-info"><span class="si-title">' + r.title + yr + '</span>'
                                 + '<span class="si-meta">' + rat + '</span></div></a>';

--- a/cr-web/templates/series_detail.html
+++ b/cr-web/templates/series_detail.html
@@ -62,7 +62,7 @@
             {% when None %}{% endmatch %}
             <div class="meta-row">
                 {% match series.imdb_rating %}
-                {% when Some with (r) %}<span class="meta-badge imdb" title="IMDB hodnocení">IMDB {{ r }}</span>
+                {% when Some with (r) %}<span class="meta-badge imdb" title="TMDB hodnocení">TMDB {{ r }}</span>
                 {% when None %}{% endmatch %}
                 {% match series.csfd_rating %}
                 {% when Some with (r) %}<span class="meta-badge csfd" title="ČSFD hodnocení">ČSFD {{ r }}%</span>
@@ -306,7 +306,7 @@ function doSearch() {
                                 ? '<img src="/serialy-online/' + r.slug + '.webp" alt="' + r.title + '" title="' + r.title + '">'
                                 : '<div class="si-placeholder"></div>';
                             var yr = r.year ? ' (' + r.year + ')' : '';
-                            var rat = r.imdb_rating ? ' — IMDB ' + r.imdb_rating : '';
+                            var rat = r.imdb_rating ? ' — TMDB ' + r.imdb_rating : '';
                             return '<a href="/serialy-online/' + r.slug + '/" class="search-item" alt="' + r.title + '" title="' + r.title + '">'
                                 + cover + '<div class="si-info"><span class="si-title">' + r.title + yr + '</span>'
                                 + '<span class="si-meta">' + rat + '</span></div></a>';

--- a/cr-web/templates/series_detail.html
+++ b/cr-web/templates/series_detail.html
@@ -307,7 +307,7 @@ function doSearch() {
                                 : '<div class="si-placeholder"></div>';
                             var yr = r.year ? ' (' + r.year + ')' : '';
                             var rat = r.imdb_rating ? ' — TMDB ' + r.imdb_rating : '';
-                            return '<a href="/serialy-online/' + r.slug + '/" class="search-item" alt="' + r.title + '" title="' + r.title + '">'
+                            return '<a href="/serialy-online/' + r.slug + '/" class="search-item" title="' + r.title + '" aria-label="' + r.title + '">'
                                 + cover + '<div class="si-info"><span class="si-title">' + r.title + yr + '</span>'
                                 + '<span class="si-meta">' + rat + '</span></div></a>';
                         }).join('');

--- a/cr-web/templates/series_list.html
+++ b/cr-web/templates/series_list.html
@@ -86,7 +86,7 @@
                         <option value="rok:desc">Od nejnovějších</option>
                         <option value="rok:asc">Od nejstarších</option>
                     </optgroup>
-                    <optgroup label="Podle hodnocení IMDB">
+                    <optgroup label="Podle hodnocení TMDB">
                         <option value="imdb:desc">Nejlépe hodnocené první</option>
                         <option value="imdb:asc">Nejhůře hodnocené první</option>
                     </optgroup>
@@ -178,7 +178,7 @@
                 {% endmatch %}
                 <div class="rating-badges">
                     {% match ep.series_imdb_rating %}
-                    {% when Some with (r) %}<span class="rating-badge imdb" title="IMDB hodnocení">{{ r }}</span>{% when None %}{% endmatch %}
+                    {% when Some with (r) %}<span class="rating-badge imdb" title="TMDB hodnocení">{{ r }}</span>{% when None %}{% endmatch %}
                     {% match ep.series_csfd_rating %}
                     {% when Some with (r) %}<span class="rating-badge csfd" title="ČSFD hodnocení">{{ r }}%</span>{% when None %}{% endmatch %}
                 </div>
@@ -194,7 +194,7 @@
                 </div>
                 <div class="film-list-extra">
                     <div class="film-ratings">
-                        {% match ep.series_imdb_rating %}{% when Some with (r) %}<span class="badge imdb">IMDB {{ r }}</span>{% when None %}{% endmatch %}
+                        {% match ep.series_imdb_rating %}{% when Some with (r) %}<span class="badge imdb">TMDB {{ r }}</span>{% when None %}{% endmatch %}
                         {% match ep.series_csfd_rating %}{% when Some with (r) %}<span class="badge csfd">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
                         {% match ep.series_first_air_year %}{% when Some with (y) %}<span class="badge year">{{ y }}</span>{% when None %}{% endmatch %}
                         {% for sg in self.series_genres(ep.series_id) %}<span class="genre-tag">{{ sg.name_cs }}</span>{% endfor %}
@@ -217,7 +217,7 @@
                 <div class="no-poster">{{ s.title }}</div>
                 {% endmatch %}
                 <div class="rating-badges">
-                    {% match s.imdb_rating %}{% when Some with (r) %}<span class="rating-badge imdb" title="IMDB hodnocení">{{ r }}</span>{% when None %}{% endmatch %}
+                    {% match s.imdb_rating %}{% when Some with (r) %}<span class="rating-badge imdb" title="TMDB hodnocení">{{ r }}</span>{% when None %}{% endmatch %}
                     {% match s.csfd_rating %}{% when Some with (r) %}<span class="rating-badge csfd" title="ČSFD hodnocení">{{ r }}%</span>{% when None %}{% endmatch %}
                 </div>
             </div>
@@ -229,7 +229,7 @@
                 </div>
                 <div class="film-list-extra">
                     <div class="film-ratings">
-                        {% match s.imdb_rating %}{% when Some with (r) %}<span class="badge imdb">IMDB {{ r }}</span>{% when None %}{% endmatch %}
+                        {% match s.imdb_rating %}{% when Some with (r) %}<span class="badge imdb">TMDB {{ r }}</span>{% when None %}{% endmatch %}
                         {% match s.csfd_rating %}{% when Some with (r) %}<span class="badge csfd">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
                         {% match s.first_air_year %}{% when Some with (y) %}<span class="badge year">{{ y }}</span>{% when None %}{% endmatch %}
                         {% for sg in self.series_genres(s.id) %}<span class="genre-tag">{{ sg.name_cs }}</span>{% endfor %}
@@ -706,7 +706,7 @@ function doSearch() {
                                 ? '<img src="/serialy-online/' + r.slug + '.webp" alt="' + r.title + '" title="' + r.title + '">'
                                 : '<div class="si-placeholder"></div>';
                             var yr = r.year ? ' (' + r.year + ')' : '';
-                            var rat = r.imdb_rating ? ' — IMDB ' + r.imdb_rating : '';
+                            var rat = r.imdb_rating ? ' — TMDB ' + r.imdb_rating : '';
                             return '<a href="/serialy-online/' + r.slug + '/" class="search-item" title="' + r.title + '">'
                                 + cover + '<div class="si-info"><span class="si-title">' + r.title + yr + '</span>'
                                 + '<span class="si-meta">' + rat + '</span></div></a>';

--- a/cr-web/templates/tv_porad_detail.html
+++ b/cr-web/templates/tv_porad_detail.html
@@ -61,7 +61,7 @@
             {% when None %}{% endmatch %}
             <div class="meta-row">
                 {% match show.imdb_rating %}
-                {% when Some with (r) %}<span class="meta-badge imdb" title="IMDB hodnocení">IMDB {{ r }}</span>
+                {% when Some with (r) %}<span class="meta-badge imdb" title="TMDB hodnocení">TMDB {{ r }}</span>
                 {% when None %}{% endmatch %}
                 {% match show.csfd_rating %}
                 {% when Some with (r) %}<span class="meta-badge csfd" title="ČSFD hodnocení">ČSFD {{ r }}%</span>

--- a/cr-web/templates/tv_porady_list.html
+++ b/cr-web/templates/tv_porady_list.html
@@ -60,7 +60,7 @@
             <select id="sort-select" onchange="applySortCombined(this.value)" aria-label="Řazení" class="sort-select-combined">
                 <option value="pridano:desc">Naposledy přidané</option>
                 <option value="rok:desc">Od nejnovějších</option>
-                <option value="imdb:desc">Nejlépe hodnocené IMDB</option>
+                <option value="imdb:desc">Nejlépe hodnocené TMDB</option>
                 <option value="nazev:asc">Podle názvu A–Z</option>
             </select>
         </label>
@@ -85,7 +85,7 @@
             {% endmatch %}
             <div class="rating-badges">
                 {% match ep.tv_show_imdb_rating %}
-                {% when Some with (r) %}<span class="rating-badge imdb" title="IMDB hodnocení">{{ r }}</span>{% when None %}{% endmatch %}
+                {% when Some with (r) %}<span class="rating-badge imdb" title="TMDB hodnocení">{{ r }}</span>{% when None %}{% endmatch %}
                 {% match ep.tv_show_csfd_rating %}
                 {% when Some with (r) %}<span class="rating-badge csfd" title="ČSFD hodnocení">{{ r }}%</span>{% when None %}{% endmatch %}
             </div>
@@ -101,7 +101,7 @@
             </div>
             <div class="film-list-extra">
                 <div class="film-ratings">
-                    {% match ep.tv_show_imdb_rating %}{% when Some with (r) %}<span class="badge imdb">IMDB {{ r }}</span>{% when None %}{% endmatch %}
+                    {% match ep.tv_show_imdb_rating %}{% when Some with (r) %}<span class="badge imdb">TMDB {{ r }}</span>{% when None %}{% endmatch %}
                     {% match ep.tv_show_csfd_rating %}{% when Some with (r) %}<span class="badge csfd">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
                     {% match ep.tv_show_first_air_year %}{% when Some with (y) %}<span class="badge year">{{ y }}</span>{% when None %}{% endmatch %}
                 </div>
@@ -123,7 +123,7 @@
             <div class="no-poster">{{ s.title }}</div>
             {% endmatch %}
             <div class="rating-badges">
-                {% match s.imdb_rating %}{% when Some with (r) %}<span class="rating-badge imdb" title="IMDB hodnocení">{{ r }}</span>{% when None %}{% endmatch %}
+                {% match s.imdb_rating %}{% when Some with (r) %}<span class="rating-badge imdb" title="TMDB hodnocení">{{ r }}</span>{% when None %}{% endmatch %}
                 {% match s.csfd_rating %}{% when Some with (r) %}<span class="rating-badge csfd" title="ČSFD hodnocení">{{ r }}%</span>{% when None %}{% endmatch %}
             </div>
         </div>
@@ -135,7 +135,7 @@
             </div>
             <div class="film-list-extra">
                 <div class="film-ratings">
-                    {% match s.imdb_rating %}{% when Some with (r) %}<span class="badge imdb">IMDB {{ r }}</span>{% when None %}{% endmatch %}
+                    {% match s.imdb_rating %}{% when Some with (r) %}<span class="badge imdb">TMDB {{ r }}</span>{% when None %}{% endmatch %}
                     {% match s.csfd_rating %}{% when Some with (r) %}<span class="badge csfd">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
                 </div>
                 {% match s.description %}{% when Some with (d) %}<p class="film-desc">{{ d }}</p>{% when None %}{% endmatch %}
@@ -330,7 +330,7 @@ function applySortCombined(v) {
             title.textContent = r.title + (r.year ? ' (' + r.year + ')' : '');
             var meta = document.createElement('span');
             meta.className = 'si-meta';
-            meta.textContent = r.imdb_rating ? ' — IMDB ' + r.imdb_rating : '';
+            meta.textContent = r.imdb_rating ? ' — TMDB ' + r.imdb_rating : '';
             info.appendChild(title);
             info.appendChild(meta);
             item.appendChild(info);


### PR DESCRIPTION
<!-- claude-session: 9c42f99e-d1ab-4b4c-9d4d-e7d09129237a -->

Closes #584

## Summary
- Templates displayed the rating badge as `IMDB {value}`, but the value stored in `imdb_rating` is actually TMDB's `vote_average` (documented in `scripts/auto_import/enricher.py:191` as a proxy "until we wire in the real IMDB")
- Replaced all user-visible `IMDB` strings with `TMDB` across 7 templates (film/series/tv_porad detail + list + episode detail search autocomplete)
- DB column name left unchanged — rename is separate schema work
- Admin pages (admin_import_detail.html, admin_import_summary.html) keep `IMDB` since they reference real `imdb_id` links

## Test plan
Already deployed to production and verified with Playwright:
- [x] Film detail (`/filmy-online/along-with-the-gods-the-last-49-days/`) → `TMDB 8` badge, no IMDB
- [x] Films list → optgroup "Podle hodnocení TMDB", badges `TMDB 4.9`, `TMDB 7` …
- [x] Series list → optgroup "Podle hodnocení TMDB", badges `TMDB 8.3`, `TMDB 7.7` …
- [x] TV-pořady list → option "Nejlépe hodnocené TMDB"
- [x] Series detail (`/serialy-online/monarch-odkaz-monster/`) → `TMDB 7.7` badge, no IMDB
- [x] TV-pořad detail (`/tv-porady/asia-express/`) → no IMDB visible
- [x] Zero console errors, zero warnings
- [x] Only remaining `IMDB` occurrences in the HTML are CSS comments and admin pages with real IMDB links