### PR TITLE
feat(series): lazy-fetch large covers from TMDB (#582)

### DIFF
--- a/cr-infra/migrations/20260525_054_series_tmdb_poster_path.sql
+++ b/cr-infra/migrations/20260525_054_series_tmdb_poster_path.sql
@@ -1,0 +1,6 @@
+-- Stores the TMDB `poster_path` for each series, e.g. `/mqlgZiQHT3B5J8Q4mkgaCkt47uJ.jpg`.
+-- Needed so the large-cover route can build the live TMDB URL
+-- (`https://image.tmdb.org/t/p/w780{poster_path}`) without having to call the
+-- TMDB API on every detail page render. Backfilled once by
+-- `scripts/backfill-tmdb-poster-paths.py --table series` and kept fresh by the enricher.
+ALTER TABLE series ADD COLUMN tmdb_poster_path VARCHAR(64);

--- a/cr-web/src/handlers/series.rs
+++ b/cr-web/src/handlers/series.rs
@@ -33,11 +33,13 @@ pub struct SeriesRow {
     #[allow(dead_code)] // Needed in SELECT for ORDER BY; not rendered in templates
     added_at: Option<chrono::DateTime<chrono::Utc>>,
     /// TMDB poster_path (e.g. `/mqlg…uJ.jpg`), backfilled by
-    /// `scripts/backfill-tmdb-poster-paths.py --table series`. When set, the
-    /// large-cover URL switches to the extension the path ends with
-    /// (`.jpg`/`.png`) and `series_cover_large_dynamic` proxies the TMDB
-    /// image. When None, the template keeps the legacy `-large.webp` URL
-    /// served from R2.
+    /// `scripts/backfill-tmdb-poster-paths.py --table series`. The detail
+    /// template only emits a large-cover URL when `cover_filename` is `Some`
+    /// (otherwise it renders a no-cover placeholder); in that branch
+    /// `large_url_ext()` consults this field and flips the extension to the
+    /// one the path ends with (`.jpg`/`.png`), which `series_cover_large_dynamic`
+    /// proxies from TMDB. When this field is `None` but `cover_filename` is
+    /// `Some`, the template keeps the legacy `-large.webp` URL served from R2.
     tmdb_poster_path: Option<String>,
 }
 
@@ -638,7 +640,8 @@ pub async fn series_resolve(
     axum::extract::Query(params): axum::extract::Query<SeriesQuery>,
     headers: axum::http::HeaderMap,
 ) -> WebResult<Response> {
-    let state_clone = state.clone();
+    // Cover requests short-circuit before the `state.clone()` below so that
+    // hot image endpoints don't pay for a clone they never read.
     // Large cover dynamically proxied from TMDB — real extension in URL so
     // the response content type matches what the template rendered. See
     // `series_cover_large_dynamic` for the fallback chain.
@@ -649,6 +652,7 @@ pub async fn series_resolve(
     if slug_raw.ends_with(".webp") {
         return series_cover(State(state), Path(slug_raw)).await;
     }
+    let state_clone = state.clone();
 
     // Genre page?
     let genre =

--- a/cr-web/src/handlers/series.rs
+++ b/cr-web/src/handlers/series.rs
@@ -32,6 +32,32 @@ pub struct SeriesRow {
     cover_filename: Option<String>,
     #[allow(dead_code)] // Needed in SELECT for ORDER BY; not rendered in templates
     added_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// TMDB poster_path (e.g. `/mqlg…uJ.jpg`), backfilled by
+    /// `scripts/backfill-tmdb-poster-paths.py --table series`. When set, the
+    /// large-cover URL switches to the extension the path ends with
+    /// (`.jpg`/`.png`) and `series_cover_large_dynamic` proxies the TMDB
+    /// image. When None, the template keeps the legacy `-large.webp` URL
+    /// served from R2.
+    tmdb_poster_path: Option<String>,
+}
+
+impl SeriesRow {
+    /// Extension for the large-cover URL rendered in the detail template.
+    /// Derived from `tmdb_poster_path` when the series has been backfilled;
+    /// otherwise falls back to `webp` so the existing R2-backed route keeps
+    /// serving until the backfill completes.
+    pub fn large_url_ext(&self) -> &str {
+        match self.tmdb_poster_path.as_deref() {
+            Some(p) => {
+                if let Some(dot) = p.rfind('.') {
+                    &p[dot + 1..]
+                } else {
+                    "jpg"
+                }
+            }
+            None => "webp",
+        }
+    }
 }
 
 /// Episode card shown on list pages — one latest episode per series,
@@ -326,7 +352,8 @@ pub async fn series_list(
         let query = format!(
             "SELECT s.id, s.title, s.slug, s.first_air_year, s.last_air_year, \
              s.description, s.original_title, s.imdb_rating, s.csfd_rating, \
-             s.season_count, s.episode_count, s.cover_filename, s.added_at \
+             s.season_count, s.episode_count, s.cover_filename, s.added_at, \
+             s.tmdb_poster_path \
              FROM series s \
              WHERE s.title ILIKE $1 OR s.original_title ILIKE $1 \
              ORDER BY {order} LIMIT $2 OFFSET $3"
@@ -612,6 +639,12 @@ pub async fn series_resolve(
     headers: axum::http::HeaderMap,
 ) -> WebResult<Response> {
     let state_clone = state.clone();
+    // Large cover dynamically proxied from TMDB — real extension in URL so
+    // the response content type matches what the template rendered. See
+    // `series_cover_large_dynamic` for the fallback chain.
+    if slug_raw.ends_with("-large.jpg") || slug_raw.ends_with("-large.png") {
+        return series_cover_large_dynamic(State(state), Path(slug_raw)).await;
+    }
     // WebP cover
     if slug_raw.ends_with(".webp") {
         return series_cover(State(state), Path(slug_raw)).await;
@@ -645,7 +678,7 @@ pub async fn series_resolve(
     let series = sqlx::query_as::<_, SeriesRow>(
         "SELECT id, title, slug, first_air_year, last_air_year, description, \
          original_title, imdb_rating, csfd_rating, season_count, episode_count, \
-         cover_filename, added_at \
+         cover_filename, added_at, tmdb_poster_path \
          FROM series WHERE slug = $1",
     )
     .bind(&slug_raw)
@@ -659,7 +692,7 @@ pub async fn series_resolve(
             let old_match = sqlx::query_as::<_, SeriesRow>(
                 "SELECT id, title, slug, first_air_year, last_air_year, description, \
                  original_title, imdb_rating, csfd_rating, season_count, episode_count, \
-                 cover_filename, added_at FROM series WHERE old_slug = $1",
+                 cover_filename, added_at, tmdb_poster_path FROM series WHERE old_slug = $1",
             )
             .bind(&slug_raw)
             .fetch_optional(&state.db)
@@ -788,7 +821,7 @@ pub async fn episode_detail(
     let series = sqlx::query_as::<_, SeriesRow>(
         "SELECT id, title, slug, first_air_year, last_air_year, description, \
          original_title, imdb_rating, csfd_rating, season_count, episode_count, \
-         cover_filename, added_at FROM series WHERE slug = $1",
+         cover_filename, added_at, tmdb_poster_path FROM series WHERE slug = $1",
     )
     .bind(&slug)
     .fetch_optional(&state.db)
@@ -801,7 +834,7 @@ pub async fn episode_detail(
             let old_match = sqlx::query_as::<_, SeriesRow>(
                 "SELECT id, title, slug, first_air_year, last_air_year, description, \
                  original_title, imdb_rating, csfd_rating, season_count, episode_count, \
-                 cover_filename, added_at FROM series WHERE old_slug = $1",
+                 cover_filename, added_at, tmdb_poster_path FROM series WHERE old_slug = $1",
             )
             .bind(&slug)
             .fetch_optional(&state.db)
@@ -1180,6 +1213,77 @@ pub async fn series_cover_large(
         }
     }
     Ok(placeholder_webp())
+}
+
+/// GET /serialy-online/{slug}-large.{jpg,png} — proxy TMDB poster on demand.
+///
+/// Mirrors `films_cover_large_dynamic` (see `handlers::films`): detail-page
+/// thumbnails get few hits, so we skip R2 storage and stream the TMDB image
+/// through. Cloudflare caches the response for a year. On any failure we
+/// serve a placeholder in the SAME format the URL advertises so browsers
+/// and OG scrapers decode without a MIME mismatch.
+pub async fn series_cover_large_dynamic(
+    State(state): State<AppState>,
+    Path(slug_ext): Path<String>,
+) -> WebResult<Response> {
+    use crate::handlers::cover_proxy::placeholder_for_ext;
+
+    let (slug, ext) = if let Some(s) = slug_ext.strip_suffix("-large.jpg") {
+        (s, "jpg")
+    } else if let Some(s) = slug_ext.strip_suffix("-large.png") {
+        (s, "png")
+    } else {
+        (slug_ext.as_str(), "jpg")
+    };
+
+    #[derive(sqlx::FromRow)]
+    struct CoverRow {
+        tmdb_poster_path: Option<String>,
+    }
+
+    let row = sqlx::query_as::<_, CoverRow>("SELECT tmdb_poster_path FROM series WHERE slug = $1")
+        .bind(slug)
+        .fetch_optional(&state.db)
+        .await?;
+
+    let Some(path) = row.and_then(|r| r.tmdb_poster_path) else {
+        return Ok(placeholder_for_ext(ext));
+    };
+
+    let url = format!("https://image.tmdb.org/t/p/w780{path}");
+    let Ok(resp) = state
+        .http_client
+        .get(&url)
+        .timeout(std::time::Duration::from_secs(10))
+        .send()
+        .await
+    else {
+        return Ok(placeholder_for_ext(ext));
+    };
+    if !resp.status().is_success() {
+        return Ok(placeholder_for_ext(ext));
+    }
+    let ct = resp
+        .headers()
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| "image/jpeg".to_string());
+    let Ok(bytes) = resp.bytes().await else {
+        return Ok(placeholder_for_ext(ext));
+    };
+    Ok((
+        StatusCode::OK,
+        [
+            (axum::http::header::CONTENT_TYPE, ct),
+            (
+                axum::http::header::CACHE_CONTROL,
+                "public, max-age=31536000, immutable".to_string(),
+            ),
+        ],
+        bytes.to_vec(),
+    )
+        .into_response())
 }
 
 /// Build pagination query string for series list views.

--- a/cr-web/templates/series_detail.html
+++ b/cr-web/templates/series_detail.html
@@ -6,8 +6,27 @@
 
 {% block og_title %}{{ series.title }}{% match series.first_air_year %}{% when Some with (y) %} ({{ y }}){% when None %}{% endmatch %} — seriál online{% endblock %}
 {% block og_description %}{% match series.description %}{% when Some with (d) %}{{ d }}{% when None %}{{ series.title }} — seriál online zdarma{% endmatch %}{% endblock %}
-{% block og_image %}{% match series.cover_filename %}{% when Some with (c) %}https://ceskarepublika.wiki/serialy-online/{{ series.slug }}.webp{% when None %}https://ceskarepublika.wiki/static/img/og-filmy-a-serialy-v6.png{% endmatch %}{% endblock %}
+{% block og_image %}{% match series.cover_filename %}{% when Some with (c) %}https://ceskarepublika.wiki/serialy-online/{{ series.slug }}-large.{{ series.large_url_ext() }}{% when None %}https://ceskarepublika.wiki/static/img/og-filmy-a-serialy-v6.png{% endmatch %}{% endblock %}
 {% block og_type %}video.tv_show{% endblock %}
+
+{# Portrait poster dimensions (780×1170, 2:3 aspect) trigger Discord's
+   "movie card" layout — cover on the LEFT, title/description on the RIGHT. #}
+{% block og_extra %}
+{% match series.cover_filename %}
+{% when Some with (c) %}
+<meta property="og:image:type" content="image/{% if series.large_url_ext() == "jpg" %}jpeg{% else %}{{ series.large_url_ext() }}{% endif %}">
+<meta property="og:image:width" content="780">
+<meta property="og:image:height" content="1170">
+<meta property="og:image:alt" content="{{ series.title }}{% match series.first_air_year %}{% when Some with (y) %} ({{ y }}){% when None %}{% endmatch %}">
+{% when None %}
+<meta property="og:image:type" content="image/png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:alt" content="{{ series.title }} — ceskarepublika.wiki">
+{% endmatch %}
+<meta property="og:site_name" content="ceskarepublika.wiki">
+<meta name="twitter:card" content="summary">
+{% endblock %}
 
 {% block leaflet %}{% endblock %}
 
@@ -48,7 +67,7 @@
             {% match series.cover_filename %}
             {% when Some with (c) %}
             <div class="cover-zoom" data-gallery-open="series" data-index="0"
-                 data-gallery-photos="[&quot;/serialy-online/{{ series.slug }}-large.webp&quot;]">
+                 data-gallery-photos="[&quot;/serialy-online/{{ series.slug }}-large.{{ series.large_url_ext() }}&quot;]">
                 <img src="/serialy-online/{{ series.slug }}.webp" alt="{{ series.title }}" title="{{ series.title }}" width="200" height="300">
             </div>
             {% when None %}

--- a/scripts/auto_import/series_enricher.py
+++ b/scripts/auto_import/series_enricher.py
@@ -138,8 +138,8 @@ def ensure_series(
         """INSERT INTO series
            (title, original_title, slug, first_air_year, last_air_year,
             description, imdb_id, tmdb_id,
-            season_count, episode_count, cover_filename, added_at)
-           VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s, now())
+            season_count, episode_count, cover_filename, tmdb_poster_path, added_at)
+           VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s, now())
            RETURNING id""",
         (
             name_cs, name_en if name_en != name_cs else None, slug,
@@ -147,7 +147,7 @@ def ensure_series(
             description,
             tv.imdb_id, tv.tmdb_id,
             tv.season_count, tv.episode_count,
-            cover_filename,
+            cover_filename, tv.poster_path,
         ),
     )
     series_id = cur.fetchone()[0]


### PR DESCRIPTION
<!-- claude-session: 9c42f99e-d1ab-4b4c-9d4d-e7d09129237a -->

Closes #582

## Summary
Applies the #581 TMDB lazy-fetch pattern to series:
- New migration adds `series.tmdb_poster_path VARCHAR(64)`.
- `SeriesRow` gains `tmdb_poster_path` + `large_url_ext()` (yields `jpg` when backfilled, falls back to `webp`).
- `series_cover_large_dynamic` handler in `cr-web/src/handlers/series.rs` proxies `image.tmdb.org/t/p/w780`, preserves the TMDB Content-Type, and returns `placeholder_for_ext(ext)` on any failure so the MIME promised in the URL always matches the served bytes.
- `series_detail.html` now emits `og:image` as `-large.{jpg|webp}`, matching `og:image:type` and 780×1170 portrait dimensions (Discord/Slack friendly).
- `series_enricher.py` INSERT writes `tmdb_poster_path` so new series don't need a re-backfill.

## Test plan
- [x] `cargo check`, `cargo clippy -- -D warnings`, `cargo fmt --check`, `cargo test` — all pass locally
- [x] Migration + backfill already executed on prod:
  - Applied: `ALTER TABLE series ADD COLUMN tmdb_poster_path VARCHAR(64)`
  - Registered in `_sqlx_migrations` with SHA-384 checksum of file content
  - Backfill: **838 series with poster_path, 3 without** (all JPG, took ~30 s)
- [x] Binary cross-compiled and deployed to prod
- [x] Playwright verified on https://ceskarepublika.wiki/serialy-online/teror/:
  - `og:image` → `https://ceskarepublika.wiki/serialy-online/teror-large.jpg`
  - `og:image:type` → `image/jpeg` (width 780, height 1170)
  - `data-gallery-photos` → `/serialy-online/teror-large.jpg`
  - Small cover still served as `.webp` from R2 (6 KB)
  - Large JPG direct fetch: 200, `content-type: image/jpeg`, 77 016 B, `Cache-Control: public, max-age=31536000, immutable`
  - Zero console errors / warnings
- [x] Legacy `.webp` route still functional for the 3 series without TMDB data

## Notes
Issue #582 description was updated on GitHub to drop the outdated "WebP conversion" wording — we serve native TMDB JPG bytes without re-encoding. Placeholder fallbacks are also JPG for `.jpg` URLs so OG scrapers never see a MIME mismatch.