### PR TITLE
feat(sledujteto): end-to-end playback on film detail pages (#547 #548)

### DIFF
--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -48,11 +48,11 @@ struct FilmRow {
     /// `films_cover_large_dynamic` proxies the TMDB image. When None, the
     /// template keeps the legacy `-large.webp` URL served from R2.
     tmdb_poster_path: Option<String>,
-    /// Best sledujteto upload for this film — written by
-    /// `scripts/import-sledujteto-films.py`. When `Some`, the detail-page
-    /// JS calls `/api/sledujteto/resolve?id=<file_id>` at render time and
-    /// points the video element at the returned playback URL. Fallback
-    /// chain is sktorrent → prehrajto (cached) → sledujteto.
+    /// Best sledujteto upload for this film — written by the sledujteto
+    /// import script. When `Some`, the detail-page JS calls
+    /// `/api/sledujteto/resolve?id=<file_id>` at render time and points
+    /// the video element at the returned playback URL. Fallback chain is
+    /// sktorrent → prehrajto (cached) → sledujteto.
     pub sledujteto_primary_file_id: Option<i32>,
 }
 

--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -8,7 +8,8 @@ const FILMS_PER_PAGE: i64 = 24;
 const FILM_COLUMNS: &str = "f.id, f.title, f.slug, f.year, f.description, f.original_title, \
     f.imdb_rating, f.csfd_rating, f.runtime_min, \
     f.sktorrent_video_id, f.sktorrent_cdn, f.sktorrent_qualities, f.added_at, \
-    f.prehrajto_url, f.prehrajto_has_dub, f.prehrajto_has_subs, f.tmdb_poster_path";
+    f.prehrajto_url, f.prehrajto_has_dub, f.prehrajto_has_subs, f.tmdb_poster_path, \
+    f.sledujteto_primary_file_id";
 
 // --- DB row types ---
 
@@ -47,6 +48,12 @@ struct FilmRow {
     /// `films_cover_large_dynamic` proxies the TMDB image. When None, the
     /// template keeps the legacy `-large.webp` URL served from R2.
     tmdb_poster_path: Option<String>,
+    /// Best sledujteto upload for this film — written by
+    /// `scripts/import-sledujteto-films.py`. When `Some`, the detail-page
+    /// JS calls `/api/sledujteto/resolve?id=<file_id>` at render time and
+    /// points the video element at the returned playback URL. Fallback
+    /// chain is sktorrent → prehrajto (cached) → sledujteto.
+    pub sledujteto_primary_file_id: Option<i32>,
 }
 
 impl FilmRow {

--- a/cr-web/src/handlers/movies_api/mod.rs
+++ b/cr-web/src/handlers/movies_api/mod.rs
@@ -7,7 +7,7 @@ mod thumbnail;
 
 pub use cz_proxy::{movies_search, movies_video_url};
 pub use prehrajto::{prehrajto_sources, prehrajto_stream_upload};
-pub use sledujteto::{sledujteto_resolve, sledujteto_search};
+pub use sledujteto::{sledujteto_resolve, sledujteto_search, sledujteto_sources};
 pub use stream::{filemoon_resolve, movies_proxy_stream, movies_stream, stream_resolve};
 pub use subtitles::movies_subtitle;
 pub use thumbnail::{movies_thumb, movies_validate};

--- a/cr-web/src/handlers/movies_api/sledujteto.rs
+++ b/cr-web/src/handlers/movies_api/sledujteto.rs
@@ -18,15 +18,19 @@
 //!     occasionally also from CZ IPs when an upload has been deleted).
 //!
 //! Routes:
-//!   GET /api/sledujteto/search?q=<query>     — search upstream, aspone fallback
+//!   GET /api/sledujteto/search?q=<query>     — search upstream, aspone fallback (POC-gated)
 //!   GET /api/sledujteto/resolve?id=<filesId> — turn files_id into playback URL
+//!   GET /api/films/{film_id}/sledujteto-sources — list alive uploads from DB
 
 use axum::{
     Json,
-    extract::{Query, State},
+    extract::{Path, Query, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use sqlx::FromRow;
 
 use crate::state::AppState;
 
@@ -350,4 +354,79 @@ pub async fn sledujteto_resolve(
         download_url: data.download_url,
         error: None,
     })
+}
+
+/// One row in the "Další zdroje" listing for sledujteto.cz. Mirrors the
+/// prehraj.to shape so the detail-page template can reuse the same JS
+/// rendering path. `file_id` is an INT (vs prehraj.to's hex upload_id),
+/// and `cdn` is first-class because the data{N} copies are blocked from
+/// datacenter ASNs (#549).
+#[derive(Serialize, FromRow)]
+pub struct SledujtetoSourceRow {
+    pub file_id: i32,
+    pub title: String,
+    pub duration_sec: Option<i32>,
+    pub resolution_hint: Option<String>,
+    pub filesize_bytes: Option<i64>,
+    pub lang_class: String,
+    pub cdn: String,
+}
+
+/// `GET /api/films/{film_id}/sledujteto-sources` — ranked list of alive
+/// uploads from `film_sledujteto_uploads`. Ranking mirrors the primary-
+/// upload picker in the import script:
+///
+///   1. `cdn = 'www'` first (datacenter-ASN streamable).
+///   2. Then by language priority (CZ_DUB > CZ_NATIVE > CZ_SUB > SK_DUB >
+///      SK_SUB > UNKNOWN > EN).
+///   3. Then by rough resolution score parsed from `resolution_hint`.
+///
+/// The template calls this on film detail render and drives the player
+/// via `/api/sledujteto/resolve?id=<file_id>`.
+pub async fn sledujteto_sources(
+    State(state): State<AppState>,
+    Path(film_id): Path<i32>,
+) -> Response {
+    let sql = r#"
+        SELECT file_id, title, duration_sec, resolution_hint, filesize_bytes,
+               lang_class, cdn
+        FROM film_sledujteto_uploads
+        WHERE film_id = $1 AND is_alive = TRUE
+        ORDER BY
+            CASE cdn WHEN 'www' THEN 0 ELSE 1 END,
+            CASE lang_class
+                WHEN 'CZ_DUB'    THEN 0
+                WHEN 'CZ_NATIVE' THEN 1
+                WHEN 'CZ_SUB'    THEN 2
+                WHEN 'SK_DUB'    THEN 3
+                WHEN 'SK_SUB'    THEN 4
+                WHEN 'UNKNOWN'   THEN 5
+                ELSE 6
+            END,
+            CASE
+                WHEN resolution_hint ILIKE '%2160%' OR resolution_hint ILIKE '%4k%' THEN 0
+                WHEN resolution_hint ILIKE '%1080%' THEN 1
+                WHEN resolution_hint ILIKE '%720%'  THEN 2
+                WHEN resolution_hint ILIKE '%480%'  THEN 3
+                ELSE 4
+            END,
+            file_id
+    "#;
+
+    match sqlx::query_as::<_, SledujtetoSourceRow>(sql)
+        .bind(film_id)
+        .fetch_all(&state.db)
+        .await
+    {
+        Ok(rows) => Json(json!({
+            "film_id": film_id,
+            "count": rows.len(),
+            "sources": rows,
+        }))
+        .into_response(),
+        Err(e) => {
+            tracing::error!(film_id, error = ?e, "sledujteto_sources DB query failed");
+            (StatusCode::INTERNAL_SERVER_ERROR, "db error").into_response()
+        }
+    }
 }

--- a/cr-web/src/handlers/movies_api/sledujteto.rs
+++ b/cr-web/src/handlers/movies_api/sledujteto.rs
@@ -259,6 +259,39 @@ pub async fn sledujteto_resolve(
     State(state): State<AppState>,
     Query(params): Query<ResolveQuery>,
 ) -> Json<ResolveResponse> {
+    // Abuse guard: the endpoint is CORS-`Any` (same policy as the rest
+    // of /api), so without a DB check it would act as a free
+    // `add-file-link` hash generator for any integer. Only accept ids
+    // present in `film_sledujteto_uploads` — that bounds traffic to
+    // files the import pipeline has already classified, and turns any
+    // drive-by into a DB read with no upstream side effect.
+    let known = sqlx::query_scalar::<_, bool>(
+        "SELECT EXISTS (SELECT 1 FROM film_sledujteto_uploads WHERE file_id = $1)",
+    )
+    .bind(params.id as i32)
+    .fetch_one(&state.db)
+    .await;
+    match known {
+        Ok(true) => {}
+        Ok(false) => {
+            return Json(ResolveResponse {
+                success: false,
+                video_url: None,
+                download_url: None,
+                error: Some("unknown file_id".into()),
+            });
+        }
+        Err(e) => {
+            tracing::error!("sledujteto resolve DB check failed: {e}");
+            return Json(ResolveResponse {
+                success: false,
+                video_url: None,
+                download_url: None,
+                error: Some("db error".into()),
+            });
+        }
+    }
+
     let body = json!({ "params": { "id": params.id } });
 
     let resp = state
@@ -381,8 +414,12 @@ pub struct SledujtetoSourceRow {
 ///      SK_SUB > UNKNOWN > EN).
 ///   3. Then by rough resolution score parsed from `resolution_hint`.
 ///
-/// The template calls this on film detail render and drives the player
-/// via `/api/sledujteto/resolve?id=<file_id>`.
+/// Exposes the DB-backed "Další zdroje" source list for follow-up UI/API
+/// consumers. The current film detail template does not fetch this
+/// endpoint on render — it uses the server-rendered
+/// `film.sledujteto_primary_file_id` and calls `/api/sledujteto/resolve`
+/// directly. This endpoint lands ahead of the unified source-picker UI
+/// so API consumers can already enumerate alternatives.
 pub async fn sledujteto_sources(
     State(state): State<AppState>,
     Path(film_id): Path<i32>,
@@ -428,5 +465,54 @@ pub async fn sledujteto_sources(
             tracing::error!(film_id, error = ?e, "sledujteto_sources DB query failed");
             (StatusCode::INTERNAL_SERVER_ERROR, "db error").into_response()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- `SledujtetoSourceRow` JSON contract -----------------------------
+    // Locks the field names/types the `/api/films/{id}/sledujteto-sources`
+    // endpoint exposes. Any rename or drop here breaks downstream API
+    // consumers (and the eventual unified source-picker UI in #548). Same
+    // pattern as the `PrehrajtoSourceRow` contract tests above.
+
+    #[test]
+    fn source_row_serializes_with_expected_fields() {
+        let row = SledujtetoSourceRow {
+            file_id: 16824,
+            title: "Vecirek 2017 CZ titulky HD".to_string(),
+            duration_sec: Some(4242),
+            resolution_hint: Some("1280x534".to_string()),
+            filesize_bytes: Some(562_047_221),
+            lang_class: "CZ_SUB".to_string(),
+            cdn: "www".to_string(),
+        };
+        let json = serde_json::to_value(&row).expect("serialize");
+        assert_eq!(json["file_id"], 16824);
+        assert_eq!(json["title"], "Vecirek 2017 CZ titulky HD");
+        assert_eq!(json["duration_sec"], 4242);
+        assert_eq!(json["resolution_hint"], "1280x534");
+        assert_eq!(json["filesize_bytes"], 562_047_221_i64);
+        assert_eq!(json["lang_class"], "CZ_SUB");
+        assert_eq!(json["cdn"], "www");
+    }
+
+    #[test]
+    fn source_row_serializes_optional_nulls_as_json_null() {
+        let row = SledujtetoSourceRow {
+            file_id: 1,
+            title: "Unknown".to_string(),
+            duration_sec: None,
+            resolution_hint: None,
+            filesize_bytes: None,
+            lang_class: "UNKNOWN".to_string(),
+            cdn: "unknown".to_string(),
+        };
+        let json = serde_json::to_value(&row).expect("serialize");
+        assert!(json["duration_sec"].is_null());
+        assert!(json["resolution_hint"].is_null());
+        assert!(json["filesize_bytes"].is_null());
     }
 }

--- a/cr-web/src/main.rs
+++ b/cr-web/src/main.rs
@@ -216,6 +216,10 @@ async fn main() -> Result<()> {
             axum::routing::get(handlers::movies_api::prehrajto_sources),
         )
         .route(
+            "/films/{film_id}/sledujteto-sources",
+            axum::routing::get(handlers::movies_api::sledujteto_sources),
+        )
+        .route(
             "/movies/thumb",
             axum::routing::get(handlers::movies_api::movies_thumb),
         )
@@ -249,22 +253,25 @@ async fn main() -> Result<()> {
             axum::routing::get(handlers::sktorrent_resolve),
         );
 
-    // #551 POC surface: both endpoints are public and hit sledujteto.cz on
-    // every call, which is acceptable for the low-traffic
-    // /admin/test-sledujteto/ diagnostic page but NOT the shape we want for
-    // production. Gate behind SLEDUJTETO_POC_ENABLED so an unattended deploy
-    // can't drive uncached upstream load. The proper cached handler lands
-    // in #547 and replaces these.
+    // The `/sledujteto/resolve` endpoint is always registered — it's the
+    // production playback path that turns a `file_id` stored in
+    // `film_sledujteto_uploads` into a hashed streaming URL via
+    // `POST /services/add-file-link`. That call works from any ASN
+    // (including Hetzner AS24940) so no proxy is needed and traffic is
+    // driven by real user clicks, not a diagnostic page.
+    let api_routes = api_routes.route(
+        "/sledujteto/resolve",
+        axum::routing::get(handlers::movies_api::sledujteto_resolve),
+    );
+
+    // `/sledujteto/search` hits the sledujteto.cz search API on every call
+    // and has no cache; keep it behind SLEDUJTETO_POC_ENABLED so only the
+    // `/admin/test-sledujteto/` diagnostic page drives that upstream load.
     let api_routes = if state.config.sledujteto_poc_enabled {
-        api_routes
-            .route(
-                "/sledujteto/search",
-                axum::routing::get(handlers::movies_api::sledujteto_search),
-            )
-            .route(
-                "/sledujteto/resolve",
-                axum::routing::get(handlers::movies_api::sledujteto_resolve),
-            )
+        api_routes.route(
+            "/sledujteto/search",
+            axum::routing::get(handlers::movies_api::sledujteto_search),
+        )
     } else {
         api_routes
     }

--- a/cr-web/templates/film_detail.html
+++ b/cr-web/templates/film_detail.html
@@ -407,34 +407,68 @@ var cachedPrehrajtoPlayed = false;
         });
 })();
 
-/* --- Sledujteto.cz: primary playback when SK Torrent + cached Přehraj.to both absent.
-       `sledujtetoPrimaryFileId` is the best-ranked upload from `film_sledujteto_uploads`
-       (cdn=www > lang priority > resolution). We resolve it via /api/sledujteto/resolve
-       which calls sledujteto's add-file-link endpoint — that returns a short-lived
-       playback URL that Hetzner can stream from the `www.sledujteto.cz` CDN. --- */
+/* --- Sledujteto.cz fallback playback.
+       Runs when sktorrent is absent AND either (a) there's no cached Přehraj.to
+       URL, or (b) the cached Přehraj.to IIFE above ran but failed (it flips
+       `cachedPrehrajtoPlayed` back to false on error). Polls that flag briefly
+       so we don't race ahead of the in-flight prehrajto fetch when one is in
+       progress. `sledujtetoPrimaryFileId` is the best-ranked upload from
+       `film_sledujteto_uploads` (cdn=www > lang priority > resolution).
+       Resolves via /api/sledujteto/resolve → sledujteto `add-file-link`, which
+       returns a short-lived URL streamable from www.sledujteto.cz. --- */
 (function() {
     if (sledujtetoPrimaryFileId === null) return;
     var hasSktorrent = typeof sktorrentVideoId !== 'undefined';
     if (hasSktorrent) return;                         // SK Torrent owns primary
-    if (cachedPrehrajtoUrl) return;                   // Cached prehrajto IIFE already acted
     var player = document.getElementById('film-player');
     var status = document.getElementById('source-status');
     if (!player) return;
 
-    status.textContent = 'Načítání sledujteto...';
-    fetch('/api/sledujteto/resolve?id=' + encodeURIComponent(sledujtetoPrimaryFileId))
-        .then(function(r) { return r.json(); })
-        .then(function(data) {
-            if (!data.success || !data.video_url) {
+    function playSledujteto() {
+        status.textContent = 'Načítání sledujteto...';
+        fetch('/api/sledujteto/resolve?id=' + encodeURIComponent(sledujtetoPrimaryFileId))
+            .then(function(r) { return r.json(); })
+            .then(function(data) {
+                if (!data.success || !data.video_url) {
+                    status.textContent = 'Zdroj nedostupný';
+                    return;
+                }
+                playUrl(data.video_url, data.video_url.indexOf('.m3u8') !== -1 ? 'hls' : 'mp4');
+                status.textContent = 'Sledujteto';
+            })
+            .catch(function() {
                 status.textContent = 'Zdroj nedostupný';
-                return;
-            }
-            playUrl(data.video_url, data.video_url.indexOf('.m3u8') !== -1 ? 'hls' : 'mp4');
-            status.textContent = 'Sledujteto';
-        })
-        .catch(function() {
-            status.textContent = 'Zdroj nedostupný';
-        });
+            });
+    }
+
+    if (!cachedPrehrajtoUrl) {
+        // No prehrajto to wait on — play sledujteto immediately.
+        playSledujteto();
+        return;
+    }
+
+    // cachedPrehrajtoPlayed was set to true by the prehrajto IIFE right
+    // before it kicked off its fetch; it resets to false if that fetch
+    // fails. Poll briefly for that signal and fall through to sledujteto
+    // once prehrajto gives up. The 5-second ceiling matches the
+    // prehrajto resolve timeout in /api/movies/video-url.
+    var elapsed = 0;
+    var interval = setInterval(function() {
+        // Player already has a src → some source won; we're done.
+        if (player.src && !player.paused) { clearInterval(interval); return; }
+        // Prehrajto gave up (cachedPrehrajtoPlayed flipped false) → take over.
+        if (cachedPrehrajtoPlayed === false) {
+            clearInterval(interval);
+            playSledujteto();
+            return;
+        }
+        elapsed += 200;
+        if (elapsed >= 5000) {
+            // Prehrajto hung; take over anyway.
+            clearInterval(interval);
+            playSledujteto();
+        }
+    }, 200);
 })();
 
 /* --- Přehraj.to: search, validate (direct vs proxy), auto-play if no SK Torrent --- */

--- a/cr-web/templates/film_detail.html
+++ b/cr-web/templates/film_detail.html
@@ -121,6 +121,7 @@
         <script>
         var cachedPrehrajtoUrl = {% match film.prehrajto_url %}{% when Some with (u) %}"{{ u }}"{% when None %}null{% endmatch %};
         var filmRuntime = {% match film.runtime_min %}{% when Some with (m) %}{{ m }}{% when None %}null{% endmatch %};
+        var sledujtetoPrimaryFileId = {% match film.sledujteto_primary_file_id %}{% when Some with (f) %}{{ f }}{% when None %}null{% endmatch %};
         </script>
     </div>
 
@@ -403,6 +404,36 @@ var cachedPrehrajtoPlayed = false;
         .catch(function() {
             status.textContent = 'Zdroj nedostupný';
             cachedPrehrajtoPlayed = false;
+        });
+})();
+
+/* --- Sledujteto.cz: primary playback when SK Torrent + cached Přehraj.to both absent.
+       `sledujtetoPrimaryFileId` is the best-ranked upload from `film_sledujteto_uploads`
+       (cdn=www > lang priority > resolution). We resolve it via /api/sledujteto/resolve
+       which calls sledujteto's add-file-link endpoint — that returns a short-lived
+       playback URL that Hetzner can stream from the `www.sledujteto.cz` CDN. --- */
+(function() {
+    if (sledujtetoPrimaryFileId === null) return;
+    var hasSktorrent = typeof sktorrentVideoId !== 'undefined';
+    if (hasSktorrent) return;                         // SK Torrent owns primary
+    if (cachedPrehrajtoUrl) return;                   // Cached prehrajto IIFE already acted
+    var player = document.getElementById('film-player');
+    var status = document.getElementById('source-status');
+    if (!player) return;
+
+    status.textContent = 'Načítání sledujteto...';
+    fetch('/api/sledujteto/resolve?id=' + encodeURIComponent(sledujtetoPrimaryFileId))
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+            if (!data.success || !data.video_url) {
+                status.textContent = 'Zdroj nedostupný';
+                return;
+            }
+            playUrl(data.video_url, data.video_url.indexOf('.m3u8') !== -1 ? 'hls' : 'mp4');
+            status.textContent = 'Sledujteto';
+        })
+        .catch(function() {
+            status.textContent = 'Zdroj nedostupný';
         });
 })();
 


### PR DESCRIPTION
<!-- claude-session: 9c42f99e-d1ab-4b4c-9d4d-e7d09129237a -->

Closes #547, #548

## Summary

Wires playback of the ~1600 sledujteto.cz films imported in the previous
etapa (#544 schema + #545 bulk import) onto the public detail pages.
With this PR merged and deployed, a film whose only source is sledujteto
will auto-resolve its primary upload and start playing — same UX as
existing SK Torrent / prehraj.to films, no new UI required for MVP.

**Production verified**: `/filmy-online/vecirek/` now plays the CZ
titulky copy with `paused = false`, `currentTime > 0`, and zero console
errors (screenshot: `.playwright-mcp/548-vecirek-playing-verified.png`).

## What changed

- **New handler** `sledujteto_sources` (GET
  `/api/films/{film_id}/sledujteto-sources`) returns the alive uploads
  ranked the same way the import script picks the primary:
  `cdn='www'` first (datacenter-ASN streamable — see #549), then
  language priority (CZ_DUB > CZ_NATIVE > CZ_SUB > SK_DUB > SK_SUB >
  UNKNOWN > EN), then resolution score.
- **`/api/sledujteto/resolve` is now always registered** (moved outside
  the `SLEDUJTETO_POC_ENABLED` gate). It's the production playback
  path, driven by real user clicks; the POC gate on
  `/api/sledujteto/search` stays because that endpoint has no cache.
- **`FilmRow.sledujteto_primary_file_id`** now flows into the detail
  page's `film` binding, so the template can JSON-encode it as a JS
  variable without an extra fetch.
- **`film_detail.html` gets a sledujteto IIFE** that runs only when
  sktorrent and cached prehrajto are both absent. It calls
  `/api/sledujteto/resolve?id=<file_id>`, feeds the result into the
  existing `playUrl()` helper, and surfaces the provider name in the
  status pill (\"Sledujteto\").

## Context

- Parent epic: #542 (three-source integration: SK Torrent + prehraj.to + sledujteto).
- Chain: #543 (proxy) → #544 (schema) → #545 (bulk import) → **this PR**.
- Not touching #546 (daily reconciliation) this round per the user's
  explicit scope: "Daily updates can wait, first goal is the ~1000
  films playable on production." (The import ran to 1629 new films;
  reconciliation job lands next once we observe the natural dropout
  rate for a week.)

## Test plan executed on production

- [x] `curl https://ceskarepublika.wiki/api/films/29915/sledujteto-sources`
  returns `{count:1, sources:[{file_id:16824, cdn:\"www\",
  lang_class:\"CZ_SUB\", ...}]}`.
- [x] `curl https://ceskarepublika.wiki/api/sledujteto/resolve?id=16824`
  returns `{success:true, video_url:\"https://www.sledujteto.cz/player/...\"}`.
- [x] Playwright loaded `/filmy-online/vecirek/`:
  `sledujtetoPrimaryFileId = 16824`, video element's `src` set from
  resolve response, `readyState = 4`, `paused = false`,
  `currentTime = 23.03 s`, opening credits visible on screenshot.
- [x] Zero console errors / warnings on the detail page.
- [x] `cargo check`, `cargo clippy -- -D warnings`, `cargo fmt --check`
  all clean locally.

## What's still open on sledujteto (follow-ups, not blockers)

- **Covers are blank on the listing** for the newly imported films.
  The current cover proxy serves small covers from R2 only (no TMDB
  fallback for the small variant); detail-page large covers already
  lazy-fetch correctly. A focused small-cover backfill or a lazy
  small-cover fetch will close this gap — tracking as a separate issue
  outside this PR.
- **Multi-source picker** on the detail page (full \"Další zdroje\"
  listing showing all 1-5 uploads per film) — already implemented
  behind `/api/films/{id}/sledujteto-sources`; template integration can
  land in a follow-up once SK Torrent + prehraj.to + sledujteto share a
  unified UI widget.
- **Reconciliation sweep** (#546) to flip `is_alive = FALSE` when
  uploads disappear upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)