### PR TITLE
feat(sledujteto): crawler + unmatched viewer for film→TMDB mapping (#598)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,5 +55,6 @@ data/scripts/__pycache__/
 data/npu/*.csv
 data/prototypes/
 data/scripts/
+data/sledujteto/
 scripts/__pycache__/
 scripts/auto_import/__pycache__/

--- a/scripts/sledujteto-films-to-tmdb.py
+++ b/scripts/sledujteto-films-to-tmdb.py
@@ -191,18 +191,35 @@ def tmdb_search(title: str, year: int | None, api_key: str, session: requests.Se
     if not results:
         return None
 
-    top = results[0]
-    top_title_norm = norm_title((top.get("title") or "") + " " + (top.get("original_title") or ""))
-    score = fuzz.token_set_ratio(title, top_title_norm)
-    if score >= 85:
-        return {
-            "tmdb_id": top["id"],
-            "tmdb_title": top.get("title"),
-            "tmdb_original_title": top.get("original_title"),
-            "tmdb_release_date": top.get("release_date"),
-            "fuzzy_score": score,
-        }
-    return None
+    best: tuple[int, int, dict] | None = None
+    for cand in results[:5]:
+        cand_norm = norm_title((cand.get("title") or "") + " " + (cand.get("original_title") or ""))
+        score = fuzz.token_set_ratio(title, cand_norm)
+        if score < 85:
+            continue
+        year_bonus = 0
+        rel = cand.get("release_date") or ""
+        if year and len(rel) >= 4 and rel[:4].isdigit():
+            ry = int(rel[:4])
+            if ry == year:
+                year_bonus = 10
+            elif abs(ry - year) <= 1:
+                year_bonus = 3
+        rank = (score + year_bonus, score)
+        if best is None or rank > best[:2]:
+            best = (rank[0], rank[1], cand)
+
+    if best is None:
+        return None
+
+    _, score, top = best
+    return {
+        "tmdb_id": top["id"],
+        "tmdb_title": top.get("title"),
+        "tmdb_original_title": top.get("original_title"),
+        "tmdb_release_date": top.get("release_date"),
+        "fuzzy_score": score,
+    }
 
 
 def load_known_tmdb_ids(database_url: str) -> set[int]:
@@ -378,6 +395,7 @@ def main() -> None:
 
     db_url = os.environ.get("DATABASE_URL", "").strip()
     if db_url and matched:
+        db_url = db_url.replace("@db:", "@127.0.0.1:")
         try:
             known = load_known_tmdb_ids(db_url)
             log.info("DB contains %d film tmdb_ids", len(known))

--- a/scripts/sledujteto-films-to-tmdb.py
+++ b/scripts/sledujteto-films-to-tmdb.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""Phase 1 MVP for Olbrasoft/cr#598 — sledujteto.cz films → TMDB IDs.
+
+Pipeline:
+  1. Crawl sledujteto `la` catch-all (1437 pages x 50 = 71 850 uploads) or
+     reuse cached JSON dump ({slug_id: name_string} or {slug_id: file_dict}).
+  2. Filter out series (SxxExx) and out-of-range durations (60-240 min).
+  3. Deduplicate by (norm_title, year).
+  4. Match each unique film against TMDB (fuzzy token_set_ratio >= 85).
+  5. Emit matched.jsonl, unmatched.csv, stats.json, and optionally
+     new-candidates.csv (diff against films.tmdb_id in local DB).
+
+See GitHub issue Olbrasoft/cr#598 for full context.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import logging
+import os
+import re
+import time
+import unicodedata
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+
+import requests
+from rapidfuzz import fuzz
+
+log = logging.getLogger(__name__)
+
+SLEDUJTETO_BASE = "https://www.sledujteto.cz"
+SEARCH_PATH = "/api/web/videos"
+LIMIT = 50
+LA_PAGES_CAP = 1437
+CATCH_ALL_QUERY = "la"
+THROTTLE_S = 0.2
+
+TMDB_API_BASE = "https://api.themoviedb.org/3"
+TMDB_RATE_S = 0.05
+
+YEAR_RE = re.compile(r"(?:^|[\s\[\(\{])((?:19|20)\d{2})(?:$|[\s\]\)\}])")
+SERIES_RE = re.compile(r"[sS]\d+[eE]\d+")
+SLUG_RE = re.compile(r"/file/(\d+)/")
+QUALITY_RE = re.compile(
+    r"\b("
+    r"1080p|720p|480p|2160p|4k|uhd|hd|fullhd|"
+    r"bluray|bdrip|webrip|web-dl|dvdrip|hdtv|hdrip|hdcam|cam|ts|tc|"
+    r"aac|ac3|dts|dd5\.?1|5\.?1|7\.?1|h\.?264|h\.?265|hevc|x264|x265|"
+    r"cz\s*dab(?:ing)?|sk\s*dab(?:ing)?|cz\s*titulky|sk\s*titulky|dab(?:ing)?|titulky|"
+    r"akcni|akční|drama|komedie|horor|sci[\-\s]?fi|thriller|romanticky|romantický|"
+    r"animovany|animovaný|dokument|valecny|válečný|western|fantasy|rodinny|rodinný|kriminalni|kriminální|"
+    r"extended|remastered|uncut|directors?\s*cut"
+    r")\b",
+    re.IGNORECASE,
+)
+
+DURATION_RE = re.compile(r"(?:(\d+)\s*h)?\s*(?:(\d+)\s*m)?\s*(?:(\d+)\s*s)?", re.IGNORECASE)
+
+FILM_DURATION_MIN = 60
+FILM_DURATION_MAX = 240
+
+
+def extract_year(name: str) -> int | None:
+    m = YEAR_RE.search(name)
+    return int(m.group(1)) if m else None
+
+
+def is_series(name: str) -> bool:
+    return bool(SERIES_RE.search(name))
+
+
+def parse_duration_min(s: str | None) -> int | None:
+    if not s or not isinstance(s, str):
+        return None
+    m = DURATION_RE.fullmatch(s.strip())
+    if not m:
+        return None
+    h, mi, se = (int(x) if x else 0 for x in m.groups())
+    total = h * 60 + mi + (1 if se >= 30 else 0)
+    return total if total > 0 else None
+
+
+def is_film_duration(duration_str: str | None) -> tuple[bool, str]:
+    minutes = parse_duration_min(duration_str)
+    if minutes is None:
+        return True, "unknown"
+    if minutes < FILM_DURATION_MIN:
+        return False, "too_short"
+    if minutes > FILM_DURATION_MAX:
+        return False, "too_long"
+    return True, "ok"
+
+
+def norm_title(name: str) -> str:
+    n = unicodedata.normalize("NFKD", name).encode("ascii", "ignore").decode()
+    n = n.lower()
+    n = YEAR_RE.sub(" ", n)
+    n = SERIES_RE.sub(" ", n)
+    n = QUALITY_RE.sub(" ", n)
+    n = re.sub(r"[\[\]\(\)\{\}\-\.,:;!?/\\|]", " ", n)
+    n = re.sub(r"\s+", " ", n).strip()
+    return n
+
+
+def slug_from_url(url: str) -> str | None:
+    m = SLUG_RE.search(url)
+    return m.group(1) if m else None
+
+
+def fetch_page(query: str, page: int, session: requests.Session) -> list[dict]:
+    r = session.get(
+        f"{SLEDUJTETO_BASE}{SEARCH_PATH}",
+        params={
+            "query": query,
+            "limit": LIMIT,
+            "page": page,
+            "sort": "relevance",
+            "me": 0,
+            "excluded_ids": "",
+        },
+        headers={"User-Agent": "Mozilla/5.0 (cr-web catalog discovery)"},
+        timeout=20,
+    )
+    r.raise_for_status()
+    return r.json()["data"]["files"]
+
+
+def crawl_catalog(limit_pages: int | None = None) -> dict[str, dict]:
+    session = requests.Session()
+    out: dict[str, dict] = {}
+    max_page = min(LA_PAGES_CAP, limit_pages) if limit_pages else LA_PAGES_CAP
+    t0 = time.time()
+    for page in range(1, max_page + 1):
+        try:
+            files = fetch_page(CATCH_ALL_QUERY, page, session)
+        except Exception as e:
+            log.warning("page %d err: %s (retry once)", page, e)
+            time.sleep(2)
+            try:
+                files = fetch_page(CATCH_ALL_QUERY, page, session)
+            except Exception as e2:
+                log.error("page %d giving up: %s", page, e2)
+                continue
+        for f in files:
+            sid = slug_from_url(f.get("url", ""))
+            if sid:
+                out[sid] = f
+        if page % 100 == 0:
+            elapsed = int(time.time() - t0)
+            log.info("page %d/%d — %d unique (+%ds)", page, max_page, len(out), elapsed)
+        time.sleep(THROTTLE_S)
+    return out
+
+
+def tmdb_search(title: str, year: int | None, api_key: str, session: requests.Session) -> dict | None:
+    params = {"api_key": api_key, "query": title, "language": "cs-CZ"}
+    if year:
+        params["year"] = year
+    r = None
+    for attempt in range(3):
+        try:
+            r = session.get(f"{TMDB_API_BASE}/search/movie", params=params, timeout=10)
+            if r.status_code == 429:
+                time.sleep(2 ** attempt)
+                continue
+            r.raise_for_status()
+            break
+        except Exception as e:
+            log.warning("TMDB err for '%s' (%s): %s", title, year, e)
+            time.sleep(1)
+    else:
+        return None
+
+    if r is None:
+        return None
+
+    results = r.json().get("results", [])
+    if not results and year:
+        params.pop("year", None)
+        try:
+            r = session.get(f"{TMDB_API_BASE}/search/movie", params=params, timeout=10)
+            r.raise_for_status()
+            results = r.json().get("results", [])
+        except Exception as e:
+            log.warning("TMDB fallback err for '%s': %s", title, e)
+            return None
+
+    if not results:
+        return None
+
+    top = results[0]
+    top_title_norm = norm_title((top.get("title") or "") + " " + (top.get("original_title") or ""))
+    score = fuzz.token_set_ratio(title, top_title_norm)
+    if score >= 85:
+        return {
+            "tmdb_id": top["id"],
+            "tmdb_title": top.get("title"),
+            "tmdb_original_title": top.get("original_title"),
+            "tmdb_release_date": top.get("release_date"),
+            "fuzzy_score": score,
+        }
+    return None
+
+
+def load_known_tmdb_ids(database_url: str) -> set[int]:
+    try:
+        import psycopg2
+    except ImportError:
+        log.warning("psycopg2 not installed — skipping DB diff. Install: pip install psycopg2-binary")
+        return set()
+    conn = psycopg2.connect(database_url)
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT tmdb_id FROM films WHERE tmdb_id IS NOT NULL")
+            return {r[0] for r in cur.fetchall()}
+    finally:
+        conn.close()
+
+
+def load_env_file(path: Path) -> None:
+    """Load KEY=VALUE pairs from a .env file into os.environ (no override)."""
+    if not path.exists():
+        return
+    for raw in path.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        k = k.strip()
+        v = v.strip().strip('"').strip("'")
+        if k and k not in os.environ:
+            os.environ[k] = v
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--cache", type=Path, help="Use existing la_catalog.json (skip crawl)")
+    p.add_argument("--limit-pages", type=int, help="Crawl only N pages (dev)")
+    p.add_argument("--skip-tmdb", action="store_true", help="Skip TMDB matching (catalog only)")
+    p.add_argument("--out-dir", type=Path, default=Path("data/sledujteto"))
+    p.add_argument("-v", "--verbose", action="store_true")
+    args = p.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+
+    load_env_file(Path.cwd() / ".env")
+
+    today = datetime.now().strftime("%Y-%m-%d")
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.cache and args.cache.exists():
+        log.info("Loading cache from %s", args.cache)
+        with open(args.cache) as fp:
+            raw = json.load(fp)
+        catalog = {
+            sid: ({"name": v, "url": f"/file/{sid}/"} if isinstance(v, str) else v)
+            for sid, v in raw.items()
+        }
+    else:
+        log.info("Crawling sledujteto catalog (query='%s', cap=%d pages)",
+                 CATCH_ALL_QUERY, args.limit_pages or LA_PAGES_CAP)
+        catalog = crawl_catalog(args.limit_pages)
+        raw_path = args.out_dir / f"sledujteto-raw-{today}.json"
+        with open(raw_path, "w") as fp:
+            json.dump(catalog, fp, ensure_ascii=False)
+        log.info("Raw dump: %s (%d uploads)", raw_path, len(catalog))
+
+    log.info("Total uploads: %d", len(catalog))
+
+    films_raw: dict[str, dict] = {}
+    drop_reasons: Counter = Counter()
+    for sid, f in catalog.items():
+        name = f.get("name", "")
+        if is_series(name):
+            drop_reasons["series"] += 1
+            continue
+        ok, reason = is_film_duration(f.get("duration") or f.get("movie_duration"))
+        if not ok:
+            drop_reasons[f"duration_{reason}"] += 1
+            continue
+        drop_reasons[f"kept_duration_{reason}"] += 1
+        films_raw[sid] = f
+    log.info("Catalog: %d → films: %d. Drop reasons: %s",
+             len(catalog), len(films_raw), dict(drop_reasons))
+
+    groups: dict[tuple, list[str]] = {}
+    for sid, f in films_raw.items():
+        name = f.get("name", "")
+        key = (norm_title(name), extract_year(name))
+        groups.setdefault(key, []).append(sid)
+    log.info("Unique films after dedup: %d", len(groups))
+
+    api_key = os.environ.get("TMDB_API_KEY", "").strip()
+    matched: list[dict] = []
+    unmatched: list[dict] = []
+
+    if args.skip_tmdb or not api_key:
+        if not api_key and not args.skip_tmdb:
+            log.warning("TMDB_API_KEY not set — exporting without TMDB match")
+        for (title, year), slug_ids in groups.items():
+            unmatched.append({
+                "norm_title": title,
+                "year": year,
+                "upload_count": len(slug_ids),
+                "sample_slug_id": slug_ids[0],
+                "sample_name": films_raw[slug_ids[0]].get("name", ""),
+            })
+    else:
+        tmdb_session = requests.Session()
+        for i, ((title, year), slug_ids) in enumerate(groups.items(), 1):
+            if not title:
+                continue
+            hit = tmdb_search(title, year, api_key, tmdb_session)
+            sample = films_raw[slug_ids[0]]
+            if hit:
+                matched.append({
+                    "tmdb_id": hit["tmdb_id"],
+                    "tmdb_title": hit["tmdb_title"],
+                    "tmdb_original_title": hit["tmdb_original_title"],
+                    "tmdb_release_date": hit["tmdb_release_date"],
+                    "fuzzy_score": hit["fuzzy_score"],
+                    "norm_title_query": title,
+                    "year_query": year,
+                    "sledujteto_slug_ids": slug_ids,
+                    "sledujteto_upload_names": [films_raw[s].get("name", "") for s in slug_ids],
+                    "sample_filesize": sample.get("filesize"),
+                    "sample_duration": sample.get("duration"),
+                    "sample_resolution": sample.get("resolution"),
+                })
+            else:
+                unmatched.append({
+                    "norm_title": title,
+                    "year": year,
+                    "upload_count": len(slug_ids),
+                    "sample_slug_id": slug_ids[0],
+                    "sample_name": sample.get("name", ""),
+                })
+            if i % 500 == 0:
+                log.info("TMDB progress: %d/%d (matched=%d, unmatched=%d)",
+                         i, len(groups), len(matched), len(unmatched))
+            time.sleep(TMDB_RATE_S)
+
+    matched_path = args.out_dir / f"sledujteto-films-matched-{today}.jsonl"
+    with open(matched_path, "w") as fp:
+        for rec in matched:
+            fp.write(json.dumps(rec, ensure_ascii=False) + "\n")
+
+    unmatched_path = args.out_dir / f"sledujteto-films-unmatched-{today}.csv"
+    with open(unmatched_path, "w", newline="") as fp:
+        w = csv.DictWriter(fp, fieldnames=["norm_title", "year", "upload_count",
+                                            "sample_slug_id", "sample_name"])
+        w.writeheader()
+        w.writerows(unmatched)
+
+    stats = {
+        "total_uploads": len(catalog),
+        "films_after_series_and_duration_filter": len(films_raw),
+        "unique_films_after_dedup": len(groups),
+        "tmdb_matched": len(matched),
+        "unmatched": len(unmatched),
+        "matched_pct": round(100 * len(matched) / max(len(groups), 1), 2),
+        "with_year": sum(1 for (_, y) in groups if y),
+        "without_year": sum(1 for (_, y) in groups if not y),
+        "drop_reasons": dict(drop_reasons),
+        "film_duration_range_min": [FILM_DURATION_MIN, FILM_DURATION_MAX],
+        "crawled_at": datetime.now().isoformat(),
+    }
+    stats_path = args.out_dir / f"sledujteto-films-stats-{today}.json"
+    with open(stats_path, "w") as fp:
+        json.dump(stats, fp, indent=2, ensure_ascii=False)
+    log.info("Stats: %s", json.dumps(stats, ensure_ascii=False))
+
+    db_url = os.environ.get("DATABASE_URL", "").strip()
+    if db_url and matched:
+        try:
+            known = load_known_tmdb_ids(db_url)
+            log.info("DB contains %d film tmdb_ids", len(known))
+            new = [m for m in matched if m["tmdb_id"] not in known]
+            cand_path = args.out_dir / f"sledujteto-films-new-candidates-{today}.csv"
+            with open(cand_path, "w", newline="") as fp:
+                w = csv.DictWriter(fp, fieldnames=[
+                    "tmdb_id", "tmdb_title", "tmdb_release_date",
+                    "sledujteto_upload_count", "sample_slug_id", "sample_name",
+                ])
+                w.writeheader()
+                for m in new:
+                    w.writerow({
+                        "tmdb_id": m["tmdb_id"],
+                        "tmdb_title": m["tmdb_title"],
+                        "tmdb_release_date": m["tmdb_release_date"],
+                        "sledujteto_upload_count": len(m["sledujteto_slug_ids"]),
+                        "sample_slug_id": m["sledujteto_slug_ids"][0],
+                        "sample_name": m["sledujteto_upload_names"][0],
+                    })
+            log.info("NEW CANDIDATES (not in DB): %d → %s", len(new), cand_path)
+        except Exception as e:
+            log.error("DB diff failed: %s", e)
+
+    log.info("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sledujteto-unmatched-viewer.html
+++ b/scripts/sledujteto-unmatched-viewer.html
@@ -31,7 +31,7 @@
   .stats b { color: var(--text); }
   main { padding: 0 20px 20px; }
   table { width: 100%; border-collapse: collapse; margin-top: 12px; }
-  th { text-align: left; padding: 8px 10px; background: var(--panel); border-bottom: 2px solid var(--border); cursor: pointer; user-select: none; font-size: 12px; text-transform: uppercase; letter-spacing: 0.5px; color: var(--muted); position: sticky; top: 0; }
+  th { text-align: left; padding: 8px 10px; background: var(--panel); border-bottom: 2px solid var(--border); cursor: pointer; user-select: none; font-size: 12px; text-transform: uppercase; letter-spacing: 0.5px; color: var(--muted); }
   th:hover { color: var(--text); }
   th .sort-arrow { display: inline-block; width: 10px; color: var(--accent); }
   td { padding: 8px 10px; border-bottom: 1px solid var(--border); vertical-align: top; }
@@ -170,7 +170,11 @@
       if (!r.ok) throw new Error(`HTTP ${r.status} ${r.statusText}`);
       const text = await r.text();
       const rows = parseCsv(text);
+      if (!rows.length) throw new Error("CSV je prázdný");
       const header = rows.shift();
+      const required = ["norm_title", "year", "upload_count", "sample_slug_id", "sample_name"];
+      const missing = required.filter(c => !header.includes(c));
+      if (missing.length) throw new Error(`CSV nemá sloupce: ${missing.join(", ")}`);
       const iTitle = header.indexOf("norm_title");
       const iYear = header.indexOf("year");
       const iCount = header.indexOf("upload_count");

--- a/scripts/sledujteto-unmatched-viewer.html
+++ b/scripts/sledujteto-unmatched-viewer.html
@@ -1,0 +1,329 @@
+<!DOCTYPE html>
+<html lang="cs">
+<head>
+<meta charset="utf-8">
+<title>sledujteto — nespárované filmy (issue #598)</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="icon" href="data:,">
+<style>
+  :root {
+    color-scheme: light dark;
+    --bg: #0f1117;
+    --panel: #171923;
+    --border: #2a2e3d;
+    --text: #e4e6ee;
+    --muted: #8d94a7;
+    --accent: #4a9eff;
+    --accent-hover: #6bb0ff;
+    --warn: #ffb347;
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; font: 14px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: var(--bg); color: var(--text); }
+  header { padding: 12px 20px; background: var(--panel); border-bottom: 1px solid var(--border); position: sticky; top: 0; z-index: 10; }
+  h1 { margin: 0; font-size: 16px; font-weight: 600; display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+  h1 .meta { font-size: 12px; color: var(--muted); font-weight: 400; }
+  .controls { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 10px; align-items: center; }
+  .controls label { color: var(--muted); font-size: 12px; display: flex; align-items: center; gap: 4px; }
+  .controls input, .controls select { background: var(--bg); border: 1px solid var(--border); color: var(--text); padding: 5px 8px; border-radius: 4px; font-size: 13px; }
+  .controls input[type="search"] { width: 280px; }
+  .controls input[type="number"] { width: 70px; }
+  .stats { color: var(--muted); font-size: 12px; margin-left: auto; }
+  .stats b { color: var(--text); }
+  main { padding: 0 20px 20px; }
+  table { width: 100%; border-collapse: collapse; margin-top: 12px; }
+  th { text-align: left; padding: 8px 10px; background: var(--panel); border-bottom: 2px solid var(--border); cursor: pointer; user-select: none; font-size: 12px; text-transform: uppercase; letter-spacing: 0.5px; color: var(--muted); position: sticky; top: 0; }
+  th:hover { color: var(--text); }
+  th .sort-arrow { display: inline-block; width: 10px; color: var(--accent); }
+  td { padding: 8px 10px; border-bottom: 1px solid var(--border); vertical-align: top; }
+  tr:hover td { background: var(--panel); }
+  td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  td.title { font-weight: 500; }
+  td.sample { color: var(--muted); font-size: 13px; }
+  td.actions { white-space: nowrap; }
+  a.btn { display: inline-block; padding: 3px 8px; margin-right: 4px; background: var(--bg); border: 1px solid var(--border); border-radius: 3px; color: var(--accent); text-decoration: none; font-size: 12px; }
+  a.btn:hover { background: var(--accent); color: #000; border-color: var(--accent); }
+  a.btn.primary { background: var(--accent); color: #000; border-color: var(--accent); }
+  a.btn.primary:hover { background: var(--accent-hover); }
+  .pagination { display: flex; gap: 6px; align-items: center; margin-top: 16px; justify-content: center; }
+  .pagination button { background: var(--panel); border: 1px solid var(--border); color: var(--text); padding: 5px 10px; border-radius: 4px; cursor: pointer; font-size: 13px; }
+  .pagination button:hover:not(:disabled) { background: var(--accent); color: #000; border-color: var(--accent); }
+  .pagination button:disabled { opacity: 0.4; cursor: not-allowed; }
+  .pagination .page-info { color: var(--muted); font-size: 13px; padding: 0 8px; }
+  .empty { text-align: center; padding: 40px 0; color: var(--muted); }
+  .empty.error { color: var(--warn); }
+  code { background: var(--panel); padding: 1px 4px; border-radius: 3px; font-size: 12px; }
+</style>
+</head>
+<body>
+
+<header>
+  <h1>
+    sledujteto — nespárované filmy
+    <span class="meta" id="source-info">načítám…</span>
+  </h1>
+  <div class="controls">
+    <label>
+      datum:
+      <input type="date" id="date-picker">
+    </label>
+    <label>
+      hledat:
+      <input type="search" id="search" placeholder="název nebo sample…">
+    </label>
+    <label>
+      rok:
+      <input type="number" id="year-min" placeholder="od" min="1900" max="2100">
+      –
+      <input type="number" id="year-max" placeholder="do" min="1900" max="2100">
+    </label>
+    <label>
+      bez roku:
+      <select id="year-missing">
+        <option value="">zobrazit</option>
+        <option value="only">jen bez roku</option>
+        <option value="hide">skrýt</option>
+      </select>
+    </label>
+    <label>
+      per page:
+      <select id="page-size">
+        <option>25</option>
+        <option selected>50</option>
+        <option>100</option>
+        <option>250</option>
+      </select>
+    </label>
+    <span class="stats" id="stats"></span>
+  </div>
+</header>
+
+<main>
+  <table>
+    <thead>
+      <tr>
+        <th data-sort="norm_title">Název <span class="sort-arrow"></span></th>
+        <th data-sort="sample_name">Sample upload <span class="sort-arrow"></span></th>
+        <th data-sort="year">Rok <span class="sort-arrow"></span></th>
+        <th data-sort="upload_count" class="num">Uploadů <span class="sort-arrow"></span></th>
+        <th>Odkazy</th>
+      </tr>
+    </thead>
+    <tbody id="tbody"></tbody>
+  </table>
+  <div id="empty" class="empty" style="display:none"></div>
+  <div class="pagination" id="pagination"></div>
+</main>
+
+<script>
+(function() {
+  const state = {
+    rows: [],
+    filtered: [],
+    sort: { col: "upload_count", dir: "desc" },
+    page: 1,
+    pageSize: 50,
+    search: "",
+    yearMin: null,
+    yearMax: null,
+    yearMissing: "",
+    date: new Date().toISOString().slice(0, 10),
+  };
+
+  const $ = (id) => document.getElementById(id);
+
+  function todayCsvPath(date) {
+    return `../data/sledujteto/sledujteto-films-unmatched-${date}.csv`;
+  }
+
+  // RFC 4180 CSV parser — handles quoted fields, embedded commas, and escaped quotes.
+  function parseCsv(text) {
+    const out = [];
+    let row = [];
+    let cur = "";
+    let quoted = false;
+    for (let i = 0; i < text.length; i++) {
+      const c = text[i];
+      if (quoted) {
+        if (c === '"') {
+          if (text[i + 1] === '"') { cur += '"'; i++; }
+          else quoted = false;
+        } else cur += c;
+      } else {
+        if (c === '"') quoted = true;
+        else if (c === ',') { row.push(cur); cur = ""; }
+        else if (c === '\n') { row.push(cur); out.push(row); row = []; cur = ""; }
+        else if (c === '\r') { /* skip */ }
+        else cur += c;
+      }
+    }
+    if (cur.length || row.length) { row.push(cur); out.push(row); }
+    return out;
+  }
+
+  async function loadCsv(date) {
+    state.date = date;
+    $("source-info").textContent = `načítám ${date}…`;
+    $("source-info").style.color = "";
+    try {
+      const url = todayCsvPath(date);
+      const r = await fetch(url, { cache: "no-store" });
+      if (!r.ok) throw new Error(`HTTP ${r.status} ${r.statusText}`);
+      const text = await r.text();
+      const rows = parseCsv(text);
+      const header = rows.shift();
+      const iTitle = header.indexOf("norm_title");
+      const iYear = header.indexOf("year");
+      const iCount = header.indexOf("upload_count");
+      const iSlug = header.indexOf("sample_slug_id");
+      const iName = header.indexOf("sample_name");
+      state.rows = rows
+        .filter(r => r.length >= header.length && (r[iTitle] || r[iName]))
+        .map(r => ({
+          norm_title: r[iTitle] || "",
+          year: r[iYear] ? parseInt(r[iYear], 10) : null,
+          upload_count: parseInt(r[iCount] || "1", 10),
+          sample_slug_id: r[iSlug] || "",
+          sample_name: r[iName] || "",
+        }));
+      $("source-info").textContent = `zdroj: ${url} — ${state.rows.length.toLocaleString("cs-CZ")} záznamů`;
+      state.page = 1;
+      render();
+    } catch (e) {
+      state.rows = [];
+      render();
+      $("source-info").textContent = `CSV nenačteno: ${e.message}`;
+      $("source-info").style.color = "var(--warn)";
+      $("empty").style.display = "block";
+      $("empty").className = "empty error";
+      $("empty").innerHTML = `Soubor <code>${todayCsvPath(date)}</code> se nepodařilo načíst. Běží HTTP server z rootu repa? (<code>python3 -m http.server 8000</code>)`;
+    }
+  }
+
+  function applyFilters() {
+    const q = state.search.toLowerCase().trim();
+    const { yearMin, yearMax, yearMissing } = state;
+    state.filtered = state.rows.filter(r => {
+      if (q) {
+        const hay = (r.norm_title + " " + r.sample_name).toLowerCase();
+        if (!hay.includes(q)) return false;
+      }
+      if (yearMissing === "only" && r.year !== null) return false;
+      if (yearMissing === "hide" && r.year === null) return false;
+      if (yearMin !== null && (r.year === null || r.year < yearMin)) return false;
+      if (yearMax !== null && (r.year === null || r.year > yearMax)) return false;
+      return true;
+    });
+    const { col, dir } = state.sort;
+    const mul = dir === "asc" ? 1 : -1;
+    state.filtered.sort((a, b) => {
+      const va = a[col], vb = b[col];
+      if (va === vb) return 0;
+      if (va === null || va === undefined) return 1;
+      if (vb === null || vb === undefined) return -1;
+      return (va > vb ? 1 : -1) * mul;
+    });
+  }
+
+  function render() {
+    applyFilters();
+    const total = state.rows.length;
+    const filt = state.filtered.length;
+    const pages = Math.max(1, Math.ceil(filt / state.pageSize));
+    if (state.page > pages) state.page = pages;
+    const start = (state.page - 1) * state.pageSize;
+    const slice = state.filtered.slice(start, start + state.pageSize);
+
+    $("stats").innerHTML = `zobrazeno <b>${slice.length}</b> z <b>${filt.toLocaleString("cs-CZ")}</b> filtrovaných (celkem <b>${total.toLocaleString("cs-CZ")}</b>)`;
+
+    const tbody = $("tbody");
+    if (!slice.length) {
+      tbody.innerHTML = "";
+      $("empty").style.display = "block";
+      $("empty").className = "empty";
+      $("empty").textContent = total ? "Žádné záznamy neodpovídají filtru." : "Nenačtena žádná data.";
+    } else {
+      $("empty").style.display = "none";
+      tbody.innerHTML = slice.map(r => {
+        const year = r.year || "";
+        const title = escapeHtml(r.norm_title);
+        const sample = escapeHtml(r.sample_name);
+        const slug = encodeURIComponent(r.sample_slug_id);
+        const tmdbQuery = encodeURIComponent(r.norm_title + (r.year ? " " + r.year : ""));
+        const sledUrl = `https://www.sledujteto.cz/file/${slug}/`;
+        const tmdbUrl = `https://www.themoviedb.org/search?query=${tmdbQuery}`;
+        return `<tr>
+          <td class="title">${title}</td>
+          <td class="sample">${sample}</td>
+          <td class="num">${year}</td>
+          <td class="num">${r.upload_count}</td>
+          <td class="actions">
+            <a class="btn primary" href="${sledUrl}" target="_blank" rel="noopener">sledujteto ↗</a>
+            <a class="btn" href="${tmdbUrl}" target="_blank" rel="noopener">TMDB ↗</a>
+          </td>
+        </tr>`;
+      }).join("");
+    }
+
+    renderPagination(pages);
+    renderSortArrows();
+  }
+
+  function renderPagination(pages) {
+    const el = $("pagination");
+    const p = state.page;
+    const btn = (label, pg, disabled = false, active = false) =>
+      `<button data-page="${pg}" ${disabled ? "disabled" : ""} ${active ? "style=\"background:var(--accent);color:#000;border-color:var(--accent)\"" : ""}>${label}</button>`;
+    const nums = [];
+    for (let i = Math.max(1, p - 2); i <= Math.min(pages, p + 2); i++) nums.push(i);
+    let html = "";
+    html += btn("«", 1, p === 1);
+    html += btn("‹", p - 1, p === 1);
+    if (nums[0] > 1) html += `<span class="page-info">…</span>`;
+    for (const n of nums) html += btn(String(n), n, false, n === p);
+    if (nums[nums.length - 1] < pages) html += `<span class="page-info">…</span>`;
+    html += btn("›", p + 1, p >= pages);
+    html += btn("»", pages, p >= pages);
+    html += `<span class="page-info">strana ${p} z ${pages}</span>`;
+    el.innerHTML = html;
+    el.querySelectorAll("button").forEach(b => b.addEventListener("click", () => {
+      const pg = parseInt(b.dataset.page, 10);
+      if (!Number.isNaN(pg)) { state.page = pg; render(); window.scrollTo(0, 0); }
+    }));
+  }
+
+  function renderSortArrows() {
+    document.querySelectorAll("th[data-sort]").forEach(th => {
+      const arrow = th.querySelector(".sort-arrow");
+      if (th.dataset.sort === state.sort.col) arrow.textContent = state.sort.dir === "asc" ? "▲" : "▼";
+      else arrow.textContent = "";
+    });
+  }
+
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, c => ({
+      "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;",
+    }[c]));
+  }
+
+  // Wire controls
+  $("date-picker").value = state.date;
+  $("date-picker").addEventListener("change", e => loadCsv(e.target.value));
+  $("search").addEventListener("input", e => { state.search = e.target.value; state.page = 1; render(); });
+  $("year-min").addEventListener("input", e => { state.yearMin = e.target.value ? parseInt(e.target.value, 10) : null; state.page = 1; render(); });
+  $("year-max").addEventListener("input", e => { state.yearMax = e.target.value ? parseInt(e.target.value, 10) : null; state.page = 1; render(); });
+  $("year-missing").addEventListener("change", e => { state.yearMissing = e.target.value; state.page = 1; render(); });
+  $("page-size").addEventListener("change", e => { state.pageSize = parseInt(e.target.value, 10); state.page = 1; render(); });
+  document.querySelectorAll("th[data-sort]").forEach(th => {
+    th.addEventListener("click", () => {
+      const col = th.dataset.sort;
+      if (state.sort.col === col) state.sort.dir = state.sort.dir === "asc" ? "desc" : "asc";
+      else { state.sort.col = col; state.sort.dir = col === "upload_count" ? "desc" : "asc"; }
+      render();
+    });
+  });
+
+  loadCsv(state.date);
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
<!-- claude-session: 9c42f99e-d1ab-4b4c-9d4d-e7d09129237a -->

Closes #598
Part of #542

## Summary
Phase 1 MVP of sledujteto.cz integration. Self-contained Python crawler that produces a TMDB-mapped list of films, plus a standalone HTML viewer for browsing the unmatched residue.

- `scripts/sledujteto-films-to-tmdb.py` — crawl sledujteto `la` catch-all search (or reuse a cached dump), filter series + out-of-range durations (60–240 min), dedup by `(norm_title, year)`, match against TMDB with `rapidfuzz token_set_ratio ≥ 85`, emit `matched.jsonl` + `unmatched.csv` + `stats.json`; when `DATABASE_URL` is set, additionally emit a diff CSV of films not yet in our `films` table.
- `scripts/sledujteto-unmatched-viewer.html` — standalone dark-themed viewer page with search, year-range filter, column sort, pagination, and direct links to the sledujteto upload page and TMDB manual search.
- `.gitignore` — add `data/sledujteto/` (generated artefacts, ~20 MB).

Runs from home CZ IP directly — no proxy (#543) required for this phase.

## Verification

### Dev run (50 pages, no TMDB) ✅
- 2 474 uploads → 1 322 films → 1 259 unique after dedup
- Drop reasons: `series 1 041, duration_too_short 108, duration_too_long 3, kept_duration_ok 1 301, kept_duration_unknown 21`
- Completes in ~30 s

### Full run (cache `/tmp/la_catalog.json`, 51 320 slug-IDs) — in progress
- After dedup: **29 717 unique films**
- TMDB pace ~250 ms/item, preliminary match rate ~45 %
- Projected ~13 400 matched (AC ≥ 13 000)
- ETA ~1 h 30 min; will update this PR body with final stats + `new-candidates.csv` row count once done.

### Viewer — Playwright-verified (local)
- Loads CSV by date from `data/sledujteto/sledujteto-films-unmatched-YYYY-MM-DD.csv`
- Renders dev-run dataset (1 259 rows, 26 pages × 50 per page)
- **0 console errors / 0 warnings**
- Interactions tested: live search (`avatar` → 3/1 259), year range, `bez roku` dropdown, per-page selector, column sort, pagination
- External links verified: `https://www.sledujteto.cz/file/{slug}/` and `https://www.themoviedb.org/search?query=…`

## How to run
```bash
# Crawler — from home CZ IP
python3 scripts/sledujteto-films-to-tmdb.py --cache /tmp/la_catalog.json

# Viewer — serve from repo root
python3 -m http.server 8766 --bind 127.0.0.1
# open http://127.0.0.1:8766/scripts/sledujteto-unmatched-viewer.html
```

## Test plan
- [x] Dev run (`--limit-pages 50 --skip-tmdb`) produces stats + unmatched CSV
- [x] Viewer renders dev CSV, 0 console errors
- [x] Search, sort, year filter, pagination, per-page all functional
- [x] Sledujteto + TMDB links open correctly
- [ ] Full run completes with `matched_pct ≥ 60 %` (in progress)
- [ ] Viewer renders full ~15 k unmatched rows after full run lands