### PR TITLE
feat(sledujteto): thread SLEDUJTETO_PROXY_URL/KEY through search fallback (#543)

### DIFF
--- a/cr-web/src/config.rs
+++ b/cr-web/src/config.rs
@@ -56,8 +56,16 @@ pub struct AppConfig {
     /// Optional sledujteto-specific proxy (SledujteToCzProxy on aspone) for
     /// calls that upstream rate-limits by ASN (search API). Separate from
     /// `cz_proxy` by design — different rate limits, different uploader
-    /// ecosystem, different incident blast radius. `None` when the env vars
-    /// aren't set; handlers then skip the aspone fallback path.
+    /// ecosystem, different incident blast radius.
+    ///
+    /// Convention (differs from `cz_proxy`): `SLEDUJTETO_PROXY_URL` is the
+    /// proxy **site root** (e.g. `http://sledujteto.aspfree.cz`), *not* a
+    /// specific `.ashx` endpoint URL. Handlers append the endpoint name
+    /// themselves (`/Search.ashx`, `/Hash.ashx`, …) because the proxy exposes
+    /// multiple endpoints. A trailing slash on the base URL is tolerated.
+    ///
+    /// `None` when the env vars aren't set; handlers then skip the aspone
+    /// fallback path.
     pub sledujteto_proxy: Option<CzProxyConfig>,
     /// Hard gate on the sledujteto.cz POC surface (issue #551): the
     /// `/admin/test-sledujteto/` diagnostic page and the `/api/sledujteto/*`

--- a/cr-web/src/config.rs
+++ b/cr-web/src/config.rs
@@ -53,6 +53,12 @@ pub struct AppConfig {
     /// Optional CZ-hosted proxy for scraping geo-blocked sources (prehraj.to,
     /// SK Torrent). None if unconfigured.
     pub cz_proxy: Option<CzProxyConfig>,
+    /// Optional sledujteto-specific proxy (SledujteToCzProxy on aspone) for
+    /// calls that upstream rate-limits by ASN (search API). Separate from
+    /// `cz_proxy` by design — different rate limits, different uploader
+    /// ecosystem, different incident blast radius. `None` when the env vars
+    /// aren't set; handlers then skip the aspone fallback path.
+    pub sledujteto_proxy: Option<CzProxyConfig>,
     /// Hard gate on the sledujteto.cz POC surface (issue #551): the
     /// `/admin/test-sledujteto/` diagnostic page and the `/api/sledujteto/*`
     /// endpoints it consumes. Both register only when
@@ -133,6 +139,18 @@ impl AppConfig {
             _ => None,
         };
 
+        let sledujteto_proxy = match (
+            std::env::var("SLEDUJTETO_PROXY_URL")
+                .ok()
+                .filter(|s| !s.is_empty()),
+            std::env::var("SLEDUJTETO_PROXY_KEY")
+                .ok()
+                .filter(|s| !s.is_empty()),
+        ) {
+            (Some(url), Some(key)) => Some(CzProxyConfig { url, key }),
+            _ => None,
+        };
+
         let prehrajto_sources_from_db = matches!(
             std::env::var("PREHRAJTO_SOURCES_FROM_DB").as_deref(),
             Ok("1")
@@ -165,6 +183,7 @@ impl AppConfig {
             admin_import_run_enabled,
             admin_cache_purge_enabled,
             cz_proxy,
+            sledujteto_proxy,
             prehrajto_sources_from_db,
             sledujteto_poc_enabled,
             cf_cache_purge,

--- a/cr-web/src/handlers/movies_api/sledujteto.rs
+++ b/cr-web/src/handlers/movies_api/sledujteto.rs
@@ -7,9 +7,11 @@
 //!   - `GET /api/web/videos` (search) rate-limits known datacenter ASNs to
 //!     an empty result set — Hetzner and Oracle currently get `files: []`,
 //!     aspone AS43541 is allowed through. We fall back to the SledujteToCzProxy
-//!     mirror (`SLEDUJTETO_PROXY_URL` + key, default `sledujteto.aspfree.cz`)
-//!     on an empty direct response. The fallback is skipped silently when the
-//!     proxy env vars aren't configured — useful in local dev.
+//!     mirror (`SLEDUJTETO_PROXY_URL` + `SLEDUJTETO_PROXY_KEY`; no built-in
+//!     default, prod currently points at `sledujteto.aspfree.cz`). Behaviour
+//!     when the proxy env vars aren't configured: empty-direct returns an
+//!     empty result silently (useful in local dev), direct-failure returns
+//!     an explicit error so callers can tell why search broke.
 //!   - Playback hostname varies per upload: `www.sledujteto.cz/player/...`
 //!     serves 206 Partial Content from Hetzner; `data{N}.sledujteto.cz/...`
 //!     responds with a redirect to invalid-file for datacenter ASNs (and
@@ -149,9 +151,11 @@ pub async fn sledujteto_search(
 
     let direct = fetch_sledujteto_search(&state.http_client, &direct_url).await;
 
-    // Build the aspone fallback URL lazily — only when both the direct call
-    // comes back unhelpful AND the proxy is configured. Keeps local dev from
-    // firing blank requests at the aspone mirror.
+    // Build the aspone fallback URL whenever the proxy is configured so both
+    // the empty-direct and direct-error branches below have it ready. `None`
+    // when no proxy is configured — local dev then skips the fallback entirely.
+    // `SLEDUJTETO_PROXY_URL` is the site root; we append `/Search.ashx` here
+    // (IIS is case-insensitive, but we match the file casing we actually ship).
     let fallback_url = state.config.sledujteto_proxy.as_ref().map(|proxy| {
         format!(
             "{}/Search.ashx?q={}&key={}",
@@ -199,6 +203,8 @@ pub async fn sledujteto_search(
                 return Json(SearchResponse {
                     success: false,
                     movies: vec![],
+                    // `e` is from the upstream www.sledujteto.cz URL (no
+                    // secrets), so echoing it to the client is fine.
                     error: Some(format!("direct={e}; no proxy configured")),
                 });
             };
@@ -208,11 +214,22 @@ pub async fn sledujteto_search(
                     movies,
                     error: None,
                 }),
-                Err(fallback_err) => Json(SearchResponse {
-                    success: false,
-                    movies: vec![],
-                    error: Some(format!("direct={e}; fallback={fallback_err}")),
-                }),
+                Err(fallback_err) => {
+                    // Log full detail server-side — fallback_err can contain
+                    // the proxy URL with `key=…` because `reqwest::Error`'s
+                    // Display includes the request URL on transport failures.
+                    tracing::warn!(
+                        "sledujteto search fallback (aspone) failed after direct failure: direct={e}; fallback={fallback_err}"
+                    );
+                    Json(SearchResponse {
+                        success: false,
+                        movies: vec![],
+                        // Client-facing error is intentionally sanitized to
+                        // avoid leaking `SLEDUJTETO_PROXY_KEY`. Operators read
+                        // the full reason from the log line above.
+                        error: Some("upstream search failed and proxy fallback unavailable".into()),
+                    })
+                }
             }
         }
     }

--- a/cr-web/src/handlers/movies_api/sledujteto.rs
+++ b/cr-web/src/handlers/movies_api/sledujteto.rs
@@ -6,8 +6,10 @@
 //!     including Hetzner AS24940 — no CZ proxy needed.
 //!   - `GET /api/web/videos` (search) rate-limits known datacenter ASNs to
 //!     an empty result set — Hetzner and Oracle currently get `files: []`,
-//!     aspone AS43541 is allowed through. We fall back to an aspone mirror
-//!     (`http://sledujteto.aspfree.cz/search.ashx`) on an empty direct response.
+//!     aspone AS43541 is allowed through. We fall back to the SledujteToCzProxy
+//!     mirror (`SLEDUJTETO_PROXY_URL` + key, default `sledujteto.aspfree.cz`)
+//!     on an empty direct response. The fallback is skipped silently when the
+//!     proxy env vars aren't configured — useful in local dev.
 //!   - Playback hostname varies per upload: `www.sledujteto.cz/player/...`
 //!     serves 206 Partial Content from Hetzner; `data{N}.sledujteto.cz/...`
 //!     responds with a redirect to invalid-file for datacenter ASNs (and
@@ -147,6 +149,18 @@ pub async fn sledujteto_search(
 
     let direct = fetch_sledujteto_search(&state.http_client, &direct_url).await;
 
+    // Build the aspone fallback URL lazily — only when both the direct call
+    // comes back unhelpful AND the proxy is configured. Keeps local dev from
+    // firing blank requests at the aspone mirror.
+    let fallback_url = state.config.sledujteto_proxy.as_ref().map(|proxy| {
+        format!(
+            "{}/Search.ashx?q={}&key={}",
+            proxy.url.trim_end_matches('/'),
+            urlencoding::encode(q),
+            urlencoding::encode(&proxy.key),
+        )
+    });
+
     match direct {
         Ok(movies) if !movies.is_empty() => Json(SearchResponse {
             success: true,
@@ -155,12 +169,15 @@ pub async fn sledujteto_search(
         }),
         Ok(_empty) => {
             // Empty result might be a real zero-hit query or a silent ASN
-            // blocklist — the caller can't tell, so try aspone.
-            let fallback_url = format!(
-                "http://sledujteto.aspfree.cz/search.ashx?q={}",
-                urlencoding::encode(q)
-            );
-            match fetch_sledujteto_search(&state.http_client, &fallback_url).await {
+            // blocklist — the caller can't tell, so try the aspone mirror.
+            let Some(url) = fallback_url else {
+                return Json(SearchResponse {
+                    success: true,
+                    movies: vec![],
+                    error: None,
+                });
+            };
+            match fetch_sledujteto_search(&state.http_client, &url).await {
                 Ok(movies) => Json(SearchResponse {
                     success: true,
                     movies,
@@ -178,11 +195,14 @@ pub async fn sledujteto_search(
         }
         Err(e) => {
             tracing::warn!("sledujteto search direct failed: {e}");
-            let fallback_url = format!(
-                "http://sledujteto.aspfree.cz/search.ashx?q={}",
-                urlencoding::encode(q)
-            );
-            match fetch_sledujteto_search(&state.http_client, &fallback_url).await {
+            let Some(url) = fallback_url else {
+                return Json(SearchResponse {
+                    success: false,
+                    movies: vec![],
+                    error: Some(format!("direct={e}; no proxy configured")),
+                });
+            };
+            match fetch_sledujteto_search(&state.http_client, &url).await {
                 Ok(movies) => Json(SearchResponse {
                     success: true,
                     movies,


### PR DESCRIPTION
<!-- claude-session: 9c42f99e-d1ab-4b4c-9d4d-e7d09129237a -->

Closes #543

## Summary
The SledujteToCzProxy aspone endpoints now enforce `?key=<shared-secret>` (issue #543 acceptance criterion \"volání bez správného `key` → 401/403\"). This PR wires the key into cr-web's search fallback path:

- New optional `SLEDUJTETO_PROXY_URL` + `SLEDUJTETO_PROXY_KEY` env vars, parsed into an `Option<CzProxyConfig>` on boot.
- `sledujteto_search` builds the fallback URL lazily (skips when unset in dev), sends the key, and returns an explicit error when direct-fails + no-proxy — no more silent 0-movies.
- Docstring updated to point at `SLEDUJTETO_PROXY_URL` instead of the hardcoded aspone hostname.

Paired with the new repo `Olbrasoft/SledujteToCzProxy` (initial commit separate) and a `docker-compose.yml` env passthrough on prod.

## Context
Parent epic: #542 (sledujteto as third film source). This is Etapa 1 from the gradual implementation plan — proxy + handler. Etapa 2 (#544 DB migration) is next.

## Test plan

- [x] `cargo check -p cr-web` — clean
- [x] Unit tests — pre-existing, unchanged
- [x] Deployed to prod (`cargo zigbuild` → scp → `docker compose up -d web`)
- [x] `/api/sledujteto/search?q=matrix` → **22 items** (was `movies:[]` before the key-forwarding fix)
- [x] `/api/sledujteto/resolve?id=15546` → 200 + `www.sledujteto.cz/player/…` URL
- [x] Playwright: `/admin/test-sledujteto/` → click Matrix 1 → video plays (`currentTime=14.3s`, `duration=2h9min`, `readyState=4`, 0 console errors)
- [x] Aspone guard verified: `curl http://sledujteto.aspfree.cz/Hash.ashx?id=15546` → `403 {"error":"forbidden"}`; with key → 200 + `cdn:"www"`