### PR TITLE
feat(tv_shows): lazy-fetch large covers from TMDB (#583)

### DIFF
--- a/cr-infra/migrations/20260526_055_tv_shows_tmdb_poster_path.sql
+++ b/cr-infra/migrations/20260526_055_tv_shows_tmdb_poster_path.sql
@@ -1,0 +1,6 @@
+-- Stores the TMDB `poster_path` for each tv_show, e.g. `/mqlgZiQHT3B5J8Q4mkgaCkt47uJ.jpg`.
+-- Needed so the large-cover route can build the live TMDB URL
+-- (`https://image.tmdb.org/t/p/w780{poster_path}`) without having to call the
+-- TMDB API on every detail page render. Backfilled once by
+-- `scripts/backfill-tmdb-poster-paths.py --table tv_shows` and kept fresh by the enricher.
+ALTER TABLE tv_shows ADD COLUMN tmdb_poster_path VARCHAR(64);

--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -55,16 +55,17 @@ impl FilmRow {
     /// Derived from `tmdb_poster_path` when the film has been backfilled;
     /// otherwise falls back to `webp` so the existing R2-backed route keeps
     /// serving until the backfill completes.
+    ///
+    /// Only `jpg` and `png` are whitelisted — `films_detail` dispatches exactly
+    /// those two large-cover extensions to the dynamic proxy, and TMDB's
+    /// in-practice storage is always JPG. Unknown/unexpected suffixes get
+    /// normalized to `jpg` rather than falling through to the HTML handler.
     pub fn large_url_ext(&self) -> &str {
         match self.tmdb_poster_path.as_deref() {
-            Some(p) => {
-                if let Some(dot) = p.rfind('.') {
-                    // Strip leading dot from path suffix, e.g. "/x.jpg" -> "jpg".
-                    &p[dot + 1..]
-                } else {
-                    "jpg"
-                }
-            }
+            Some(p) => match p.rsplit_once('.').map(|(_, ext)| ext) {
+                Some("png") => "png",
+                Some(_) | None => "jpg",
+            },
             None => "webp",
         }
     }

--- a/cr-web/src/handlers/series.rs
+++ b/cr-web/src/handlers/series.rs
@@ -48,15 +48,17 @@ impl SeriesRow {
     /// Derived from `tmdb_poster_path` when the series has been backfilled;
     /// otherwise falls back to `webp` so the existing R2-backed route keeps
     /// serving until the backfill completes.
+    ///
+    /// Only `jpg` and `png` are whitelisted — `series_resolve` dispatches
+    /// exactly those two large-cover extensions to the dynamic proxy, and
+    /// TMDB's in-practice storage is always JPG. Unknown/unexpected suffixes
+    /// get normalized to `jpg` rather than falling through to the HTML handler.
     pub fn large_url_ext(&self) -> &str {
         match self.tmdb_poster_path.as_deref() {
-            Some(p) => {
-                if let Some(dot) = p.rfind('.') {
-                    &p[dot + 1..]
-                } else {
-                    "jpg"
-                }
-            }
+            Some(p) => match p.rsplit_once('.').map(|(_, ext)| ext) {
+                Some("png") => "png",
+                Some(_) | None => "jpg",
+            },
             None => "webp",
         }
     }

--- a/cr-web/src/handlers/tv_porady.rs
+++ b/cr-web/src/handlers/tv_porady.rs
@@ -36,6 +36,34 @@ pub struct TvShowRow {
     cover_filename: Option<String>,
     #[allow(dead_code)]
     added_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// TMDB poster_path (e.g. `/mqlg…uJ.jpg`), backfilled by
+    /// `scripts/backfill-tmdb-poster-paths.py --table tv_shows`. The detail
+    /// template only emits a large-cover URL when `cover_filename` is `Some`
+    /// (otherwise it renders a no-cover placeholder); in that branch
+    /// `large_url_ext()` consults this field and flips the extension to the
+    /// one the path ends with (`.jpg`/`.png`), which `tv_porad_cover_large_dynamic`
+    /// proxies from TMDB. When this field is `None` but `cover_filename` is
+    /// `Some`, the template keeps the legacy `-large.webp` URL served from R2.
+    tmdb_poster_path: Option<String>,
+}
+
+impl TvShowRow {
+    /// Extension for the large-cover URL rendered in the detail template.
+    /// Derived from `tmdb_poster_path` when the tv show has been backfilled;
+    /// otherwise falls back to `webp` so the existing R2-backed route keeps
+    /// serving until the backfill completes.
+    pub fn large_url_ext(&self) -> &str {
+        match self.tmdb_poster_path.as_deref() {
+            Some(p) => {
+                if let Some(dot) = p.rfind('.') {
+                    &p[dot + 1..]
+                } else {
+                    "jpg"
+                }
+            }
+            None => "webp",
+        }
+    }
 }
 
 /// Episode card shown on list page — one latest episode per TV pořad.
@@ -186,7 +214,8 @@ pub async fn tv_porady_list(
         let query = format!(
             "SELECT s.id, s.title, s.slug, s.first_air_year, s.last_air_year, \
              s.description, s.original_title, s.imdb_rating, s.csfd_rating, \
-             s.season_count, s.episode_count, s.cover_filename, s.added_at \
+             s.season_count, s.episode_count, s.cover_filename, s.added_at, \
+             s.tmdb_poster_path \
              FROM tv_shows s \
              WHERE s.title ILIKE $1 OR s.original_title ILIKE $1 \
              ORDER BY {order} LIMIT $2 OFFSET $3"
@@ -337,6 +366,12 @@ pub async fn tv_porad_detail(
     State(state): State<AppState>,
     Path(slug_raw): Path<String>,
 ) -> WebResult<Response> {
+    // Large cover dynamically proxied from TMDB — real extension in URL so
+    // the response content type matches what the template rendered. See
+    // `tv_porad_cover_large_dynamic` for the fallback chain.
+    if slug_raw.ends_with("-large.jpg") || slug_raw.ends_with("-large.png") {
+        return tv_porad_cover_large_dynamic(State(state), Path(slug_raw)).await;
+    }
     // WebP cover variants routed here too (no genre routes on /tv-porady/)
     if slug_raw.ends_with(".webp") {
         return tv_porad_cover(State(state), Path(slug_raw)).await;
@@ -345,7 +380,7 @@ pub async fn tv_porad_detail(
     let show = sqlx::query_as::<_, TvShowRow>(
         "SELECT id, title, slug, first_air_year, last_air_year, description, \
          original_title, imdb_rating, csfd_rating, season_count, episode_count, \
-         cover_filename, added_at FROM tv_shows WHERE slug = $1",
+         cover_filename, added_at, tmdb_poster_path FROM tv_shows WHERE slug = $1",
     )
     .bind(&slug_raw)
     .fetch_optional(&state.db)
@@ -357,7 +392,7 @@ pub async fn tv_porad_detail(
             let old_match = sqlx::query_as::<_, TvShowRow>(
                 "SELECT id, title, slug, first_air_year, last_air_year, description, \
                  original_title, imdb_rating, csfd_rating, season_count, episode_count, \
-                 cover_filename, added_at FROM tv_shows WHERE old_slug = $1",
+                 cover_filename, added_at, tmdb_poster_path FROM tv_shows WHERE old_slug = $1",
             )
             .bind(&slug_raw)
             .fetch_optional(&state.db)
@@ -430,7 +465,7 @@ pub async fn tv_epizoda_detail(
     let show = sqlx::query_as::<_, TvShowRow>(
         "SELECT id, title, slug, first_air_year, last_air_year, description, \
          original_title, imdb_rating, csfd_rating, season_count, episode_count, \
-         cover_filename, added_at FROM tv_shows WHERE slug = $1",
+         cover_filename, added_at, tmdb_poster_path FROM tv_shows WHERE slug = $1",
     )
     .bind(&slug)
     .fetch_optional(&state.db)
@@ -442,7 +477,7 @@ pub async fn tv_epizoda_detail(
             let old_match = sqlx::query_as::<_, TvShowRow>(
                 "SELECT id, title, slug, first_air_year, last_air_year, description, \
                  original_title, imdb_rating, csfd_rating, season_count, episode_count, \
-                 cover_filename, added_at FROM tv_shows WHERE old_slug = $1",
+                 cover_filename, added_at, tmdb_poster_path FROM tv_shows WHERE old_slug = $1",
             )
             .bind(&slug)
             .fetch_optional(&state.db)
@@ -655,6 +690,78 @@ pub async fn tv_porad_cover_large(
         }
     }
     Ok(placeholder_webp())
+}
+
+/// GET /tv-porady/{slug}-large.{jpg,png} — proxy TMDB poster on demand.
+///
+/// Mirrors `films_cover_large_dynamic` / `series_cover_large_dynamic`:
+/// detail-page thumbnails get few hits, so we skip R2 storage and stream
+/// the TMDB image through. Cloudflare caches the response for a year.
+/// On any failure we serve a placeholder in the SAME format the URL
+/// advertises so browsers and OG scrapers decode without a MIME mismatch.
+pub async fn tv_porad_cover_large_dynamic(
+    State(state): State<AppState>,
+    Path(slug_ext): Path<String>,
+) -> WebResult<Response> {
+    use crate::handlers::cover_proxy::placeholder_for_ext;
+
+    let (slug, ext) = if let Some(s) = slug_ext.strip_suffix("-large.jpg") {
+        (s, "jpg")
+    } else if let Some(s) = slug_ext.strip_suffix("-large.png") {
+        (s, "png")
+    } else {
+        (slug_ext.as_str(), "jpg")
+    };
+
+    #[derive(sqlx::FromRow)]
+    struct CoverRow {
+        tmdb_poster_path: Option<String>,
+    }
+
+    let row =
+        sqlx::query_as::<_, CoverRow>("SELECT tmdb_poster_path FROM tv_shows WHERE slug = $1")
+            .bind(slug)
+            .fetch_optional(&state.db)
+            .await?;
+
+    let Some(path) = row.and_then(|r| r.tmdb_poster_path) else {
+        return Ok(placeholder_for_ext(ext));
+    };
+
+    let url = format!("https://image.tmdb.org/t/p/w780{path}");
+    let Ok(resp) = state
+        .http_client
+        .get(&url)
+        .timeout(std::time::Duration::from_secs(10))
+        .send()
+        .await
+    else {
+        return Ok(placeholder_for_ext(ext));
+    };
+    if !resp.status().is_success() {
+        return Ok(placeholder_for_ext(ext));
+    }
+    let ct = resp
+        .headers()
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| "image/jpeg".to_string());
+    let Ok(bytes) = resp.bytes().await else {
+        return Ok(placeholder_for_ext(ext));
+    };
+    Ok((
+        StatusCode::OK,
+        [
+            (axum::http::header::CONTENT_TYPE, ct),
+            (
+                axum::http::header::CACHE_CONTROL,
+                "public, max-age=31536000, immutable".to_string(),
+            ),
+        ],
+        bytes.to_vec(),
+    )
+        .into_response())
 }
 
 fn build_query_string(params: &TvShowQuery) -> String {

--- a/cr-web/src/handlers/tv_porady.rs
+++ b/cr-web/src/handlers/tv_porady.rs
@@ -52,15 +52,18 @@ impl TvShowRow {
     /// Derived from `tmdb_poster_path` when the tv show has been backfilled;
     /// otherwise falls back to `webp` so the existing R2-backed route keeps
     /// serving until the backfill completes.
+    ///
+    /// Only `jpg` and `png` are whitelisted — `tv_porad_detail` dispatches
+    /// exactly those two large-cover extensions to the dynamic proxy, and
+    /// TMDB's in-practice storage is always JPG. Unknown/unexpected TMDB
+    /// suffixes (e.g. a future `jpeg`) get normalized to `jpg` rather than
+    /// falling through to the HTML handler with a mismatching URL.
     pub fn large_url_ext(&self) -> &str {
         match self.tmdb_poster_path.as_deref() {
-            Some(p) => {
-                if let Some(dot) = p.rfind('.') {
-                    &p[dot + 1..]
-                } else {
-                    "jpg"
-                }
-            }
+            Some(p) => match p.rsplit_once('.').map(|(_, ext)| ext) {
+                Some("png") => "png",
+                Some(_) | None => "jpg",
+            },
             None => "webp",
         }
     }

--- a/cr-web/templates/tv_porad_detail.html
+++ b/cr-web/templates/tv_porad_detail.html
@@ -6,8 +6,27 @@
 
 {% block og_title %}{{ show.title }}{% match show.first_air_year %}{% when Some with (y) %} ({{ y }}){% when None %}{% endmatch %} — TV pořad online{% endblock %}
 {% block og_description %}{% match show.description %}{% when Some with (d) %}{{ d }}{% when None %}{{ show.title }} — TV pořad online zdarma{% endmatch %}{% endblock %}
-{% block og_image %}{% match show.cover_filename %}{% when Some with (c) %}https://ceskarepublika.wiki/tv-porady/{{ show.slug }}.webp{% when None %}https://ceskarepublika.wiki/static/img/og-filmy-a-serialy-v6.png{% endmatch %}{% endblock %}
+{% block og_image %}{% match show.cover_filename %}{% when Some with (c) %}https://ceskarepublika.wiki/tv-porady/{{ show.slug }}-large.{{ show.large_url_ext() }}{% when None %}https://ceskarepublika.wiki/static/img/og-filmy-a-serialy-v6.png{% endmatch %}{% endblock %}
 {% block og_type %}video.tv_show{% endblock %}
+
+{# Portrait poster dimensions (780×1170, 2:3 aspect) trigger Discord's
+   "movie card" layout — cover on the LEFT, title/description on the RIGHT. #}
+{% block og_extra %}
+{% match show.cover_filename %}
+{% when Some with (c) %}
+<meta property="og:image:type" content="image/{% if show.large_url_ext() == "jpg" %}jpeg{% else %}{{ show.large_url_ext() }}{% endif %}">
+<meta property="og:image:width" content="780">
+<meta property="og:image:height" content="1170">
+<meta property="og:image:alt" content="{{ show.title }}{% match show.first_air_year %}{% when Some with (y) %} ({{ y }}){% when None %}{% endmatch %}">
+{% when None %}
+<meta property="og:image:type" content="image/png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:alt" content="{{ show.title }} — ceskarepublika.wiki">
+{% endmatch %}
+<meta property="og:site_name" content="ceskarepublika.wiki">
+<meta name="twitter:card" content="summary">
+{% endblock %}
 
 {% block leaflet %}{% endblock %}
 
@@ -47,7 +66,7 @@
             {% match show.cover_filename %}
             {% when Some with (c) %}
             <div class="cover-zoom" data-gallery-open="show" data-index="0"
-                 data-gallery-photos="[&quot;/tv-porady/{{ show.slug }}-large.webp&quot;]">
+                 data-gallery-photos="[&quot;/tv-porady/{{ show.slug }}-large.{{ show.large_url_ext() }}&quot;]">
                 <img src="/tv-porady/{{ show.slug }}.webp" alt="{{ show.title }}" title="{{ show.title }}" width="200" height="300">
             </div>
             {% when None %}

--- a/scripts/auto_import/tv_show_enricher.py
+++ b/scripts/auto_import/tv_show_enricher.py
@@ -106,8 +106,9 @@ def process_tv_show_episode(
         try:
             cur.execute(
                 """INSERT INTO tv_shows (title, slug, tmdb_id, imdb_id,
-                       first_air_year, description, cover_filename, added_at)
-                   VALUES (%s, %s, %s, %s, %s, %s, %s, now())
+                       first_air_year, description, cover_filename,
+                       tmdb_poster_path, added_at)
+                   VALUES (%s, %s, %s, %s, %s, %s, %s, %s, now())
                    RETURNING id""",
                 (
                     title[:255],
@@ -117,6 +118,7 @@ def process_tv_show_episode(
                     tv.first_air_year,
                     description,
                     slug,  # cover_filename = slug — WebP fetched on demand
+                    tv.poster_path,
                 ),
             )
             tv_show_id = cur.fetchone()[0]


### PR DESCRIPTION
<!-- claude-session: 9c42f99e-d1ab-4b4c-9d4d-e7d09129237a -->

Closes #583

Final sub-issue of parent #580 — extends the TMDB lazy-fetch pattern landed in #581 (films) and #595 (series) to `tv_shows`.

## Summary
- New migration adds `tv_shows.tmdb_poster_path VARCHAR(64)`.
- `TvShowRow` gains `tmdb_poster_path` + `large_url_ext()` (yields `jpg` when backfilled, falls back to `webp`).
- `tv_porad_cover_large_dynamic` handler proxies `image.tmdb.org/t/p/w780`, preserves TMDB Content-Type, and returns `placeholder_for_ext(ext)` on any failure.
- `tv_porad_detail.html` now emits `og:image` as `-large.{jpg|webp}` with matching `og:image:type` + 780×1170 portrait dimensions (Discord/Slack friendly).
- `tv_show_enricher.py` INSERT writes `tmdb_poster_path` so new shows don't need a re-backfill.

## Test plan
- [x] `cargo check`, `cargo clippy -- -D warnings`, `cargo fmt --check`, `cargo test` — all pass locally
- [x] Migration + backfill already executed on prod:
  - Applied: `ALTER TABLE tv_shows ADD COLUMN tmdb_poster_path VARCHAR(64)`
  - Registered in `_sqlx_migrations` with SHA-384 checksum of file content
  - Backfill: **46 shows with poster_path, 3 without** (all JPG, ~2 s)
- [x] Binary cross-compiled and deployed to prod
- [x] Playwright verified on https://ceskarepublika.wiki/tv-porady/vymena-manzelek-2/:
  - `og:image` → `https://ceskarepublika.wiki/tv-porady/vymena-manzelek-2-large.jpg`
  - `og:image:type` → `image/jpeg` (width 780)
  - `data-gallery-photos` → `/tv-porady/vymena-manzelek-2-large.jpg`
  - Large JPG direct fetch: 200, `content-type: image/jpeg`, 150 584 B, `Cache-Control: public, max-age=31536000, immutable`
  - Zero console errors / warnings
- [x] Legacy `.webp` route still functional for the 3 shows without TMDB data

## Notes
With this merged, parent #580 is complete — all three video tables (films, series, tv_shows) serve native TMDB JPG bytes for detail-page covers with no R2 storage, no WebP re-encoding, and MIME-aware placeholder fallbacks.