### PR TITLE
feat(sledujteto): migration 057 — film_sledujteto_uploads + films rollups (#544)

### DIFF
--- a/cr-infra/migrations/20260528_057_film_sledujteto_uploads.sql
+++ b/cr-infra/migrations/20260528_057_film_sledujteto_uploads.sql
@@ -2,9 +2,9 @@
 -- can have many uploads (observed in pilot: 1-5× the same film) with different
 -- language markers, resolutions, and CDN hosts. Import source is a
 -- title-first search crawl via the SledujteToCzProxy (issue #545/#597);
--- audio-language is detected separately by whisper on a short sample
--- (scripts/sledujteto-detect-audio.py), because sledujteto title strings
--- frequently miss dubbing hints.
+-- audio-language is detected separately by whisper on a short sample in a
+-- dedicated audio-detection step, because sledujteto title strings frequently
+-- miss dubbing hints.
 --
 -- Serves three consumers (mirrors the prehrajto.cz model in
 -- 20260508_048_film_prehrajto_uploads.sql):
@@ -31,8 +31,8 @@ CREATE TABLE IF NOT EXISTS film_sledujteto_uploads (
     -- rewritten by the uploader.
     file_id          INTEGER     NOT NULL,
     -- Raw title from the uploader — used as the input for language
-    -- classification below (scripts/sledujteto-detect-audio.py combines
-    -- this with a whisper sample of the actual audio track).
+    -- classification below (combined with a whisper sample of the actual
+    -- audio track).
     title            TEXT        NOT NULL,
     duration_sec     INTEGER,
     -- Detected language class. Sledujteto uploads are less disciplined
@@ -58,11 +58,11 @@ CREATE TABLE IF NOT EXISTS film_sledujteto_uploads (
     -- returned an error / missing video_url". The primary-upload picker
     -- skips these; the reconciliation job sweeps them to cross-check
     -- against upstream before permanent delete.
-    is_alive         BOOLEAN     NOT NULL DEFAULT TRUE,
+    is_alive         BOOLEAN     NOT NULL DEFAULT true,
     last_seen        TIMESTAMPTZ,
     last_checked     TIMESTAMPTZ,
-    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
 
     PRIMARY KEY (film_id, file_id),
     CONSTRAINT film_sledujteto_uploads_lang_check CHECK (
@@ -79,18 +79,25 @@ CREATE INDEX IF NOT EXISTS idx_fsu_film_alive
     WHERE is_alive;
 
 -- Secondary: reconciliation job hunts uploads that haven't been seen in a
--- while (WHERE last_seen < NOW() - INTERVAL '30 days'). Index helps this
+-- while (WHERE last_seen < now() - INTERVAL '30 days'). Index helps this
 -- periodic full-table scan stay fast as the table grows.
 CREATE INDEX IF NOT EXISTS idx_fsu_last_seen
     ON film_sledujteto_uploads (last_seen)
     WHERE is_alive;
+
+-- Stream endpoint (/api/movies/stream/sledujteto/<file_id>, #547) looks
+-- uploads up by `file_id` alone; enforce uniqueness so a given upload
+-- can only map to one film and resolution never becomes ambiguous.
+-- Mirrors `uq_fpu_upload_id` in the prehrajto.cz table.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_fsu_file_id
+    ON film_sledujteto_uploads (file_id);
 
 -- Rollup flags and preferred upload per film. Unlike prehraj.to (where CZ
 -- flags were already present from migration #032), sledujteto introduces
 -- the whole column family fresh — both CZ and SK flavors.
 ALTER TABLE films
     ADD COLUMN IF NOT EXISTS sledujteto_primary_file_id INTEGER,
-    ADD COLUMN IF NOT EXISTS sledujteto_has_dub     BOOLEAN NOT NULL DEFAULT FALSE,
-    ADD COLUMN IF NOT EXISTS sledujteto_has_subs    BOOLEAN NOT NULL DEFAULT FALSE,
-    ADD COLUMN IF NOT EXISTS sledujteto_has_sk_dub  BOOLEAN NOT NULL DEFAULT FALSE,
-    ADD COLUMN IF NOT EXISTS sledujteto_has_sk_subs BOOLEAN NOT NULL DEFAULT FALSE;
+    ADD COLUMN IF NOT EXISTS sledujteto_has_dub     BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS sledujteto_has_subs    BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS sledujteto_has_sk_dub  BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS sledujteto_has_sk_subs BOOLEAN NOT NULL DEFAULT false;

--- a/cr-infra/migrations/20260528_057_film_sledujteto_uploads.sql
+++ b/cr-infra/migrations/20260528_057_film_sledujteto_uploads.sql
@@ -1,0 +1,96 @@
+-- Per-upload metadata for every sledujteto.cz video linked to a film. One film
+-- can have many uploads (observed in pilot: 1-5× the same film) with different
+-- language markers, resolutions, and CDN hosts. Import source is a
+-- title-first search crawl via the SledujteToCzProxy (issue #545/#597);
+-- audio-language is detected separately by whisper on a short sample
+-- (scripts/sledujteto-detect-audio.py), because sledujteto title strings
+-- frequently miss dubbing hints.
+--
+-- Serves three consumers (mirrors the prehrajto.cz model in
+-- 20260508_048_film_prehrajto_uploads.sql):
+--   1) Detail-page "Další zdroje" — reads from this table.
+--   2) /api/movies/stream/sledujteto/<file_id> player endpoint — picks the
+--      primary upload and has a deterministic fallback when an upload on
+--      sledujteto.cz disappears.
+--   3) Audio filter on /filmy-a-serialy — aggregated booleans on `films`
+--      (below) are filled as UNION over alive uploads.
+--
+-- Key differences from prehrajto.cz:
+--   a) `file_id` is INT (sledujteto's internal `files.id`), not a hex token.
+--   b) `cdn` tracks www / data{N} / unknown — critical for filtering
+--      playable copies (datacenter ASNs can stream from `www.sledujteto.cz`
+--      but are blocked from `data{N}.sledujteto.cz`, see issue #549).
+
+CREATE TABLE IF NOT EXISTS film_sledujteto_uploads (
+    film_id          INTEGER     NOT NULL REFERENCES films(id) ON DELETE CASCADE,
+    -- Sledujteto internal `files.id` (stable DB key, int). The short URL
+    -- slug visible in the browser (`/file/<slug_id>/<name>.html`) is a
+    -- separate value; we keep `file_id` here because it's what the
+    -- `POST /services/add-file-link` endpoint consumes to mint a playback
+    -- URL, and because it's monotonically stable while slugs can be
+    -- rewritten by the uploader.
+    file_id          INTEGER     NOT NULL,
+    -- Raw title from the uploader — used as the input for language
+    -- classification below (scripts/sledujteto-detect-audio.py combines
+    -- this with a whisper sample of the actual audio track).
+    title            TEXT        NOT NULL,
+    duration_sec     INTEGER,
+    -- Detected language class. Sledujteto uploads are less disciplined
+    -- than prehraj.to in their naming conventions, so this is a merge of
+    -- title-derived hints and whisper audio-detection results.
+    lang_class       TEXT        NOT NULL DEFAULT 'UNKNOWN',
+    -- Resolution hint parsed from the upload metadata (`1920x1080`,
+    -- `1280x720`, `720p`, …). TEXT + no constraint because the shape
+    -- varies by uploader.
+    resolution_hint  TEXT,
+    -- Raw filesize in bytes. Useful for ranking (higher bitrate ≈ better
+    -- quality, tie-breaker against resolution) and for UI display.
+    filesize_bytes   BIGINT,
+    -- CDN host family for this upload's `video_url`:
+    --   'www'      → www.sledujteto.cz — playable from any ASN (Hetzner, Oracle)
+    --   'dataN'    → data{N}.sledujteto.cz — blocked from datacenter ASNs
+    --   'unknown'  → resolve hasn't run yet or returned an unparseable URL
+    -- The import pipeline sets this per upload via the Hash.ashx proxy
+    -- endpoint (which itself parses `video_url` from the add-file-link
+    -- response). See issue #549 for the data{N} routing strategy.
+    cdn              TEXT        NOT NULL DEFAULT 'unknown',
+    -- FALSE means "search crawl no longer finds it" or "add-file-link
+    -- returned an error / missing video_url". The primary-upload picker
+    -- skips these; the reconciliation job sweeps them to cross-check
+    -- against upstream before permanent delete.
+    is_alive         BOOLEAN     NOT NULL DEFAULT TRUE,
+    last_seen        TIMESTAMPTZ,
+    last_checked     TIMESTAMPTZ,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    PRIMARY KEY (film_id, file_id),
+    CONSTRAINT film_sledujteto_uploads_lang_check CHECK (
+        lang_class IN ('CZ_DUB', 'CZ_NATIVE', 'CZ_SUB',
+                       'SK_DUB', 'SK_SUB', 'EN', 'UNKNOWN')
+    )
+);
+
+-- Main read pattern: "all alive uploads for a given film, sorted" (Další
+-- zdroje listing + primary selection). Partial index on `film_id` only for
+-- rows where is_alive = TRUE; is_alive itself is not a key column.
+CREATE INDEX IF NOT EXISTS idx_fsu_film_alive
+    ON film_sledujteto_uploads (film_id)
+    WHERE is_alive;
+
+-- Secondary: reconciliation job hunts uploads that haven't been seen in a
+-- while (WHERE last_seen < NOW() - INTERVAL '30 days'). Index helps this
+-- periodic full-table scan stay fast as the table grows.
+CREATE INDEX IF NOT EXISTS idx_fsu_last_seen
+    ON film_sledujteto_uploads (last_seen)
+    WHERE is_alive;
+
+-- Rollup flags and preferred upload per film. Unlike prehraj.to (where CZ
+-- flags were already present from migration #032), sledujteto introduces
+-- the whole column family fresh — both CZ and SK flavors.
+ALTER TABLE films
+    ADD COLUMN IF NOT EXISTS sledujteto_primary_file_id INTEGER,
+    ADD COLUMN IF NOT EXISTS sledujteto_has_dub     BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS sledujteto_has_subs    BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS sledujteto_has_sk_dub  BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS sledujteto_has_sk_subs BOOLEAN NOT NULL DEFAULT FALSE;


### PR DESCRIPTION
<!-- claude-session: 9c42f99e-d1ab-4b4c-9d4d-e7d09129237a -->

Closes #544

## Summary

Adds migration `20260528_057_film_sledujteto_uploads.sql` which:

1. Creates `film_sledujteto_uploads` — per-upload metadata mirroring the
   prehraj.to model from migration `20260508_048`, adapted for sledujteto's
   integer `file_id` PK and with a first-class `cdn` column
   (`www` / `dataN` / `unknown`) that the `/api/movies/stream/sledujteto/`
   handler (#547) will use to filter streamable copies.
2. Adds 5 rollup columns to `films`:
   - `sledujteto_primary_file_id INTEGER`
   - `sledujteto_has_dub BOOLEAN NOT NULL DEFAULT FALSE`
   - `sledujteto_has_subs BOOLEAN NOT NULL DEFAULT FALSE`
   - `sledujteto_has_sk_dub BOOLEAN NOT NULL DEFAULT FALSE`
   - `sledujteto_has_sk_subs BOOLEAN NOT NULL DEFAULT FALSE`

Unlike the prehrajto migration, sledujteto introduces the CZ dub/subs
flags fresh here — there was no earlier `sledujteto_*` column family on
films to reuse.

This is a schema-only PR. The bulk importer (#545) and handler (#547)
land in follow-up PRs and read/write these columns; this migration
unblocks them.

## Context

Parent epic: #542 (integrate sledujteto.cz as a third film source).
Chain: **#543 (proxy) ✅ → #544 (this PR) → #545 import → #547 handler → #548 frontend.**

## Test plan

- [x] Migration applies cleanly to cr_dev: `sqlx migrate run` →
      `Applied 20260528/migrate 057 film sledujteto uploads (8.4ms)`
- [x] `\d film_sledujteto_uploads` shows all 13 columns, PK
      `(film_id, file_id)`, both partial indexes (`idx_fsu_film_alive`
      WHERE is_alive, `idx_fsu_last_seen` WHERE is_alive), lang check
      constraint, FK to `films(id)` ON DELETE CASCADE.
- [x] `\d films` shows all 5 new `sledujteto_*` columns with correct
      types and defaults.
- [x] Smoke INSERT: `INSERT INTO film_sledujteto_uploads (film_id,
      file_id, title, cdn) VALUES (4, 999999, 'TEST', 'www')` succeeds;
      defaults fill in `lang_class='UNKNOWN'`, `is_alive=TRUE`,
      timestamps.
- [x] `cargo check` across the workspace is clean.
- [ ] Prod: migration will run on container startup after binary redeploy
      post-merge (verified via `SELECT version FROM _sqlx_migrations
      ORDER BY version DESC LIMIT 1`).

## Notes for reviewer

- Per the repo's SQLx Migration Checksum rule in CLAUDE.md: after this
  lands, I must `cargo clean && cargo zigbuild` before deploying so
  cargo re-embeds the new migration hash into the binary.
- No code changes in this PR — `SELECT * FROM film_sledujteto_uploads`
  is not called anywhere yet, so there's no `SQLX_OFFLINE` bundle to
  update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)