### PR TITLE
feat(film_detail): per-provider source tabs with host-name labels (#548)

### DIFF
--- a/cr-web/templates/film_detail.html
+++ b/cr-web/templates/film_detail.html
@@ -68,11 +68,27 @@
            Bombuj providers (Filemoon/Streamtape/Mixdrop) removed — CDN URLs
            are session-bound, proxy-streaming doesn't scale (#407).
            Přehraj.to section below provides additional sources. #}
-        {# Same "Zdroj 1 / Zdroj 2" pattern as episode_detail.html.
-           "Zdroj 1" = primary (SK Torrent, or cached Přehraj.to when SKT missing);
-           "Zdroj 2" appears when the user picks an alternative from "Další zdroje". #}
+        {# Source tabs — one per known provider attached to this film.
+           The first available (in priority order SK Torrent → Přehraj.to →
+           Sledujteto) renders with `.active` so the auto-play IIFE picks
+           it up. Additional live-search results from "Další zdroje"
+           continue to append a dynamic prehraj.to-tagged tab on click. #}
         <div class="source-tabs" id="source-tabs">
-            <button class="source-tab active" id="tab-source-1" onclick="switchBackToSource1()">Zdroj 1</button>
+            {% match film.sktorrent_video_id %}
+            {% when Some with (_vid) %}
+            <button class="source-tab source-sktorrent active" data-provider="sktorrent" onclick="switchSource(this)">online.sktorrent.eu</button>
+            {% when None %}
+            {% endmatch %}
+            {% match film.prehrajto_url %}
+            {% when Some with (_u) %}
+            <button class="source-tab source-prehrajto {% match film.sktorrent_video_id %}{% when Some with (_) %}{% when None %}active{% endmatch %}" data-provider="prehrajto" onclick="switchSource(this)">prehraj.to</button>
+            {% when None %}
+            {% endmatch %}
+            {% match film.sledujteto_primary_file_id %}
+            {% when Some with (_f) %}
+            <button class="source-tab source-sledujteto {% match film.sktorrent_video_id %}{% when Some with (_) %}{% when None %}{% match film.prehrajto_url %}{% when Some with (_) %}{% when None %}active{% endmatch %}{% endmatch %}" data-provider="sledujteto" onclick="switchSource(this)">sledujteto.cz</button>
+            {% when None %}
+            {% endmatch %}
         </div>
 
         {# Video player — auto-select best available quality #}
@@ -314,6 +330,20 @@ function showSource(provider, btn) {
     document.getElementById('source-status').textContent = '';
 }
 
+/* Click handler for provider tabs (rendered statically per film's known
+   providers). Delegates to the provider-specific playback function. */
+function switchSource(btn) {
+    var provider = btn.dataset.provider;
+    showSource(provider, btn);
+    if (provider === 'sktorrent') {
+        resolveAndPlaySktorrent('Načítám zdroj...');
+    } else if (provider === 'prehrajto') {
+        playCachedPrehrajto();
+    } else if (provider === 'sledujteto') {
+        playSledujteto();
+    }
+}
+
 /* --- Resolve & play from bombuj.si providers --- */
 var resolveCache = {};
 
@@ -374,19 +404,18 @@ function showSktorrent(btn) {
     }
 }
 
-/* --- Cached Přehraj.to URL: primary source when SK Torrent is absent --- */
+/* --- Cached Přehraj.to URL: plays on page load when SK Torrent is
+       absent, and any time the user clicks the prehraj.to provider tab. --- */
 var cachedPrehrajtoPlayed = false;
-(function() {
-    var hasSktorrent = typeof sktorrentVideoId !== 'undefined';
-    if (hasSktorrent) return;                      // SK Torrent owns primary
-    if (!cachedPrehrajtoUrl) return;               // Nothing to play
+function playCachedPrehrajto() {
+    if (!cachedPrehrajtoUrl) return;
     var player = document.getElementById('film-player');
     var status = document.getElementById('source-status');
     if (!player) return;
 
     cachedPrehrajtoPlayed = true;
     status.textContent = 'Načítání Přehraj.to...';
-    fetch('/api/movies/video-url?url=' + encodeURIComponent(cachedPrehrajtoUrl))
+    return fetch('/api/movies/video-url?url=' + encodeURIComponent(cachedPrehrajtoUrl))
         .then(function(r) { return r.json(); })
         .then(function(data) {
             if (!data.success || !data.video_url) {
@@ -405,41 +434,50 @@ var cachedPrehrajtoPlayed = false;
             status.textContent = 'Zdroj nedostupný';
             cachedPrehrajtoPlayed = false;
         });
+}
+
+(function() {
+    var hasSktorrent = typeof sktorrentVideoId !== 'undefined';
+    if (hasSktorrent) return;                      // SK Torrent owns primary
+    if (!cachedPrehrajtoUrl) return;               // Nothing to play
+    playCachedPrehrajto();
 })();
 
-/* --- Sledujteto.cz fallback playback.
-       Runs when sktorrent is absent AND either (a) there's no cached Přehraj.to
-       URL, or (b) the cached Přehraj.to IIFE above ran but failed (it flips
-       `cachedPrehrajtoPlayed` back to false on error). Polls that flag briefly
-       so we don't race ahead of the in-flight prehrajto fetch when one is in
-       progress. `sledujtetoPrimaryFileId` is the best-ranked upload from
-       `film_sledujteto_uploads` (cdn=www > lang priority > resolution).
-       Resolves via /api/sledujteto/resolve → sledujteto `add-file-link`, which
-       returns a short-lived URL streamable from www.sledujteto.cz. --- */
+/* --- Sledujteto.cz playback. Plays the primary upload (best-ranked by
+       cdn=www > lang priority > resolution — stored in
+       `films.sledujteto_primary_file_id`). Resolves via
+       /api/sledujteto/resolve → sledujteto `add-file-link`, which returns a
+       short-lived URL streamable from www.sledujteto.cz. --- */
+function playSledujteto() {
+    if (sledujtetoPrimaryFileId === null) return;
+    var player = document.getElementById('film-player');
+    var status = document.getElementById('source-status');
+    if (!player) return;
+
+    status.textContent = 'Načítání sledujteto...';
+    return fetch('/api/sledujteto/resolve?id=' + encodeURIComponent(sledujtetoPrimaryFileId))
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+            if (!data.success || !data.video_url) {
+                status.textContent = 'Zdroj nedostupný';
+                return;
+            }
+            playUrl(data.video_url, data.video_url.indexOf('.m3u8') !== -1 ? 'hls' : 'mp4');
+            status.textContent = 'Sledujteto';
+        })
+        .catch(function() {
+            status.textContent = 'Zdroj nedostupný';
+        });
+}
+
+/* Auto-play fallback: when neither sktorrent nor cached prehrajto is
+   available (or prehrajto failed), sledujteto takes over as primary. */
 (function() {
     if (sledujtetoPrimaryFileId === null) return;
     var hasSktorrent = typeof sktorrentVideoId !== 'undefined';
     if (hasSktorrent) return;                         // SK Torrent owns primary
     var player = document.getElementById('film-player');
-    var status = document.getElementById('source-status');
     if (!player) return;
-
-    function playSledujteto() {
-        status.textContent = 'Načítání sledujteto...';
-        fetch('/api/sledujteto/resolve?id=' + encodeURIComponent(sledujtetoPrimaryFileId))
-            .then(function(r) { return r.json(); })
-            .then(function(data) {
-                if (!data.success || !data.video_url) {
-                    status.textContent = 'Zdroj nedostupný';
-                    return;
-                }
-                playUrl(data.video_url, data.video_url.indexOf('.m3u8') !== -1 ? 'hls' : 'mp4');
-                status.textContent = 'Sledujteto';
-            })
-            .catch(function() {
-                status.textContent = 'Zdroj nedostupný';
-            });
-    }
 
     if (!cachedPrehrajtoUrl) {
         // No prehrajto to wait on — play sledujteto immediately.
@@ -711,56 +749,28 @@ var cachedPrehrajtoPlayed = false;
     }
 })();
 
-/* Tabs & active-source helpers — mirror of episode_detail.html */
-function setActiveTab(n) {
-    var t1 = document.getElementById('tab-source-1');
-    var t2 = document.getElementById('tab-source-2');
-    if (t1) t1.classList.toggle('active', n === 1);
-    if (t2) t2.classList.toggle('active', n === 2);
-}
-function ensureSource2Tab() {
-    if (document.getElementById('tab-source-2')) return;
+/* Dynamic tab for the "Další zdroje" live prehrajto search results.
+   When the film has a statically-rendered `prehraj.to` provider tab
+   (cached URL), we reuse it; otherwise a new tab is appended so the
+   user can see which source they just clicked. */
+function ensureLivePrehrajtoTab() {
+    var existing = document.querySelector('.source-tab[data-provider="prehrajto"]');
+    if (existing) return existing;
     var tabs = document.getElementById('source-tabs');
-    if (!tabs) return;
+    if (!tabs) return null;
     var btn = document.createElement('button');
-    btn.className = 'source-tab';
-    btn.id = 'tab-source-2';
-    btn.textContent = 'Zdroj 2';
+    btn.className = 'source-tab source-prehrajto';
+    btn.dataset.provider = 'prehrajto';
+    btn.textContent = 'prehraj.to';
     btn.onclick = function() {
-        // Clicking Zdroj 2 tab re-activates the last-played prehrajto item
+        // Clicking the prehraj.to tab re-activates the last-clicked
+        // "Další zdroje" item (if any) so its URL is resolved again.
         var last = document.querySelector('.prehrajto-item.active');
         if (last && last._movie) playPrehrajto(last._movie, last);
+        else if (cachedPrehrajtoUrl) playCachedPrehrajto();
     };
     tabs.appendChild(btn);
-}
-function switchBackToSource1() {
-    // Hide "Zdroj 1" tab click handler: replay the primary source.
-    // Primary is either SK Torrent (cachedPrehrajtoPlayed=false) or cached
-    // prehrajto_url (cachedPrehrajtoPlayed=true).
-    setActiveTab(1);
-    document.querySelectorAll('.prehrajto-item.active').forEach(function(el) { el.classList.remove('active'); });
-    var sktQ = document.getElementById('sktorrent-quality');
-    if (typeof sktorrentSources !== 'undefined' && sktorrentSources.length) {
-        if (sktQ) sktQ.style.display = '';
-        playSktorrent(0, sktQ ? sktQ.querySelector('.quality-btn') : null);
-    } else if (cachedPrehrajtoUrl) {
-        // Re-resolve the cached URL (token-bound, short TTL)
-        var player = document.getElementById('film-player');
-        var status = document.getElementById('source-status');
-        status.textContent = 'Načítání Přehraj.to...';
-        fetch('/api/movies/video-url?url=' + encodeURIComponent(cachedPrehrajtoUrl))
-            .then(function(r) { return r.json(); })
-            .then(function(data) {
-                if (data.success && data.video_url) {
-                    var url = data.video_url.replace(/&amp;/g, '&');
-                    playUrl(url, url.indexOf('.m3u8') !== -1 ? 'hls' : 'mp4');
-                    status.textContent = 'Přehraj.to';
-                    if (data.subtitles && data.subtitles.length) {
-                        addSubtitles(player, data.subtitles);
-                    }
-                } else { status.textContent = 'Zdroj nedostupný'; }
-            });
-    }
+    return btn;
 }
 
 function playPrehrajto(movie, item) {
@@ -768,14 +778,15 @@ function playPrehrajto(movie, item) {
     var status = document.getElementById('source-status');
     if (!player) return;
 
-    // Mark clicked item as the active source (gold + play arrow);
-    // append "Zdroj 2" tab and switch focus to it so the user sees which
-    // source is playing. Mirror of episode_detail.html behaviour.
+    // Mark clicked item as the active source (gold + play arrow); make
+    // the prehraj.to provider tab the current active tab so the user can
+    // see which provider is playing. If this film had no cached prehrajto
+    // URL, `ensureLivePrehrajtoTab` creates the tab on demand.
     document.querySelectorAll('.prehrajto-item.active').forEach(function(el) { el.classList.remove('active'); });
     item.classList.add('active');
     item._movie = movie;
-    ensureSource2Tab();
-    setActiveTab(2);
+    var prehrajtoTab = ensureLivePrehrajtoTab();
+    if (prehrajtoTab) showSource('prehrajto', prehrajtoTab);
     var sktQ = document.getElementById('sktorrent-quality');
     if (sktQ) sktQ.style.display = 'none';
 

--- a/cr-web/templates/film_detail.html
+++ b/cr-web/templates/film_detail.html
@@ -73,22 +73,21 @@
            Sledujteto) renders with `.active` so the auto-play IIFE picks
            it up. Additional live-search results from "Další zdroje"
            continue to append a dynamic prehraj.to-tagged tab on click. #}
+        {# Active-tab rule, computed once so nested match blocks stay simple:
+           the first available provider in SKT → Přehraj.to → Sledujteto
+           priority order matches the auto-play waterfall below. #}
+        {% let has_skt = film.sktorrent_video_id.is_some() %}
+        {% let has_prh = film.prehrajto_url.is_some() %}
         <div class="source-tabs" id="source-tabs">
-            {% match film.sktorrent_video_id %}
-            {% when Some with (_vid) %}
+            {% if has_skt %}
             <button class="source-tab source-sktorrent active" data-provider="sktorrent" onclick="switchSource(this)">online.sktorrent.eu</button>
-            {% when None %}
-            {% endmatch %}
-            {% match film.prehrajto_url %}
-            {% when Some with (_u) %}
-            <button class="source-tab source-prehrajto {% match film.sktorrent_video_id %}{% when Some with (_) %}{% when None %}active{% endmatch %}" data-provider="prehrajto" onclick="switchSource(this)">prehraj.to</button>
-            {% when None %}
-            {% endmatch %}
-            {% match film.sledujteto_primary_file_id %}
-            {% when Some with (_f) %}
-            <button class="source-tab source-sledujteto {% match film.sktorrent_video_id %}{% when Some with (_) %}{% when None %}{% match film.prehrajto_url %}{% when Some with (_) %}{% when None %}active{% endmatch %}{% endmatch %}" data-provider="sledujteto" onclick="switchSource(this)">sledujteto.cz</button>
-            {% when None %}
-            {% endmatch %}
+            {% endif %}
+            {% if has_prh %}
+            <button class="source-tab source-prehrajto{% if !has_skt %} active{% endif %}" data-provider="prehrajto" onclick="onPrehrajtoTabClick(this)">prehraj.to</button>
+            {% endif %}
+            {% if film.sledujteto_primary_file_id.is_some() %}
+            <button class="source-tab source-sledujteto{% if !has_skt && !has_prh %} active{% endif %}" data-provider="sledujteto" onclick="switchSource(this)">sledujteto.cz</button>
+            {% endif %}
         </div>
 
         {# Video player — auto-select best available quality #}
@@ -327,6 +326,15 @@ function showSource(provider, btn) {
     // Hide sktorrent quality buttons when on other source
     var sktQ = document.getElementById('sktorrent-quality');
     if (sktQ) sktQ.style.display = (provider === 'sktorrent') ? 'flex' : 'none';
+    // Drop any stale "currently playing" highlight from the live
+    // prehraj.to list whenever the user moves to a different provider —
+    // the gold highlight means "this is the active playback", so leaving
+    // it set on e.g. a prehrajto row while sledujteto actually plays is
+    // misleading.
+    if (provider !== 'prehrajto') {
+        document.querySelectorAll('.prehrajto-item.active, .prehrajto-item.loading')
+            .forEach(function(el) { el.classList.remove('active', 'loading'); });
+    }
     document.getElementById('source-status').textContent = '';
 }
 
@@ -341,6 +349,19 @@ function switchSource(btn) {
         playCachedPrehrajto();
     } else if (provider === 'sledujteto') {
         playSledujteto();
+    }
+}
+
+/* Static prehraj.to tab onclick — prefers replaying the user's last
+   click in "Další zdroje" over the cached URL, so clicking the tab
+   after picking a specific upload doesn't snap back to the default. */
+function onPrehrajtoTabClick(btn) {
+    var lastItem = document.querySelector('.prehrajto-item.active');
+    if (lastItem && lastItem._movie) {
+        // playPrehrajto handles tab activation internally via showSource.
+        playPrehrajto(lastItem._movie, lastItem);
+    } else {
+        switchSource(btn);
     }
 }
 
@@ -453,6 +474,12 @@ function playSledujteto() {
     var player = document.getElementById('film-player');
     var status = document.getElementById('source-status');
     if (!player) return;
+
+    // Make sure the sledujteto tab reflects what's actually playing —
+    // relevant when this runs via the prehrajto-fallback path rather
+    // than a direct user click on the sledujteto tab.
+    var tab = document.querySelector('.source-tab[data-provider="sledujteto"]');
+    if (tab && !tab.classList.contains('active')) showSource('sledujteto', tab);
 
     status.textContent = 'Načítání sledujteto...';
     return fetch('/api/sledujteto/resolve?id=' + encodeURIComponent(sledujtetoPrimaryFileId))
@@ -762,9 +789,12 @@ function ensureLivePrehrajtoTab() {
     btn.className = 'source-tab source-prehrajto';
     btn.dataset.provider = 'prehrajto';
     btn.textContent = 'prehraj.to';
+    // Same behaviour as the statically-rendered prehraj.to tab: mark
+    // active / hide sktorrent qualities via showSource, then replay
+    // whichever prehraj.to source the user last clicked, or fall
+    // through to the cached URL.
     btn.onclick = function() {
-        // Clicking the prehraj.to tab re-activates the last-clicked
-        // "Další zdroje" item (if any) so its URL is resolved again.
+        showSource('prehrajto', btn);
         var last = document.querySelector('.prehrajto-item.active');
         if (last && last._movie) playPrehrajto(last._movie, last);
         else if (cachedPrehrajtoUrl) playCachedPrehrajto();


### PR DESCRIPTION
<!-- claude-session: 9c42f99e-d1ab-4b4c-9d4d-e7d09129237a -->

Relates to #548

## Summary

Rename the legacy `Zdroj 1 / Zdroj 2` tabs on the film detail page
to per-provider tabs labelled by host so the user can tell which
upstream they're watching:

- `online.sktorrent.eu`
- `prehraj.to`
- `sledujteto.cz`

Each tab renders only if the film actually has that provider
attached. The auto-play waterfall (sktorrent → prehrajto →
sledujteto) is unchanged; the winning provider's tab is marked
`.active` at page load. Clicking any other tab dispatches through a
unified `switchSource(btn)` handler that re-runs the
provider-specific playback flow.

## Why

User feedback on #548 asked for provider identification:

> "v záložce u přehrávače na stránce detailu filmu zdroj 1
> online.sktorent.eu zdroj 2 prehraj.to zdroj 3 sledujteto.cz …
> aby bylo jasné, z kterého zdroje momentálně přehráváme"

Before this change the static tab always said `Zdroj 1` and a
dynamic `Zdroj 2` was appended when the user clicked a result
from the live prehraj.to search below the player — neither
surfaced which provider they came from.

## Test plan

- [x] Built + deployed to ceskarepublika.wiki.
- [x] Playwright verify on `/filmy-online/lolita/` (SK Torrent +
      cached Přehraj.to) — both `online.sktorrent.eu` and
      `prehraj.to` tabs render; clicking `prehraj.to` switches
      the player to Přehraj.to (status label "Přehraj.to").
- [x] Playwright verify on `/filmy-online/nightshift-2018/`
      (sledujteto only) — single `sledujteto.cz` tab shown and
      active; video plays as before.

## Not in this PR

Multiple uploads per provider (e.g. sledujteto film with 3 different
audio tracks) will render as clickable rows under the provider tab in
a follow-up. Today the primary upload still plays; the other uploads
are queryable via `film_sledujteto_uploads` but not yet surfaced in
the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)