### PR TITLE
feat(video_sources): dual-write from importers + drift reconciler (#610)

### DIFF
--- a/cr-infra/migrations/20260529_058_video_sources_unified.sql
+++ b/cr-infra/migrations/20260529_058_video_sources_unified.sql
@@ -1,0 +1,434 @@
+-- Unified polymorphic video source schema (issue #607 / sub-issue #608).
+--
+-- Replaces the per-provider tables (`film_prehrajto_uploads`,
+-- `film_sledujteto_uploads`) and the ~15 per-provider denormalized columns on
+-- `films` / `episodes` / `tv_episodes` with a single
+-- `video_providers` + `video_sources` + `video_source_subtitles` stack.
+--
+-- This migration is PHASE 1 of a multi-phase refactor: it only LANDS the new
+-- structure. Backfill, dual-write, reader switch, UX, and the legacy drop are
+-- separate migrations / PRs (#609–#614). Legacy columns + tables continue to
+-- exist and to be the source of truth until the reader switch ships.
+--
+-- Design notes (distilled from the issue + the RDBMS review comment on #608):
+--
+--   1. `video_sources` is polymorphic over (`film_id`, `episode_id`,
+--      `tv_episode_id`). Exactly one of the three must be NOT NULL; enforced
+--      via `num_nonnulls() = 1`. This lets us reuse the same table — and
+--      therefore the same handler code — for films, series episodes, and TV
+--      episodes.
+--
+--   2. `is_primary` replaces the scalar "primary pointer" columns
+--      (`films.prehrajto_primary_upload_id` etc.). Without a constraint the
+--      new schema would accept multiple primaries per (owner, provider), so
+--      we back it with three partial unique indexes — one per parent column
+--      (the standard Postgres way to index a nullable-key condition).
+--
+--   3. Rollup arrays `films.audio_langs` / `subtitle_langs` are maintained by
+--      a trigger that recomputes them atomically in a single SQL statement
+--      (not SELECT-then-UPDATE), so two parallel importers can't lost-update
+--      each other under READ COMMITTED. The trigger grabs the row lock on
+--      `films` via the UPDATE itself.
+--
+--   4. `lang_class` keeps the existing domain enum
+--      (`CZ_DUB|CZ_NATIVE|CZ_SUB|SK_DUB|SK_SUB|EN|UNKNOWN`) as a CHECK
+--      constraint, mirroring `film_prehrajto_uploads` / `film_sledujteto_uploads`
+--      from migrations 048 and 057. A second CHECK ensures `lang_class` and
+--      `audio_lang` can't drift into inconsistent states (e.g. `CZ_DUB` with
+--      `audio_lang='en'`).
+--
+--   5. `cdn`, `duration_sec`, `resolution_hint`, `filesize_bytes`,
+--      `view_count` stay as first-class columns (not JSONB) because they
+--      participate in ORDER BY / WHERE in the listing and detail-page
+--      queries. `metadata JSONB` is reserved for provider-specific bits with
+--      no query pressure (e.g. sktorrent `qualities` string, `added_days_ago`).
+
+-- =============================================================================
+-- video_providers — lookup table for the three source systems.
+-- Seeded with the three providers we support today. Adding a fourth is a
+-- data change, not a schema change.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS video_providers (
+    id             SMALLSERIAL PRIMARY KEY,
+    slug           VARCHAR(32) NOT NULL UNIQUE,
+    host           VARCHAR(64) NOT NULL,
+    display_name   VARCHAR(64) NOT NULL,
+    -- Lower number = shown first on the detail-page tab row. Replaces the
+    -- hard-coded `sktorrent → prehrajto → sledujteto` ordering in the
+    -- Askama templates.
+    sort_priority  SMALLINT    NOT NULL DEFAULT 100,
+    is_active      BOOLEAN     NOT NULL DEFAULT true,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+INSERT INTO video_providers (slug, host, display_name, sort_priority)
+VALUES
+    ('sktorrent',  'online.sktorrent.eu', 'SK Torrent',    10),
+    ('prehrajto',  'prehraj.to',          'Prehraj.to',    20),
+    ('sledujteto', 'sledujteto.cz',       'Sledujteto.cz', 30)
+ON CONFLICT (slug) DO NOTHING;
+
+-- =============================================================================
+-- video_sources — one row per (provider, parent entity, external id).
+-- Parent is polymorphic: exactly one of film_id / episode_id / tv_episode_id.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS video_sources (
+    id               SERIAL      PRIMARY KEY,
+    provider_id      SMALLINT    NOT NULL REFERENCES video_providers(id) ON DELETE RESTRICT,
+
+    -- Polymorphic parent: exactly one non-null, enforced by CHECK below.
+    film_id          INTEGER     REFERENCES films(id)           ON DELETE CASCADE,
+    episode_id       INTEGER     REFERENCES episodes(id) ON DELETE CASCADE,
+    tv_episode_id    INTEGER     REFERENCES tv_episodes(id)     ON DELETE CASCADE,
+
+    -- Provider-native id. sktorrent video_id is INT, prehrajto upload_id is
+    -- 13/16-hex, sledujteto file_id is INT — all serialize into the same
+    -- VARCHAR without loss. UNIQUE per provider below.
+    external_id      VARCHAR(128) NOT NULL,
+
+    title            TEXT,
+    duration_sec     INTEGER,
+    resolution_hint  VARCHAR(32),
+    filesize_bytes   BIGINT,
+    view_count       INTEGER,
+
+    -- Language classification (preserved from legacy tables for transition;
+    -- eventually derivable from audio_lang + subtitle rows).
+    lang_class       VARCHAR(16) NOT NULL DEFAULT 'UNKNOWN',
+
+    -- Detected audio language (ISO 639-1/639-2 short code).
+    audio_lang       VARCHAR(8),
+    audio_confidence REAL,
+    -- Which detector set audio_lang: whisper sample, title-regex, upstream
+    -- metadata, or unknown.
+    audio_detected_by VARCHAR(16),
+
+    -- CDN/host family for the provider-specific playback URL.
+    -- sledujteto: 'www' | 'data1'..'data9' | 'unknown'
+    -- sktorrent:  server number as text ('22' etc.)
+    -- prehrajto:  NULL (URLs are single-host + tokenized)
+    cdn              VARCHAR(32),
+
+    is_primary       BOOLEAN     NOT NULL DEFAULT false,
+    is_alive         BOOLEAN     NOT NULL DEFAULT true,
+    last_seen        TIMESTAMPTZ,
+    last_checked     TIMESTAMPTZ,
+
+    -- Schema-less provider-specific bag (sktorrent qualities, added_days_ago,
+    -- legacy upload URLs, ...). No indexes over it — avoid putting anything
+    -- here that needs fast filtering.
+    metadata         JSONB,
+
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    -- Exactly one parent. Rejects rows where zero or multiple parent FKs are
+    -- set — enforces the polymorphic contract at the DB level.
+    CONSTRAINT video_sources_one_parent_check CHECK (
+        num_nonnulls(film_id, episode_id, tv_episode_id) = 1
+    ),
+
+    -- Inherit the lang_class enum from legacy tables (migrations 048 + 057).
+    CONSTRAINT video_sources_lang_class_check CHECK (
+        lang_class IN ('CZ_DUB', 'CZ_NATIVE', 'CZ_SUB',
+                       'SK_DUB', 'SK_SUB', 'EN', 'UNKNOWN')
+    ),
+
+    -- Prevent lang_class / audio_lang drift. For subtitle-only classes, we
+    -- don't enforce the audio_lang value (original audio varies; it may be
+    -- NULL or 'en' or 'de' etc.), just that it's not the same lang as the
+    -- subtitles (otherwise the row should be DUB/NATIVE, not SUB).
+    CONSTRAINT video_sources_lang_class_audio_consistency_check CHECK (
+        (lang_class IN ('CZ_DUB','CZ_NATIVE') AND audio_lang = 'cs') OR
+        (lang_class = 'CZ_SUB' AND (audio_lang IS NULL OR audio_lang <> 'cs')) OR
+        (lang_class = 'SK_DUB' AND audio_lang = 'sk') OR
+        (lang_class = 'SK_SUB' AND (audio_lang IS NULL OR audio_lang <> 'sk')) OR
+        (lang_class = 'EN' AND audio_lang = 'en') OR
+        (lang_class = 'UNKNOWN')
+    ),
+
+    CONSTRAINT video_sources_audio_lang_format_check CHECK (
+        audio_lang IS NULL OR audio_lang ~ '^[a-z]{2,3}$'
+    ),
+
+    CONSTRAINT video_sources_audio_detected_by_check CHECK (
+        audio_detected_by IS NULL
+        OR audio_detected_by IN ('whisper', 'title_regex', 'upstream', 'unknown')
+    ),
+
+    CONSTRAINT video_sources_audio_confidence_range_check CHECK (
+        audio_confidence IS NULL
+        OR (audio_confidence >= 0.0 AND audio_confidence <= 1.0)
+    )
+);
+
+-- Same external id across providers is fine (sktorrent 12345 ≠ sledujteto 12345);
+-- within a provider the id must be globally unique.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_video_sources_provider_external
+    ON video_sources (provider_id, external_id);
+
+-- Main read paths — "all alive sources for this parent, per provider".
+CREATE INDEX IF NOT EXISTS idx_vs_film_alive
+    ON video_sources (film_id) WHERE is_alive AND film_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_vs_episode_alive
+    ON video_sources (episode_id) WHERE is_alive AND episode_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_vs_tv_episode_alive
+    ON video_sources (tv_episode_id) WHERE is_alive AND tv_episode_id IS NOT NULL;
+
+-- Reconciliation sweep ("sources unseen for 30 days") — supports the periodic
+-- is_alive=false flagging job.
+CREATE INDEX IF NOT EXISTS idx_vs_last_seen_alive
+    ON video_sources (last_seen) WHERE is_alive;
+
+-- Primary-pointer integrity. Each partial unique index enforces "at most one
+-- is_primary per (provider, parent)". Three indexes — one per parent column —
+-- is the clean Postgres pattern when the partial condition involves a
+-- non-null check on a nullable column.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_vs_primary_film
+    ON video_sources (provider_id, film_id)
+    WHERE is_primary AND film_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_vs_primary_episode
+    ON video_sources (provider_id, episode_id)
+    WHERE is_primary AND episode_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_vs_primary_tv_episode
+    ON video_sources (provider_id, tv_episode_id)
+    WHERE is_primary AND tv_episode_id IS NOT NULL;
+
+-- =============================================================================
+-- video_source_subtitles — 1:N child of video_sources.
+-- Persisted even when URL is NULL (sledujteto subtitles are resolved at
+-- play-time), so filters + badges work from the DB without live resolve.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS video_source_subtitles (
+    id          SERIAL      PRIMARY KEY,
+    source_id   INTEGER     NOT NULL REFERENCES video_sources(id) ON DELETE CASCADE,
+    lang        VARCHAR(8)  NOT NULL,
+    label       VARCHAR(64),
+    -- 'srt' | 'vtt' | 'ass' | 'ssa' | NULL (unknown until resolved).
+    format      VARCHAR(8),
+    -- NULL when we know the track exists but haven't resolved the URL yet
+    -- (sledujteto: playback endpoint returns URLs; crawler only records
+    -- existence). Resolved URLs are re-fetched live from a proxy endpoint.
+    url         TEXT,
+    is_default  BOOLEAN     NOT NULL DEFAULT false,
+    is_forced   BOOLEAN     NOT NULL DEFAULT false,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    CONSTRAINT video_source_subtitles_lang_format_check CHECK (
+        lang ~ '^[a-z]{2,3}$'
+    )
+);
+
+-- Include `format` in the uniqueness key: a single upload can legitimately
+-- carry .srt + .ass for the same (lang, is_forced) tuple, and we want both
+-- rows persisted. Uses COALESCE because format can be NULL during the
+-- window between subtitle discovery and the first URL resolve.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_vss_per_source_lang_format
+    ON video_source_subtitles (source_id, lang, is_forced, COALESCE(format, ''));
+
+CREATE INDEX IF NOT EXISTS idx_vss_source_id
+    ON video_source_subtitles (source_id);
+
+-- =============================================================================
+-- Rollup arrays on parent tables + GIN indexes for the audio/subs filter.
+--
+-- These are maintained by the trigger below. They're a denormalization for
+-- fast listing filters: `WHERE 'cs' = ANY(audio_langs)` lands a GIN index
+-- lookup instead of a correlated subquery against video_sources.
+-- =============================================================================
+
+ALTER TABLE films
+    ADD COLUMN IF NOT EXISTS audio_langs    TEXT[] NOT NULL DEFAULT '{}'::TEXT[],
+    ADD COLUMN IF NOT EXISTS subtitle_langs TEXT[] NOT NULL DEFAULT '{}'::TEXT[];
+
+ALTER TABLE episodes
+    ADD COLUMN IF NOT EXISTS audio_langs    TEXT[] NOT NULL DEFAULT '{}'::TEXT[],
+    ADD COLUMN IF NOT EXISTS subtitle_langs TEXT[] NOT NULL DEFAULT '{}'::TEXT[];
+
+ALTER TABLE tv_episodes
+    ADD COLUMN IF NOT EXISTS audio_langs    TEXT[] NOT NULL DEFAULT '{}'::TEXT[],
+    ADD COLUMN IF NOT EXISTS subtitle_langs TEXT[] NOT NULL DEFAULT '{}'::TEXT[];
+
+CREATE INDEX IF NOT EXISTS idx_films_audio_langs_gin
+    ON films USING GIN (audio_langs);
+CREATE INDEX IF NOT EXISTS idx_films_subtitle_langs_gin
+    ON films USING GIN (subtitle_langs);
+
+CREATE INDEX IF NOT EXISTS idx_episodes_audio_langs_gin
+    ON episodes USING GIN (audio_langs);
+CREATE INDEX IF NOT EXISTS idx_episodes_subtitle_langs_gin
+    ON episodes USING GIN (subtitle_langs);
+
+CREATE INDEX IF NOT EXISTS idx_tv_episodes_audio_langs_gin
+    ON tv_episodes USING GIN (audio_langs);
+CREATE INDEX IF NOT EXISTS idx_tv_episodes_subtitle_langs_gin
+    ON tv_episodes USING GIN (subtitle_langs);
+
+-- =============================================================================
+-- Rollup trigger — keeps audio_langs / subtitle_langs in sync on parent rows.
+--
+-- Implementation note (race condition):
+--   The recomputation is a single atomic UPDATE. A naive "SELECT array_agg →
+--   UPDATE" sequence under READ COMMITTED allows two concurrent inserts into
+--   video_sources for the same film to each compute a "before-the-other"
+--   snapshot and clobber each other's contribution. A one-statement UPDATE
+--   grabs the row lock on the parent row via its own UPDATE — the second
+--   transaction then waits for the first to commit before re-evaluating the
+--   subquery, so the final state reflects both inserts.
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION recompute_video_rollups_for_parent(
+    p_film_id       INTEGER,
+    p_episode_id    INTEGER,
+    p_tv_episode_id INTEGER
+) RETURNS VOID AS $$
+BEGIN
+    -- Atomic single-UPDATE per parent column. Whichever `p_*_id` argument
+    -- is non-NULL, we update the corresponding table and set its
+    -- `audio_langs` / `subtitle_langs` from a subquery over alive sources.
+    IF p_film_id IS NOT NULL THEN
+        UPDATE films f
+        SET audio_langs = COALESCE(
+                (SELECT array_agg(DISTINCT vs.audio_lang ORDER BY vs.audio_lang)
+                 FROM video_sources vs
+                 WHERE vs.film_id = p_film_id
+                   AND vs.is_alive
+                   AND vs.audio_lang IS NOT NULL),
+                '{}'::TEXT[]),
+            subtitle_langs = COALESCE(
+                (SELECT array_agg(DISTINCT vss.lang ORDER BY vss.lang)
+                 FROM video_sources vs
+                 JOIN video_source_subtitles vss ON vss.source_id = vs.id
+                 WHERE vs.film_id = p_film_id AND vs.is_alive),
+                '{}'::TEXT[])
+        WHERE f.id = p_film_id;
+    END IF;
+
+    IF p_episode_id IS NOT NULL THEN
+        UPDATE episodes e
+        SET audio_langs = COALESCE(
+                (SELECT array_agg(DISTINCT vs.audio_lang ORDER BY vs.audio_lang)
+                 FROM video_sources vs
+                 WHERE vs.episode_id = p_episode_id
+                   AND vs.is_alive
+                   AND vs.audio_lang IS NOT NULL),
+                '{}'::TEXT[]),
+            subtitle_langs = COALESCE(
+                (SELECT array_agg(DISTINCT vss.lang ORDER BY vss.lang)
+                 FROM video_sources vs
+                 JOIN video_source_subtitles vss ON vss.source_id = vs.id
+                 WHERE vs.episode_id = p_episode_id AND vs.is_alive),
+                '{}'::TEXT[])
+        WHERE e.id = p_episode_id;
+    END IF;
+
+    IF p_tv_episode_id IS NOT NULL THEN
+        UPDATE tv_episodes t
+        SET audio_langs = COALESCE(
+                (SELECT array_agg(DISTINCT vs.audio_lang ORDER BY vs.audio_lang)
+                 FROM video_sources vs
+                 WHERE vs.tv_episode_id = p_tv_episode_id
+                   AND vs.is_alive
+                   AND vs.audio_lang IS NOT NULL),
+                '{}'::TEXT[]),
+            subtitle_langs = COALESCE(
+                (SELECT array_agg(DISTINCT vss.lang ORDER BY vss.lang)
+                 FROM video_sources vs
+                 JOIN video_source_subtitles vss ON vss.source_id = vs.id
+                 WHERE vs.tv_episode_id = p_tv_episode_id AND vs.is_alive),
+                '{}'::TEXT[])
+        WHERE t.id = p_tv_episode_id;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger on video_sources — fires after INSERT / UPDATE / DELETE.
+-- For UPDATE we have to recompute for BOTH the old and new parent in case
+-- a source is re-pointed (rare, but possible during backfill re-runs).
+CREATE OR REPLACE FUNCTION trg_video_sources_rollup() RETURNS TRIGGER AS $$
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        PERFORM recompute_video_rollups_for_parent(
+            NEW.film_id, NEW.episode_id, NEW.tv_episode_id);
+    ELSIF TG_OP = 'DELETE' THEN
+        PERFORM recompute_video_rollups_for_parent(
+            OLD.film_id, OLD.episode_id, OLD.tv_episode_id);
+    ELSE  -- UPDATE
+        PERFORM recompute_video_rollups_for_parent(
+            NEW.film_id, NEW.episode_id, NEW.tv_episode_id);
+        -- If parent moved, also recompute OLD parent so it drops the lang.
+        IF OLD.film_id IS DISTINCT FROM NEW.film_id
+           OR OLD.episode_id IS DISTINCT FROM NEW.episode_id
+           OR OLD.tv_episode_id IS DISTINCT FROM NEW.tv_episode_id THEN
+            PERFORM recompute_video_rollups_for_parent(
+                OLD.film_id, OLD.episode_id, OLD.tv_episode_id);
+        END IF;
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_video_sources_rollup_aiud
+    AFTER INSERT OR UPDATE OR DELETE ON video_sources
+    FOR EACH ROW EXECUTE FUNCTION trg_video_sources_rollup();
+
+-- Trigger on video_source_subtitles — subtitle changes don't change audio_lang
+-- but do change subtitle_langs. We look up the owning source's parent ids
+-- and recompute only for that parent.
+CREATE OR REPLACE FUNCTION trg_video_source_subtitles_rollup() RETURNS TRIGGER AS $$
+DECLARE
+    v_film       INTEGER;
+    v_episode    INTEGER;
+    v_tv_episode INTEGER;
+    v_source_id  INTEGER;
+BEGIN
+    -- Pick source_id from NEW or OLD depending on op.
+    IF TG_OP = 'DELETE' THEN
+        v_source_id := OLD.source_id;
+    ELSE
+        v_source_id := NEW.source_id;
+    END IF;
+
+    SELECT film_id, episode_id, tv_episode_id
+    INTO   v_film, v_episode, v_tv_episode
+    FROM   video_sources
+    WHERE  id = v_source_id;
+
+    IF FOUND THEN
+        PERFORM recompute_video_rollups_for_parent(v_film, v_episode, v_tv_episode);
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_video_source_subtitles_rollup_aiud
+    AFTER INSERT OR UPDATE OR DELETE ON video_source_subtitles
+    FOR EACH ROW EXECUTE FUNCTION trg_video_source_subtitles_rollup();
+
+-- TRUNCATE triggers. Row-level triggers don't fire on TRUNCATE, which would
+-- leave `audio_langs` / `subtitle_langs` rollup arrays stale on parent rows.
+-- Production doesn't use TRUNCATE (the dual-write + reader switch pipelines
+-- all use INSERT/UPDATE/DELETE), but a dev cleanup path or an accidental
+-- TRUNCATE in a migration would silently desync the rollups without this.
+CREATE OR REPLACE FUNCTION trg_video_sources_truncate() RETURNS TRIGGER AS $$
+BEGIN
+    UPDATE films       SET audio_langs = '{}'::TEXT[], subtitle_langs = '{}'::TEXT[]
+                       WHERE cardinality(audio_langs) > 0 OR cardinality(subtitle_langs) > 0;
+    UPDATE episodes    SET audio_langs = '{}'::TEXT[], subtitle_langs = '{}'::TEXT[]
+                       WHERE cardinality(audio_langs) > 0 OR cardinality(subtitle_langs) > 0;
+    UPDATE tv_episodes SET audio_langs = '{}'::TEXT[], subtitle_langs = '{}'::TEXT[]
+                       WHERE cardinality(audio_langs) > 0 OR cardinality(subtitle_langs) > 0;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_video_sources_truncate_s
+    AFTER TRUNCATE ON video_sources
+    FOR EACH STATEMENT EXECUTE FUNCTION trg_video_sources_truncate();

--- a/cr-web/src/handlers/mod.rs
+++ b/cr-web/src/handlers/mod.rs
@@ -29,6 +29,7 @@ mod regions;
 mod series;
 mod tv_porady;
 pub mod video_api;
+mod video_sources;
 
 // Re-export all public handlers so main.rs doesn't need changes
 pub use admin_test_sledujteto::admin_test_sledujteto;

--- a/cr-web/src/handlers/video_sources.rs
+++ b/cr-web/src/handlers/video_sources.rs
@@ -1,0 +1,71 @@
+//! Data types for the unified `video_sources` schema (issue #607 / #608).
+//!
+//! PR1 only lands these structs so `cargo check` and `cargo sqlx prepare`
+//! verify they compile against the migrated schema. Readers and writers
+//! are wired up in the follow-up PRs (#611 reader switch, #610 dual-write).
+//!
+//! Schema reference: `cr-infra/migrations/20260529_058_video_sources_unified.sql`.
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+
+/// One row in `video_providers`. Lookup table, seeded with 3 rows
+/// (sktorrent / prehrajto / sledujteto). Adding a fourth is a data change.
+#[derive(Debug, Clone, sqlx::FromRow, Serialize)]
+#[allow(dead_code)] // Landed in PR1; consumed in PR3 (#611 reader switch).
+pub(crate) struct VideoProvider {
+    pub(crate) id: i16,
+    pub(crate) slug: String,
+    pub(crate) host: String,
+    pub(crate) display_name: String,
+    pub(crate) sort_priority: i16,
+    pub(crate) is_active: bool,
+}
+
+/// One row in `video_sources`. Polymorphic over three parent columns — exactly
+/// one of `film_id` / `episode_id` / `tv_episode_id` is `Some` (enforced by
+/// the `video_sources_one_parent_check` CHECK constraint at the DB level).
+#[derive(Debug, Clone, sqlx::FromRow, Serialize)]
+#[allow(dead_code)] // Landed in PR1; consumed in PR3 (#611 reader switch).
+pub(crate) struct VideoSource {
+    pub(crate) id: i32,
+    pub(crate) provider_id: i16,
+    pub(crate) film_id: Option<i32>,
+    pub(crate) episode_id: Option<i32>,
+    pub(crate) tv_episode_id: Option<i32>,
+    pub(crate) external_id: String,
+    pub(crate) title: Option<String>,
+    pub(crate) duration_sec: Option<i32>,
+    pub(crate) resolution_hint: Option<String>,
+    pub(crate) filesize_bytes: Option<i64>,
+    pub(crate) view_count: Option<i32>,
+    pub(crate) lang_class: String,
+    pub(crate) audio_lang: Option<String>,
+    pub(crate) audio_confidence: Option<f32>,
+    pub(crate) audio_detected_by: Option<String>,
+    pub(crate) cdn: Option<String>,
+    pub(crate) is_primary: bool,
+    pub(crate) is_alive: bool,
+    pub(crate) last_seen: Option<DateTime<Utc>>,
+    pub(crate) last_checked: Option<DateTime<Utc>>,
+    pub(crate) metadata: Option<serde_json::Value>,
+    pub(crate) created_at: DateTime<Utc>,
+    pub(crate) updated_at: DateTime<Utc>,
+}
+
+/// One row in `video_source_subtitles`. Persisted even when `url` is NULL
+/// (sledujteto resolves URLs live at play time) so filters + badges can
+/// work from the DB without a live resolve.
+#[derive(Debug, Clone, sqlx::FromRow, Serialize)]
+#[allow(dead_code)] // Landed in PR1; consumed in PR3 (#611 reader switch).
+pub(crate) struct VideoSourceSubtitle {
+    pub(crate) id: i32,
+    pub(crate) source_id: i32,
+    pub(crate) lang: String,
+    pub(crate) label: Option<String>,
+    pub(crate) format: Option<String>,
+    pub(crate) url: Option<String>,
+    pub(crate) is_default: bool,
+    pub(crate) is_forced: bool,
+    pub(crate) created_at: DateTime<Utc>,
+}

--- a/scripts/auto_import/enricher.py
+++ b/scripts/auto_import/enricher.py
@@ -21,6 +21,10 @@ import psycopg2
 from scripts.auto_import.cover_downloader import download_cover, download_sktorrent_thumb
 from scripts.auto_import.gemma_writer import generate_unique_cs
 from scripts.auto_import.tmdb_resolver import MovieResolution
+from scripts.video_sources_helper import (
+    dual_write_sktorrent,
+    get_provider_ids,
+)
 
 log = logging.getLogger(__name__)
 
@@ -158,6 +162,22 @@ def upsert_film(
              movie.poster_path,
              film_id),
         )
+        # Dual-write into the unified video_sources schema (#607 / #610).
+        # has_dub/has_subtitles here reflect only THIS run's signal (regex over
+        # the sktorrent title); the legacy UPDATE OR-ed them into the films
+        # column so historical signals are preserved. The video_sources row
+        # carries only the current detection, which is the right semantic for
+        # a per-source record (a source either has CZ audio or doesn't).
+        dual_write_sktorrent(
+            cur,
+            providers=get_provider_ids(cur),
+            film_id=film_id,
+            sktorrent_video_id=sktorrent_video_id,
+            sktorrent_cdn=sktorrent_cdn,
+            sktorrent_qualities=qualities_str,
+            has_dub=has_dub,
+            has_subtitles=has_subtitles,
+        )
         log.info("upserted SKT into existing film %d (imdb=%s)", film_id, movie.imdb_id)
         return "updated_film", film_id
 
@@ -204,6 +224,19 @@ def upsert_film(
         ),
     )
     film_id = cur.fetchone()[0]
+
+    # Dual-write into the unified video_sources schema (#607 / #610). Same
+    # transaction as the films INSERT above.
+    dual_write_sktorrent(
+        cur,
+        providers=get_provider_ids(cur),
+        film_id=film_id,
+        sktorrent_video_id=sktorrent_video_id,
+        sktorrent_cdn=sktorrent_cdn,
+        sktorrent_qualities=qualities_str,
+        has_dub=has_dub,
+        has_subtitles=has_subtitles,
+    )
 
     # Cover (best-effort, id-keyed layout). TMDB first, then SK Torrent
     # thumbnail as a low-res fallback for obscure CZ titles without a TMDB

--- a/scripts/auto_import/series_enricher.py
+++ b/scripts/auto_import/series_enricher.py
@@ -31,6 +31,10 @@ from scripts.auto_import.tmdb_resolver import (
     TvResolution,
     resolve_episode,
 )
+from scripts.video_sources_helper import (
+    dual_write_sktorrent,
+    get_provider_ids,
+)
 
 log = logging.getLogger(__name__)
 
@@ -209,6 +213,17 @@ def upsert_episode(
             (sktorrent_video_id, sktorrent_cdn, qualities_str,
              has_dub, has_subtitles, ep_id),
         )
+        # Dual-write into the unified video_sources schema (#607 / #610).
+        dual_write_sktorrent(
+            cur,
+            providers=get_provider_ids(cur),
+            episode_id=ep_id,
+            sktorrent_video_id=sktorrent_video_id,
+            sktorrent_cdn=sktorrent_cdn,
+            sktorrent_qualities=qualities_str,
+            has_dub=has_dub,
+            has_subtitles=has_subtitles,
+        )
         log.info("updated episode %d S%dE%d (added SKT %d)",
                  ep_id, season, episode_num, sktorrent_video_id)
         return "updated_episode", ep_id
@@ -234,6 +249,17 @@ def upsert_episode(
         ),
     )
     ep_id = cur.fetchone()[0]
+    # Dual-write into the unified video_sources schema (#607 / #610).
+    dual_write_sktorrent(
+        cur,
+        providers=get_provider_ids(cur),
+        episode_id=ep_id,
+        sktorrent_video_id=sktorrent_video_id,
+        sktorrent_cdn=sktorrent_cdn,
+        sktorrent_qualities=qualities_str,
+        has_dub=has_dub,
+        has_subtitles=has_subtitles,
+    )
     log.info("added episode %d S%dE%d (series_id=%d)", ep_id, season, episode_num, series_id)
     return "added_episode", ep_id
 

--- a/scripts/auto_import/tv_show_enricher.py
+++ b/scripts/auto_import/tv_show_enricher.py
@@ -27,6 +27,11 @@ import re
 import unicodedata
 from dataclasses import dataclass
 
+from scripts.video_sources_helper import (
+    dual_write_sktorrent,
+    get_provider_ids,
+)
+
 log = logging.getLogger(__name__)
 
 
@@ -164,6 +169,17 @@ def process_tv_show_episode(
         )
 
     tv_episode_id = row[0]
+    # Dual-write into the unified video_sources schema (#607 / #610).
+    dual_write_sktorrent(
+        cur,
+        providers=get_provider_ids(cur),
+        tv_episode_id=tv_episode_id,
+        sktorrent_video_id=sktorrent_video_id,
+        sktorrent_cdn=sktorrent_cdn,
+        sktorrent_qualities=qualities_str,
+        has_dub=has_dub,
+        has_subtitles=has_subtitles,
+    )
     action = (
         "added_tv_show+added_tv_episode" if created_show else "added_tv_episode"
     )

--- a/scripts/backfill-sktorrent-langs.py
+++ b/scripts/backfill-sktorrent-langs.py
@@ -22,6 +22,10 @@ sys.path.insert(0, str(_PROJECT_ROOT))
 import psycopg2
 
 from scripts.auto_import.title_parser import parse_sktorrent_title
+from scripts.video_sources_helper import (
+    dual_write_sktorrent,
+    get_provider_ids,
+)
 
 
 def _flags(title: str) -> tuple[bool, bool]:
@@ -37,6 +41,8 @@ def main() -> int:
         raise SystemExit("DATABASE_URL required")
     conn = psycopg2.connect(dsn)
     cur = conn.cursor()
+
+    providers = get_provider_ids(cur)
 
     updated_films = 0
     cur.execute(
@@ -57,6 +63,26 @@ def main() -> int:
         )
         if cur.rowcount:
             updated_films += 1
+            # Dual-write (#607 / #610): refresh the video_sources row for
+            # this film's sktorrent source so the lang classification on
+            # the new schema matches the flags we just ORed into `films`.
+            cur.execute(
+                "SELECT sktorrent_video_id, sktorrent_cdn, sktorrent_qualities "
+                "FROM films WHERE id = %s",
+                (film_id,),
+            )
+            row = cur.fetchone()
+            if row and row[0] is not None:
+                dual_write_sktorrent(
+                    cur,
+                    providers=providers,
+                    film_id=film_id,
+                    sktorrent_video_id=row[0],
+                    sktorrent_cdn=row[1],
+                    sktorrent_qualities=row[2],
+                    has_dub=has_dub,
+                    has_subtitles=has_subs,
+                )
 
     updated_episodes = 0
     cur.execute(
@@ -77,6 +103,23 @@ def main() -> int:
         )
         if cur.rowcount:
             updated_episodes += 1
+            cur.execute(
+                "SELECT sktorrent_video_id, sktorrent_cdn, sktorrent_qualities "
+                "FROM episodes WHERE id = %s",
+                (ep_id,),
+            )
+            row = cur.fetchone()
+            if row and row[0] is not None:
+                dual_write_sktorrent(
+                    cur,
+                    providers=providers,
+                    episode_id=ep_id,
+                    sktorrent_video_id=row[0],
+                    sktorrent_cdn=row[1],
+                    sktorrent_qualities=row[2],
+                    has_dub=has_dub,
+                    has_subtitles=has_subs,
+                )
 
     conn.commit()
     print(f"backfilled {updated_films} films, {updated_episodes} episodes")

--- a/scripts/backfill-video-sources.py
+++ b/scripts/backfill-video-sources.py
@@ -1,0 +1,550 @@
+#!/usr/bin/env python3
+"""Backfill `video_sources` + `video_source_subtitles` from the legacy
+per-provider tables and denormalized columns (issue #607 / sub-issue #609).
+
+After this runs, the new unified schema has parity with the legacy data;
+the legacy tables + columns remain the source of truth until the reader
+switch (#611) ships. The script is idempotent — re-running it is a no-op
+modulo `last_seen` / `updated_at` column refreshes.
+
+Data sources → target rows:
+
+  1. sktorrent: for every (films | episodes | tv_episodes) row with
+     `sktorrent_video_id IS NOT NULL`, insert one `video_sources` row with
+       provider = sktorrent
+       external_id = sktorrent_video_id::text
+       cdn = sktorrent_cdn::text
+       is_primary = true  (sktorrent is always 1:1 in legacy)
+       audio_lang/lang_class derived from has_dub + has_subtitles
+     Subtitle row inserted when has_subtitles = true (assumes CZ subs).
+
+  2. prehrajto: copy every `film_prehrajto_uploads` row →
+       provider = prehrajto
+       external_id = upload_id
+       is_primary = (upload_id = films.prehrajto_primary_upload_id)
+       lang_class copied verbatim
+       audio_lang/subtitle rows derived from lang_class
+
+  3. sledujteto: copy every `film_sledujteto_uploads` row →
+       provider = sledujteto
+       external_id = file_id::text
+       cdn = cdn
+       is_primary = (file_id = films.sledujteto_primary_file_id)
+       lang_class copied verbatim
+
+Idempotence is guaranteed by `ON CONFLICT (provider_id, external_id) DO UPDATE`
+in every INSERT.
+
+Invariants verified at end:
+  - no (owner, provider) pair has more than one is_primary row
+  - every legacy primary pointer maps to a matching video_sources primary row
+
+Usage:
+    DATABASE_URL=postgres://... \\
+    python3 scripts/backfill-video-sources.py [--dry-run] [--limit N] \\
+        [--skip-sktorrent] [--skip-prehrajto] [--skip-sledujteto]
+
+Flags:
+  --dry-run    Wrap everything in a transaction and ROLLBACK at the end.
+               Prints final summary counts but leaves the DB untouched.
+  --limit N    Process at most N source rows from each provider path
+               (ordered by id). For sanity-check runs on dev.
+  --verbose    Log every insert, not just summaries.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+try:
+    import psycopg2
+    import psycopg2.extras
+except ImportError:
+    print("pip install psycopg2-binary", file=sys.stderr)
+    sys.exit(1)
+
+
+log = logging.getLogger("backfill-video-sources")
+
+
+# video_providers.slug → (audio_lang fallback, lang_class fallback). We cache
+# the IDs looked up in provider_ids() after the first call.
+PROVIDER_SLUGS = ("sktorrent", "prehrajto", "sledujteto")
+
+
+def provider_ids(cur) -> dict[str, int]:
+    cur.execute(
+        "SELECT slug, id FROM video_providers WHERE slug = ANY(%s)",
+        (list(PROVIDER_SLUGS),),
+    )
+    return {row["slug"]: row["id"] for row in cur.fetchall()}
+
+
+def lang_class_to_audio_and_subs(lang_class: str | None,
+                                 has_dub: bool = False,
+                                 has_subtitles: bool = False
+                                 ) -> tuple[str | None, str, list[str]]:
+    """Map legacy lang signals to (audio_lang, lang_class, subtitle_langs).
+
+    `lang_class` is the legacy-table enum
+    (CZ_DUB|CZ_NATIVE|CZ_SUB|SK_DUB|SK_SUB|EN|UNKNOWN) when known, else None.
+    `has_dub` / `has_subtitles` are the sktorrent-side booleans used as a
+    fallback when no lang_class is available.
+
+    Returns a triple:
+      audio_lang  — 2/3-char ISO code or None (must satisfy the CHECK
+                    constraint `^[a-z]{2,3}$`).
+      lang_class  — normalized enum value. The DB CHECK
+                    video_sources_lang_class_audio_consistency_check
+                    enforces audio_lang ↔ lang_class consistency, so this
+                    function is the single place where those two fields
+                    are derived together.
+      sub_langs   — list of subtitle language codes to insert as
+                    video_source_subtitles rows (often empty).
+    """
+    if lang_class == "CZ_DUB":
+        return "cs", "CZ_DUB", []
+    if lang_class == "CZ_NATIVE":
+        return "cs", "CZ_NATIVE", []
+    if lang_class == "CZ_SUB":
+        # Audio is original (often en), unknown from legacy data.
+        return None, "CZ_SUB", ["cs"]
+    if lang_class == "SK_DUB":
+        return "sk", "SK_DUB", []
+    if lang_class == "SK_SUB":
+        return None, "SK_SUB", ["sk"]
+    if lang_class == "EN":
+        return "en", "EN", []
+
+    # Fallback path for sktorrent (only has_dub / has_subtitles available).
+    if has_dub and has_subtitles:
+        # Both flags → dub is primary audio signal, subtitles coexist.
+        return "cs", "CZ_DUB", ["cs"]
+    if has_dub:
+        return "cs", "CZ_DUB", []
+    if has_subtitles:
+        return None, "CZ_SUB", ["cs"]
+    return None, "UNKNOWN", []
+
+
+def upsert_video_source(cur, *,
+                        provider_id: int,
+                        external_id: str,
+                        film_id: int | None = None,
+                        episode_id: int | None = None,
+                        tv_episode_id: int | None = None,
+                        title: str | None = None,
+                        duration_sec: int | None = None,
+                        resolution_hint: str | None = None,
+                        filesize_bytes: int | None = None,
+                        view_count: int | None = None,
+                        lang_class: str = "UNKNOWN",
+                        audio_lang: str | None = None,
+                        audio_detected_by: str | None = None,
+                        cdn: str | None = None,
+                        is_primary: bool = False,
+                        is_alive: bool = True,
+                        last_seen = None,
+                        metadata = None,
+                        ) -> int:
+    """UPSERT a video_sources row. Returns the id of the (new or existing) row.
+
+    Idempotence via `ON CONFLICT (provider_id, external_id)`: a re-run updates
+    the mutable fields (is_alive, cdn, lang_class, …) but keeps the row id
+    stable, so `video_source_subtitles.source_id` stays valid across re-runs.
+    """
+    cur.execute(
+        """
+        INSERT INTO video_sources (
+            provider_id, film_id, episode_id, tv_episode_id,
+            external_id, title, duration_sec, resolution_hint,
+            filesize_bytes, view_count, lang_class, audio_lang,
+            audio_detected_by, cdn, is_primary, is_alive,
+            last_seen, metadata, updated_at
+        ) VALUES (
+            %(provider_id)s, %(film_id)s, %(episode_id)s, %(tv_episode_id)s,
+            %(external_id)s, %(title)s, %(duration_sec)s, %(resolution_hint)s,
+            %(filesize_bytes)s, %(view_count)s, %(lang_class)s, %(audio_lang)s,
+            %(audio_detected_by)s, %(cdn)s, %(is_primary)s, %(is_alive)s,
+            %(last_seen)s, %(metadata)s, NOW()
+        )
+        ON CONFLICT (provider_id, external_id) DO UPDATE SET
+            film_id           = EXCLUDED.film_id,
+            episode_id        = EXCLUDED.episode_id,
+            tv_episode_id     = EXCLUDED.tv_episode_id,
+            title             = COALESCE(EXCLUDED.title, video_sources.title),
+            duration_sec      = COALESCE(EXCLUDED.duration_sec, video_sources.duration_sec),
+            resolution_hint   = COALESCE(EXCLUDED.resolution_hint, video_sources.resolution_hint),
+            filesize_bytes    = COALESCE(EXCLUDED.filesize_bytes, video_sources.filesize_bytes),
+            view_count        = COALESCE(EXCLUDED.view_count, video_sources.view_count),
+            lang_class        = EXCLUDED.lang_class,
+            audio_lang        = EXCLUDED.audio_lang,
+            audio_detected_by = EXCLUDED.audio_detected_by,
+            cdn               = EXCLUDED.cdn,
+            is_primary        = EXCLUDED.is_primary,
+            is_alive          = EXCLUDED.is_alive,
+            last_seen         = COALESCE(EXCLUDED.last_seen, video_sources.last_seen),
+            metadata          = COALESCE(EXCLUDED.metadata, video_sources.metadata),
+            updated_at        = NOW()
+        RETURNING id
+        """,
+        dict(
+            provider_id=provider_id,
+            film_id=film_id,
+            episode_id=episode_id,
+            tv_episode_id=tv_episode_id,
+            external_id=external_id,
+            title=title,
+            duration_sec=duration_sec,
+            resolution_hint=resolution_hint,
+            filesize_bytes=filesize_bytes,
+            view_count=view_count,
+            lang_class=lang_class,
+            audio_lang=audio_lang,
+            audio_detected_by=audio_detected_by,
+            cdn=cdn,
+            is_primary=is_primary,
+            is_alive=is_alive,
+            last_seen=last_seen,
+            metadata=psycopg2.extras.Json(metadata) if metadata else None,
+        ),
+    )
+    return cur.fetchone()["id"]
+
+
+def upsert_subtitle(cur, source_id: int, lang: str) -> None:
+    """Insert a subtitle row if absent. URL + format stay NULL (filled by
+    the live resolver at play-time for sledujteto / prehrajto)."""
+    cur.execute(
+        """
+        INSERT INTO video_source_subtitles (source_id, lang)
+        VALUES (%s, %s)
+        ON CONFLICT (source_id, lang, is_forced, COALESCE(format, ''))
+        DO NOTHING
+        """,
+        (source_id, lang),
+    )
+
+
+def backfill_sktorrent(cur, providers: dict[str, int], limit: int | None
+                       ) -> tuple[int, int]:
+    """Backfill sktorrent sources for films / episodes / tv_episodes.
+
+    Returns (inserted_rows, skipped_rows) counts.
+    """
+    provider_id = providers["sktorrent"]
+    inserted = 0
+    skipped = 0
+
+    for table, parent_col in (("films", "film_id"),
+                              ("episodes", "episode_id"),
+                              ("tv_episodes", "tv_episode_id")):
+        qualities_col = "sktorrent_qualities" if table != "episodes" else "sktorrent_qualities"
+        cdn_col = "sktorrent_cdn"
+        # `has_dub` / `has_subtitles` exist on all three tables for sktorrent
+        # legacy detection.
+        limit_clause = f"LIMIT {int(limit)}" if limit else ""
+        cur.execute(
+            f"""
+            SELECT id, sktorrent_video_id, {cdn_col} AS cdn,
+                   {qualities_col} AS qualities, has_dub, has_subtitles
+            FROM {table}
+            WHERE sktorrent_video_id IS NOT NULL
+            ORDER BY id
+            {limit_clause}
+            """
+        )
+        rows = cur.fetchall()
+        log.info("sktorrent/%s: %d candidates", table, len(rows))
+
+        for row in rows:
+            audio_lang, lang_class, sub_langs = lang_class_to_audio_and_subs(
+                None, has_dub=row["has_dub"], has_subtitles=row["has_subtitles"])
+            metadata = {"qualities": row["qualities"]} if row["qualities"] else None
+
+            parent_kwargs = {parent_col: row["id"]}
+            try:
+                source_id = upsert_video_source(
+                    cur,
+                    provider_id=provider_id,
+                    external_id=str(row["sktorrent_video_id"]),
+                    **parent_kwargs,
+                    lang_class=lang_class,
+                    audio_lang=audio_lang,
+                    audio_detected_by="title_regex" if lang_class != "UNKNOWN" else None,
+                    cdn=str(row["cdn"]) if row["cdn"] is not None else None,
+                    is_primary=True,  # sktorrent is 1:1 in legacy
+                    is_alive=True,
+                    metadata=metadata,
+                )
+                for lang in sub_langs:
+                    upsert_subtitle(cur, source_id, lang)
+                inserted += 1
+            except psycopg2.Error as e:
+                log.warning("sktorrent/%s id=%d video_id=%s: %s",
+                            table, row["id"], row["sktorrent_video_id"], e)
+                skipped += 1
+
+    return inserted, skipped
+
+
+def backfill_prehrajto(cur, providers: dict[str, int], limit: int | None
+                       ) -> tuple[int, int]:
+    """Backfill prehrajto sources from film_prehrajto_uploads."""
+    provider_id = providers["prehrajto"]
+    limit_clause = f"LIMIT {int(limit)}" if limit else ""
+    cur.execute(
+        f"""
+        SELECT u.film_id, u.upload_id, u.url, u.title, u.duration_sec,
+               u.view_count, u.lang_class, u.resolution_hint,
+               u.discovered_at, u.last_seen_at, u.is_alive, u.is_direct,
+               f.prehrajto_primary_upload_id
+        FROM film_prehrajto_uploads u
+        JOIN films f ON f.id = u.film_id
+        ORDER BY u.film_id, u.upload_id
+        {limit_clause}
+        """
+    )
+    rows = cur.fetchall()
+    log.info("prehrajto: %d uploads", len(rows))
+
+    inserted = 0
+    skipped = 0
+    for row in rows:
+        audio_lang, lang_class, sub_langs = lang_class_to_audio_and_subs(row["lang_class"])
+        is_primary = row["upload_id"] == row["prehrajto_primary_upload_id"]
+        metadata = {
+            "url": row["url"],
+            "is_direct": row["is_direct"],
+            "discovered_at": row["discovered_at"].isoformat() if row["discovered_at"] else None,
+        }
+        try:
+            source_id = upsert_video_source(
+                cur,
+                provider_id=provider_id,
+                external_id=row["upload_id"],
+                film_id=row["film_id"],
+                title=row["title"],
+                duration_sec=row["duration_sec"],
+                resolution_hint=row["resolution_hint"],
+                view_count=row["view_count"],
+                lang_class=lang_class,
+                audio_lang=audio_lang,
+                audio_detected_by="title_regex" if lang_class != "UNKNOWN" else None,
+                is_primary=is_primary,
+                is_alive=row["is_alive"],
+                last_seen=row["last_seen_at"],
+                metadata=metadata,
+            )
+            for lang in sub_langs:
+                upsert_subtitle(cur, source_id, lang)
+            inserted += 1
+        except psycopg2.Error as e:
+            log.warning("prehrajto film_id=%d upload_id=%s: %s",
+                        row["film_id"], row["upload_id"], e)
+            skipped += 1
+    return inserted, skipped
+
+
+def backfill_sledujteto(cur, providers: dict[str, int], limit: int | None
+                        ) -> tuple[int, int]:
+    """Backfill sledujteto sources from film_sledujteto_uploads."""
+    provider_id = providers["sledujteto"]
+    limit_clause = f"LIMIT {int(limit)}" if limit else ""
+    cur.execute(
+        f"""
+        SELECT u.film_id, u.file_id, u.title, u.duration_sec,
+               u.lang_class, u.resolution_hint, u.filesize_bytes, u.cdn,
+               u.is_alive, u.last_seen,
+               f.sledujteto_primary_file_id
+        FROM film_sledujteto_uploads u
+        JOIN films f ON f.id = u.film_id
+        ORDER BY u.film_id, u.file_id
+        {limit_clause}
+        """
+    )
+    rows = cur.fetchall()
+    log.info("sledujteto: %d uploads", len(rows))
+
+    inserted = 0
+    skipped = 0
+    for row in rows:
+        audio_lang, lang_class, sub_langs = lang_class_to_audio_and_subs(row["lang_class"])
+        is_primary = row["file_id"] == row["sledujteto_primary_file_id"]
+        try:
+            source_id = upsert_video_source(
+                cur,
+                provider_id=provider_id,
+                external_id=str(row["file_id"]),
+                film_id=row["film_id"],
+                title=row["title"],
+                duration_sec=row["duration_sec"],
+                resolution_hint=row["resolution_hint"],
+                filesize_bytes=row["filesize_bytes"],
+                lang_class=lang_class,
+                audio_lang=audio_lang,
+                audio_detected_by="title_regex" if lang_class != "UNKNOWN" else None,
+                cdn=row["cdn"],
+                is_primary=is_primary,
+                is_alive=row["is_alive"],
+                last_seen=row["last_seen"],
+            )
+            for lang in sub_langs:
+                upsert_subtitle(cur, source_id, lang)
+            inserted += 1
+        except psycopg2.Error as e:
+            log.warning("sledujteto film_id=%d file_id=%d: %s",
+                        row["film_id"], row["file_id"], e)
+            skipped += 1
+    return inserted, skipped
+
+
+def assert_invariants(cur) -> bool:
+    """Post-backfill sanity checks. Returns True when all invariants hold.
+
+    1. No (provider, parent) pair has >1 is_primary row.
+       (Partial unique indexes enforce this at DB level, so a violation here
+       would indicate an index was dropped or a concurrent writer bypassed
+       the constraint.)
+    2. Every legacy primary pointer maps to a matching video_sources primary.
+    """
+    ok = True
+
+    # Invariant 1 — should always pass if the partial unique indexes are in
+    # place. Sanity net in case we run this against a DB where the migration
+    # is partially applied.
+    cur.execute(
+        """
+        SELECT provider_id,
+               COALESCE(film_id::text, 'E'||episode_id::text, 'T'||tv_episode_id::text) AS parent,
+               COUNT(*) AS n
+        FROM video_sources
+        WHERE is_primary
+        GROUP BY provider_id, parent
+        HAVING COUNT(*) > 1
+        """
+    )
+    dup_primaries = cur.fetchall()
+    if dup_primaries:
+        log.error("INVARIANT 1 FAILED: %d (provider, parent) pairs have "
+                  "multiple primary rows", len(dup_primaries))
+        ok = False
+
+    # Invariant 2 — legacy primary ↔ video_sources.is_primary alignment.
+    # Run per-provider so the error messages point at the right legacy
+    # column when something is off.
+    legacy_checks = [
+        ("prehrajto",
+         "SELECT f.id, f.prehrajto_primary_upload_id AS pointer FROM films f "
+         "WHERE f.prehrajto_primary_upload_id IS NOT NULL"),
+        ("sledujteto",
+         "SELECT f.id, f.sledujteto_primary_file_id::text AS pointer FROM films f "
+         "WHERE f.sledujteto_primary_file_id IS NOT NULL"),
+    ]
+    for slug, legacy_sql in legacy_checks:
+        cur.execute(
+            f"""
+            WITH legacy AS ({legacy_sql}),
+                 provider AS (SELECT id FROM video_providers WHERE slug = %s)
+            SELECT l.id, l.pointer
+            FROM legacy l, provider p
+            WHERE NOT EXISTS (
+                SELECT 1 FROM video_sources vs
+                WHERE vs.film_id = l.id
+                  AND vs.provider_id = p.id
+                  AND vs.is_primary
+                  AND vs.external_id = l.pointer
+            )
+            """,
+            (slug,),
+        )
+        mismatched = cur.fetchall()
+        if mismatched:
+            log.error("INVARIANT 2 FAILED (%s): %d films have legacy primary "
+                      "pointer but no matching video_sources primary. "
+                      "First 5: %s", slug, len(mismatched),
+                      [(r["id"], r["pointer"]) for r in mismatched[:5]])
+            ok = False
+
+    return ok
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--limit", type=int, default=None)
+    ap.add_argument("--skip-sktorrent", action="store_true")
+    ap.add_argument("--skip-prehrajto", action="store_true")
+    ap.add_argument("--skip-sledujteto", action="store_true")
+    ap.add_argument("-v", "--verbose", action="store_true")
+    args = ap.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        log.error("DATABASE_URL required")
+        return 2
+
+    conn = psycopg2.connect(dsn)
+    conn.autocommit = False
+    cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+
+    totals = {"inserted": 0, "skipped": 0}
+    try:
+        providers = provider_ids(cur)
+        log.info("Providers: %s", providers)
+
+        if not args.skip_sktorrent:
+            i, s = backfill_sktorrent(cur, providers, args.limit)
+            totals["inserted"] += i
+            totals["skipped"] += s
+            log.info("sktorrent done: inserted=%d skipped=%d", i, s)
+
+        if not args.skip_prehrajto:
+            i, s = backfill_prehrajto(cur, providers, args.limit)
+            totals["inserted"] += i
+            totals["skipped"] += s
+            log.info("prehrajto done: inserted=%d skipped=%d", i, s)
+
+        if not args.skip_sledujteto:
+            i, s = backfill_sledujteto(cur, providers, args.limit)
+            totals["inserted"] += i
+            totals["skipped"] += s
+            log.info("sledujteto done: inserted=%d skipped=%d", i, s)
+
+        log.info("Totals: inserted=%d skipped=%d", totals["inserted"], totals["skipped"])
+
+        # Invariants only meaningful on a FULL run (no --limit), otherwise
+        # "legacy pointer with no video_sources match" is expected.
+        if args.limit is None:
+            ok = assert_invariants(cur)
+            if not ok:
+                log.error("Post-backfill invariants failed; rolling back.")
+                conn.rollback()
+                return 1
+
+        if args.dry_run:
+            conn.rollback()
+            log.info("DRY RUN: rolled back.")
+        else:
+            conn.commit()
+            log.info("Committed.")
+    except Exception:
+        conn.rollback()
+        log.exception("Error during backfill — rolled back")
+        return 1
+    finally:
+        cur.close()
+        conn.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/import-prehrajto-new-films.py
+++ b/scripts/import-prehrajto-new-films.py
@@ -63,6 +63,13 @@ except ImportError:
     print("ERROR: psycopg2 not installed. pip install psycopg2-binary", file=sys.stderr)
     sys.exit(2)
 
+# Dual-write helper (#607 / #610).
+sys.path.insert(0, str(Path(__file__).parent))
+from video_sources_helper import (  # noqa: E402
+    get_provider_ids,
+    dual_write_prehrajto_upload,
+)
+
 try:
     import requests
 except ImportError:
@@ -893,6 +900,20 @@ def main() -> int:
             ]
             psycopg2.extras.execute_batch(cur, insert_upload_sql, upload_rows, page_size=200)
             inserted_uploads += len(upload_rows)
+
+            # Dual-write into the unified video_sources schema (#607 / #610).
+            # Same transaction as the uploads batch above; on any exception
+            # the whole film INSERT + uploads + video_sources rolls back
+            # together via the outer try/except savepoint path.
+            providers = get_provider_ids(cur)
+            for upload in upload_rows:
+                dual_write_prehrajto_upload(
+                    cur,
+                    providers=providers,
+                    film_id=film_id,
+                    upload_row=upload,
+                    primary_upload_id=primary_upload_id,
+                )
 
             # ---- Genre links ----
             for tmdb_gid in movie["genre_ids"]:

--- a/scripts/import-prehrajto-uploads.py
+++ b/scripts/import-prehrajto-uploads.py
@@ -46,6 +46,13 @@ except ImportError:
     print("ERROR: psycopg2 not installed. pip install psycopg2-binary", file=sys.stderr)
     sys.exit(2)
 
+# Dual-write helper (#607 / #610).
+sys.path.insert(0, str(Path(__file__).parent))
+from video_sources_helper import (  # noqa: E402
+    get_provider_ids,
+    dual_write_prehrajto_upload,
+)
+
 
 # ---------------------------------------------------------------------------
 # Sitemap parsing + clustering (vendored from /tmp/prehrajto-pilot/match_tmdb.py)
@@ -489,6 +496,22 @@ def main() -> int:
                 "film_id": film_id,
             })
             updated_flags += 1
+
+            # Dual-write into the unified video_sources schema (#607 / #610).
+            # Runs inside the caller's transaction, right after the legacy
+            # batch flush path, so video_sources stays in lock-step with
+            # film_prehrajto_uploads. `primary_upload_id` was just written to
+            # `films.prehrajto_primary_upload_id`; passing it here makes the
+            # same upload's video_sources row `is_primary=TRUE`.
+            providers = get_provider_ids(cur)
+            for upload in per_upload:
+                dual_write_prehrajto_upload(
+                    cur,
+                    providers=providers,
+                    film_id=film_id,
+                    upload_row=upload,
+                    primary_upload_id=primary_upload_id,
+                )
 
             if commit_every and i % commit_every == 0:
                 flush()

--- a/scripts/import-sledujteto-films.py
+++ b/scripts/import-sledujteto-films.py
@@ -78,6 +78,15 @@ except ImportError:
     print("ERROR: psycopg2 not installed. pip install psycopg2-binary", file=sys.stderr)
     sys.exit(2)
 
+# Dual-write helper (#607 / #610). Lives next to this script; the sys.path
+# entry at script startup (added by the shebang / python3 invocation) puts
+# scripts/ into the path already, so the import resolves directly.
+sys.path.insert(0, str(Path(__file__).parent))
+from video_sources_helper import (  # noqa: E402
+    get_provider_ids,
+    dual_write_sledujteto_upload,
+)
+
 log = logging.getLogger("import-sledujteto-films")
 
 
@@ -311,10 +320,12 @@ INSERT_FILM_SQL = """
 INSERT INTO films (
     title, original_title, slug, year, description,
     tmdb_id, runtime_min, tmdb_poster_path, lang,
+    imdb_rating,
     created_at, added_at
 ) VALUES (
     %(title)s, %(original_title)s, %(slug)s, %(year)s, %(description)s,
     %(tmdb_id)s, %(runtime_min)s, %(tmdb_poster_path)s, %(lang)s,
+    %(imdb_rating)s,
     NOW(), NOW()
 )
 RETURNING id
@@ -464,6 +475,14 @@ def build_film_row(
     )
     year = int(release_date[:4]) if release_date and len(release_date) >= 4 else None
 
+    # `films.imdb_rating` is misnamed — it actually holds the TMDB vote
+    # average (see commit 3962c20fb "fix(ui): relabel rating badge from IMDB
+    # to TMDB"). TMDB returns 0.0 for films with no votes; we store NULL in
+    # that case so the listing badge is hidden rather than showing a
+    # misleading 0.0.
+    vote_average = (tmdb_meta or {}).get("vote_average")
+    imdb_rating = float(vote_average) if vote_average and vote_average > 0 else None
+
     return {
         "title": title[:255],
         "original_title": (original_title or "")[:255] or None,
@@ -474,6 +493,7 @@ def build_film_row(
         "runtime_min": (tmdb_meta or {}).get("runtime"),
         "tmdb_poster_path": ((tmdb_meta or {}).get("poster_path") or "")[:64] or None,
         "lang": ((tmdb_meta or {}).get("original_language") or "")[:20] or None,
+        "imdb_rating": imdb_rating,
     }
 
 
@@ -567,6 +587,22 @@ def run_import(args: argparse.Namespace) -> int:
 
             rollups = pick_primary_and_rollups(upload_rows)
             cur.execute(UPDATE_FILM_ROLLUPS_SQL, {**rollups, "film_id": film_id})
+
+            # Dual-write into the unified video_sources schema (#607 / #610).
+            # Runs in the same transaction as the legacy upsert above, so the
+            # two tables never diverge. `rollups["primary"]` is the same
+            # file_id we just wrote to `films.sledujteto_primary_file_id`,
+            # which becomes `is_primary=TRUE` in video_sources via the helper.
+            providers = get_provider_ids(cur)
+            for upload in upload_rows:
+                dual_write_sledujteto_upload(
+                    cur,
+                    providers=providers,
+                    film_id=film_id,
+                    upload_row=upload,
+                    primary_file_id=rollups.get("primary"),
+                )
+            stats["dual_write_sledujteto"] += len(upload_rows)
 
             if stats["inserted_films"] + stats["existing_films"] >= 1 and (
                 (stats["inserted_films"] + stats["existing_films"]) % args.commit_every == 0

--- a/scripts/reconcile-video-sources.py
+++ b/scripts/reconcile-video-sources.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""Detect drift between legacy per-provider tables and the unified
+`video_sources` schema (#607 / #610). Intended to run periodically
+during the dual-write phase — catches missing/stale rows before the
+reader switch in PR3 trusts the new schema.
+
+Exits 0 when legacy ↔ new are in agreement, 1 on any drift. Prints a
+compact report so cron output stays greppable in logs.
+
+Checks performed:
+
+  1. Row counts per provider:
+       film_prehrajto_uploads                  vs video_sources[prehrajto]
+       film_sledujteto_uploads                 vs video_sources[sledujteto]
+       films/episodes/tv_episodes.sktorrent_video_id cardinality
+                                               vs video_sources[sktorrent]
+
+  2. Primary pointer alignment: every legacy primary pointer maps to
+     a matching video_sources row with is_primary=TRUE and the same
+     external_id.
+
+  3. Missing rows: legacy upload rows that have no corresponding
+     video_sources row (within the dual-write providers).
+
+  4. Rollup staleness: spot-check `films.audio_langs` / `subtitle_langs`
+     against what the video_sources data implies. Finds rows where the
+     trigger failed to run or was bypassed.
+
+Usage:
+    DATABASE_URL=postgres://... \\
+    python3 scripts/reconcile-video-sources.py [--verbose]
+
+Exit codes:
+    0 — no drift
+    1 — drift detected (see output)
+    2 — setup error (missing env, schema mismatch)
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+try:
+    import psycopg2
+    import psycopg2.extras
+except ImportError:
+    print("pip install psycopg2-binary", file=sys.stderr)
+    sys.exit(2)
+
+
+log = logging.getLogger("reconcile-video-sources")
+
+
+def check_counts(cur) -> list[str]:
+    """Compare legacy row counts to video_sources per-provider counts."""
+    errors = []
+    # prehrajto
+    cur.execute("SELECT COUNT(*) AS n FROM film_prehrajto_uploads")
+    legacy_prehrajto = cur.fetchone()["n"]
+    cur.execute(
+        "SELECT COUNT(*) AS n FROM video_sources "
+        "WHERE provider_id = (SELECT id FROM video_providers WHERE slug = 'prehrajto')"
+    )
+    new_prehrajto = cur.fetchone()["n"]
+    if legacy_prehrajto != new_prehrajto:
+        errors.append(
+            f"COUNT DRIFT prehrajto: legacy={legacy_prehrajto} "
+            f"video_sources={new_prehrajto} delta={new_prehrajto - legacy_prehrajto}"
+        )
+    else:
+        log.info("OK prehrajto counts: %d rows on both sides", legacy_prehrajto)
+
+    # sledujteto
+    cur.execute("SELECT COUNT(*) AS n FROM film_sledujteto_uploads")
+    legacy_sledujteto = cur.fetchone()["n"]
+    cur.execute(
+        "SELECT COUNT(*) AS n FROM video_sources "
+        "WHERE provider_id = (SELECT id FROM video_providers WHERE slug = 'sledujteto')"
+    )
+    new_sledujteto = cur.fetchone()["n"]
+    if legacy_sledujteto != new_sledujteto:
+        errors.append(
+            f"COUNT DRIFT sledujteto: legacy={legacy_sledujteto} "
+            f"video_sources={new_sledujteto} delta={new_sledujteto - legacy_sledujteto}"
+        )
+    else:
+        log.info("OK sledujteto counts: %d rows on both sides", legacy_sledujteto)
+
+    # sktorrent — distinct video_ids across films + episodes + tv_episodes
+    # (legacy allows duplicates within a table, but video_sources enforces
+    # UNIQUE per provider+external_id, so we compare against DISTINCT count).
+    cur.execute(
+        """
+        SELECT COUNT(DISTINCT sktorrent_video_id) AS n
+        FROM (
+            SELECT sktorrent_video_id FROM films       WHERE sktorrent_video_id IS NOT NULL
+            UNION ALL
+            SELECT sktorrent_video_id FROM episodes    WHERE sktorrent_video_id IS NOT NULL
+            UNION ALL
+            SELECT sktorrent_video_id FROM tv_episodes WHERE sktorrent_video_id IS NOT NULL
+        ) u
+        """
+    )
+    legacy_sktorrent = cur.fetchone()["n"]
+    cur.execute(
+        "SELECT COUNT(*) AS n FROM video_sources "
+        "WHERE provider_id = (SELECT id FROM video_providers WHERE slug = 'sktorrent')"
+    )
+    new_sktorrent = cur.fetchone()["n"]
+    if legacy_sktorrent != new_sktorrent:
+        errors.append(
+            f"COUNT DRIFT sktorrent: legacy distinct video_ids={legacy_sktorrent} "
+            f"video_sources={new_sktorrent} delta={new_sktorrent - legacy_sktorrent}"
+        )
+    else:
+        log.info("OK sktorrent counts: %d distinct video_ids on both sides", legacy_sktorrent)
+
+    return errors
+
+
+def check_primary_alignment(cur) -> list[str]:
+    """Every legacy `*_primary_*_id` must map to a `video_sources` row with
+    matching external_id and `is_primary=TRUE`."""
+    errors = []
+    for slug, pointer_sql, count_label in [
+        ("prehrajto",
+         "SELECT id, prehrajto_primary_upload_id AS ptr FROM films "
+         "WHERE prehrajto_primary_upload_id IS NOT NULL",
+         "prehrajto primary pointers"),
+        ("sledujteto",
+         "SELECT id, sledujteto_primary_file_id::text AS ptr FROM films "
+         "WHERE sledujteto_primary_file_id IS NOT NULL",
+         "sledujteto primary pointers"),
+    ]:
+        cur.execute(
+            f"""
+            WITH legacy AS ({pointer_sql}),
+                 prov AS (SELECT id FROM video_providers WHERE slug = %s)
+            SELECT COUNT(*) AS n, COALESCE(array_agg(l.id) FILTER (WHERE TRUE), '{{}}'::int[]) AS examples
+            FROM (
+                SELECT l.id, l.ptr FROM legacy l, prov p
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM video_sources vs
+                    WHERE vs.film_id = l.id
+                      AND vs.provider_id = p.id
+                      AND vs.is_primary
+                      AND vs.external_id = l.ptr
+                )
+                LIMIT 10
+            ) l
+            """,
+            (slug,),
+        )
+        row = cur.fetchone()
+        n = row["n"]
+        if n > 0:
+            errors.append(
+                f"PRIMARY MISMATCH {count_label}: {n} films have a legacy pointer "
+                f"but no matching video_sources.is_primary row. First IDs: {row['examples']}"
+            )
+        else:
+            log.info("OK %s: all legacy primary pointers align", count_label)
+
+    # sktorrent: every films.sktorrent_video_id should have a matching
+    # video_sources row. Primary is unconditional for sktorrent
+    # (is_primary=TRUE always — sktorrent is 1:1 legacy).
+    cur.execute(
+        """
+        WITH prov AS (SELECT id FROM video_providers WHERE slug = 'sktorrent')
+        SELECT COUNT(*) AS n
+        FROM films f, prov p
+        WHERE f.sktorrent_video_id IS NOT NULL
+          AND NOT EXISTS (
+              SELECT 1 FROM video_sources vs
+              WHERE vs.film_id = f.id
+                AND vs.provider_id = p.id
+                AND vs.external_id = f.sktorrent_video_id::text
+          )
+        """
+    )
+    missing_skt_films = cur.fetchone()["n"]
+    if missing_skt_films > 0:
+        errors.append(
+            f"SKT MISSING: {missing_skt_films} films with legacy sktorrent_video_id "
+            f"have no matching video_sources row"
+        )
+    else:
+        log.info("OK sktorrent films: every sktorrent_video_id has a video_sources row")
+
+    return errors
+
+
+def check_rollup_staleness(cur) -> list[str]:
+    """Spot-check rollup arrays vs. the source-of-truth in video_sources.
+
+    A rollup is stale when `films.audio_langs` does NOT match
+    `array_agg(DISTINCT vs.audio_lang)` for alive video_sources rows.
+    This indicates the trigger failed to run (e.g. if someone wrote
+    directly to the base tables bypassing the trigger) or a bulk
+    UPDATE/COPY skipped per-row triggers.
+    """
+    errors = []
+    cur.execute(
+        """
+        WITH rollup AS (
+            SELECT f.id,
+                   f.audio_langs AS stored,
+                   COALESCE(
+                       (SELECT array_agg(DISTINCT vs.audio_lang::TEXT ORDER BY vs.audio_lang::TEXT)
+                        FROM video_sources vs
+                        WHERE vs.film_id = f.id
+                          AND vs.is_alive
+                          AND vs.audio_lang IS NOT NULL),
+                       '{}'::TEXT[]
+                   ) AS expected
+            FROM films f
+            WHERE EXISTS (SELECT 1 FROM video_sources vs WHERE vs.film_id = f.id)
+        )
+        SELECT COUNT(*) AS n,
+               COALESCE(array_agg(id) FILTER (WHERE TRUE), '{}'::int[]) AS examples
+        FROM (
+            SELECT id FROM rollup WHERE stored IS DISTINCT FROM expected LIMIT 10
+        ) s
+        """
+    )
+    row = cur.fetchone()
+    stale = row["n"]
+    if stale > 0:
+        errors.append(
+            f"ROLLUP STALE: {stale} films have audio_langs drift from video_sources "
+            f"contents. First IDs: {row['examples']}"
+        )
+    else:
+        log.info("OK films.audio_langs: no rollup drift detected")
+
+    return errors
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("-v", "--verbose", action="store_true")
+    args = ap.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        log.error("DATABASE_URL required")
+        return 2
+
+    conn = psycopg2.connect(dsn)
+    cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+
+    errors: list[str] = []
+    try:
+        errors.extend(check_counts(cur))
+        errors.extend(check_primary_alignment(cur))
+        errors.extend(check_rollup_staleness(cur))
+    finally:
+        cur.close()
+        conn.close()
+
+    if errors:
+        for e in errors:
+            log.error(e)
+        log.error("Drift detected: %d check(s) failed", len(errors))
+        return 1
+
+    log.info("All checks passed — legacy and video_sources are in agreement")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/video_sources_helper.py
+++ b/scripts/video_sources_helper.py
@@ -1,0 +1,371 @@
+"""Shared dual-write helper for the unified `video_sources` schema (#607).
+
+All importer scripts (sktorrent / prehrajto / sledujteto) call into this
+module after their legacy INSERT/UPSERT, in the SAME transaction, so the
+new schema stays in lock-step with the legacy per-provider tables.
+
+Usage pattern (in every importer, inside a psycopg2 transaction):
+
+    from video_sources_helper import (
+        get_provider_ids, upsert_video_source, upsert_subtitle,
+        lang_class_to_audio_and_subs,
+    )
+
+    providers = get_provider_ids(cur)   # {slug: id}, cache per-cursor
+
+    # --- legacy write stays unchanged ---
+    cur.execute("INSERT INTO film_prehrajto_uploads ...", ...)
+
+    # --- dual-write into video_sources ---
+    audio_lang, lang_class, sub_langs = lang_class_to_audio_and_subs(
+        lang_class=row["lang_class"])
+    source_id = upsert_video_source(
+        cur,
+        provider_id=providers["prehrajto"],
+        external_id=upload_id,
+        film_id=film_id,
+        title=title, duration_sec=duration_sec, view_count=view_count,
+        resolution_hint=resolution_hint,
+        lang_class=lang_class, audio_lang=audio_lang,
+        audio_detected_by="title_regex" if lang_class != "UNKNOWN" else None,
+        is_primary=(upload_id == primary_upload_id),
+        is_alive=True,
+    )
+    for sub_lang in sub_langs:
+        upsert_subtitle(cur, source_id, sub_lang)
+
+The helper enforces:
+  - ON CONFLICT (provider_id, external_id) updates the existing row, so
+    re-runs are no-ops modulo `updated_at`. This plays well with the
+    schema's partial-unique constraints on `is_primary`.
+  - `lang_class`/`audio_lang` pair derived by `lang_class_to_audio_and_subs`
+    always satisfies the DB CHECK constraint.
+  - Sub rows are upserted via COALESCE(format,'') to tolerate format=NULL
+    during the window between discovery and first resolve.
+
+Schema reference: cr-infra/migrations/20260529_058_video_sources_unified.sql
+"""
+from __future__ import annotations
+
+try:
+    import psycopg2.extras
+except ImportError:
+    raise
+
+
+PROVIDER_SLUGS = ("sktorrent", "prehrajto", "sledujteto")
+
+# Cache the provider ids per cursor object so we don't re-query the lookup
+# table on every upsert. Keyed by id(cur) because psycopg2 cursors are not
+# hashable across DB reconnects — but within a single run the same cursor
+# is reused thousands of times.
+_PROVIDER_CACHE: dict[int, dict[str, int]] = {}
+
+
+def get_provider_ids(cur) -> dict[str, int]:
+    """Return {'sktorrent': 1, 'prehrajto': 2, 'sledujteto': 3} (ids vary by DB)."""
+    key = id(cur)
+    cached = _PROVIDER_CACHE.get(key)
+    if cached is not None:
+        return cached
+    cur.execute(
+        "SELECT slug, id FROM video_providers WHERE slug = ANY(%s)",
+        (list(PROVIDER_SLUGS),),
+    )
+    rows = cur.fetchall()
+    # cur may be a DictCursor or a tuple cursor — handle both.
+    mapping = {row[0] if not hasattr(row, "keys") else row["slug"]:
+               row[1] if not hasattr(row, "keys") else row["id"]
+               for row in rows}
+    _PROVIDER_CACHE[key] = mapping
+    return mapping
+
+
+def lang_class_to_audio_and_subs(lang_class: str | None = None,
+                                 has_dub: bool = False,
+                                 has_subtitles: bool = False
+                                 ) -> tuple[str | None, str, list[str]]:
+    """Map legacy language signals → (audio_lang, lang_class, subtitle_langs).
+
+    Inputs (in priority order):
+      1. `lang_class` — the enum from the legacy upload tables
+         (CZ_DUB|CZ_NATIVE|CZ_SUB|SK_DUB|SK_SUB|EN|UNKNOWN). When set, it
+         determines both the audio and the subtitles.
+      2. `has_dub` / `has_subtitles` — sktorrent-style booleans, used ONLY
+         when lang_class is None. Assumes CZ (the dominant audience).
+
+    Returns a triple:
+      audio_lang  — 2/3-char ISO code or None (must satisfy the CHECK
+                    constraint `^[a-z]{2,3}$`).
+      lang_class  — normalized enum value. The DB CHECK
+                    `video_sources_lang_class_audio_consistency_check`
+                    enforces audio_lang ↔ lang_class consistency, so this
+                    function is the single place where those two fields
+                    are derived together.
+      sub_langs   — list of subtitle language codes to insert as
+                    video_source_subtitles rows (often empty).
+
+    Example mappings:
+      CZ_DUB       → ('cs', 'CZ_DUB',    [])
+      CZ_SUB       → (None, 'CZ_SUB',    ['cs'])
+      SK_DUB       → ('sk', 'SK_DUB',    [])
+      has_dub=T    → ('cs', 'CZ_DUB',    [])         (fallback)
+      has_subs=T   → (None, 'CZ_SUB',    ['cs'])     (fallback)
+      both T       → ('cs', 'CZ_DUB',    ['cs'])     (fallback)
+      neither      → (None, 'UNKNOWN',   [])
+    """
+    if lang_class == "CZ_DUB":
+        return "cs", "CZ_DUB", []
+    if lang_class == "CZ_NATIVE":
+        return "cs", "CZ_NATIVE", []
+    if lang_class == "CZ_SUB":
+        # Audio is original (often en), unknown from legacy data.
+        return None, "CZ_SUB", ["cs"]
+    if lang_class == "SK_DUB":
+        return "sk", "SK_DUB", []
+    if lang_class == "SK_SUB":
+        return None, "SK_SUB", ["sk"]
+    if lang_class == "EN":
+        return "en", "EN", []
+
+    # Fallback path for sktorrent (only has_dub / has_subtitles available).
+    if has_dub and has_subtitles:
+        # Both flags — dub is primary audio signal, subtitles coexist.
+        return "cs", "CZ_DUB", ["cs"]
+    if has_dub:
+        return "cs", "CZ_DUB", []
+    if has_subtitles:
+        return None, "CZ_SUB", ["cs"]
+    return None, "UNKNOWN", []
+
+
+def upsert_video_source(cur, *,
+                        provider_id: int,
+                        external_id: str,
+                        film_id: int | None = None,
+                        episode_id: int | None = None,
+                        tv_episode_id: int | None = None,
+                        title: str | None = None,
+                        duration_sec: int | None = None,
+                        resolution_hint: str | None = None,
+                        filesize_bytes: int | None = None,
+                        view_count: int | None = None,
+                        lang_class: str = "UNKNOWN",
+                        audio_lang: str | None = None,
+                        audio_confidence: float | None = None,
+                        audio_detected_by: str | None = None,
+                        cdn: str | None = None,
+                        is_primary: bool = False,
+                        is_alive: bool = True,
+                        last_seen=None,
+                        metadata=None,
+                        ) -> int:
+    """UPSERT a `video_sources` row. Returns the row's id.
+
+    Idempotence via `ON CONFLICT (provider_id, external_id)`. A re-run
+    updates mutable fields (is_alive, cdn, lang_class, …) but keeps the
+    row id stable, so `video_source_subtitles.source_id` stays valid
+    across re-runs.
+
+    IMPORTANT: exactly one of `film_id` / `episode_id` / `tv_episode_id`
+    must be non-None. The DB enforces this via
+    `video_sources_one_parent_check`; passing two or zero here is a bug
+    in the caller, not something to work around silently.
+
+    `metadata` may be a Python dict; it's wrapped in psycopg2.extras.Json
+    so psycopg2 serializes it correctly for the JSONB column.
+    """
+    cur.execute(
+        """
+        INSERT INTO video_sources (
+            provider_id, film_id, episode_id, tv_episode_id,
+            external_id, title, duration_sec, resolution_hint,
+            filesize_bytes, view_count, lang_class, audio_lang,
+            audio_confidence, audio_detected_by, cdn,
+            is_primary, is_alive, last_seen, metadata, updated_at
+        ) VALUES (
+            %(provider_id)s, %(film_id)s, %(episode_id)s, %(tv_episode_id)s,
+            %(external_id)s, %(title)s, %(duration_sec)s, %(resolution_hint)s,
+            %(filesize_bytes)s, %(view_count)s, %(lang_class)s, %(audio_lang)s,
+            %(audio_confidence)s, %(audio_detected_by)s, %(cdn)s,
+            %(is_primary)s, %(is_alive)s, %(last_seen)s, %(metadata)s, NOW()
+        )
+        ON CONFLICT (provider_id, external_id) DO UPDATE SET
+            film_id           = EXCLUDED.film_id,
+            episode_id        = EXCLUDED.episode_id,
+            tv_episode_id     = EXCLUDED.tv_episode_id,
+            title             = COALESCE(EXCLUDED.title, video_sources.title),
+            duration_sec      = COALESCE(EXCLUDED.duration_sec, video_sources.duration_sec),
+            resolution_hint   = COALESCE(EXCLUDED.resolution_hint, video_sources.resolution_hint),
+            filesize_bytes    = COALESCE(EXCLUDED.filesize_bytes, video_sources.filesize_bytes),
+            view_count        = COALESCE(EXCLUDED.view_count, video_sources.view_count),
+            lang_class        = EXCLUDED.lang_class,
+            audio_lang        = EXCLUDED.audio_lang,
+            audio_confidence  = COALESCE(EXCLUDED.audio_confidence, video_sources.audio_confidence),
+            audio_detected_by = COALESCE(EXCLUDED.audio_detected_by, video_sources.audio_detected_by),
+            cdn               = EXCLUDED.cdn,
+            is_primary        = EXCLUDED.is_primary,
+            is_alive          = EXCLUDED.is_alive,
+            last_seen         = COALESCE(EXCLUDED.last_seen, video_sources.last_seen),
+            metadata          = COALESCE(EXCLUDED.metadata, video_sources.metadata),
+            updated_at        = NOW()
+        RETURNING id
+        """,
+        dict(
+            provider_id=provider_id,
+            film_id=film_id,
+            episode_id=episode_id,
+            tv_episode_id=tv_episode_id,
+            external_id=external_id,
+            title=title,
+            duration_sec=duration_sec,
+            resolution_hint=resolution_hint,
+            filesize_bytes=filesize_bytes,
+            view_count=view_count,
+            lang_class=lang_class,
+            audio_lang=audio_lang,
+            audio_confidence=audio_confidence,
+            audio_detected_by=audio_detected_by,
+            cdn=cdn,
+            is_primary=is_primary,
+            is_alive=is_alive,
+            last_seen=last_seen,
+            metadata=psycopg2.extras.Json(metadata) if metadata else None,
+        ),
+    )
+    result = cur.fetchone()
+    # Handle both DictCursor (row["id"]) and plain cursor (row[0]).
+    return result["id"] if hasattr(result, "keys") else result[0]
+
+
+def upsert_subtitle(cur, source_id: int, lang: str,
+                    *, format: str | None = None,
+                    is_forced: bool = False,
+                    label: str | None = None,
+                    url: str | None = None,
+                    is_default: bool = False) -> None:
+    """Insert a subtitle row if absent (no-op on duplicate).
+
+    URL + format are allowed to be NULL (sledujteto subtitles are
+    resolved at play-time, so we persist the existence of the track
+    without the URL). The uniqueness key includes COALESCE(format, '')
+    so a (source, lang, forced) tuple can legitimately carry .srt + .ass
+    side by side.
+    """
+    cur.execute(
+        """
+        INSERT INTO video_source_subtitles
+            (source_id, lang, format, url, is_default, is_forced, label)
+        VALUES (%s, %s, %s, %s, %s, %s, %s)
+        ON CONFLICT (source_id, lang, is_forced, COALESCE(format, ''))
+        DO NOTHING
+        """,
+        (source_id, lang, format, url, is_default, is_forced, label),
+    )
+
+
+def dual_write_prehrajto_upload(cur, *, providers, film_id, upload_row,
+                                primary_upload_id=None) -> int:
+    """One-shot wrapper for prehrajto importers.
+
+    `upload_row` is a dict (or DictRow) with keys:
+      upload_id, url, title, duration_sec, view_count,
+      lang_class, resolution_hint, is_alive (default True)
+
+    Equivalent to the explicit `lang_class_to_audio_and_subs` + `upsert_video_source`
+    + `upsert_subtitle` sequence, but collapsed into a single call so
+    importer code stays short.
+    """
+    audio_lang, lang_class, sub_langs = lang_class_to_audio_and_subs(
+        upload_row.get("lang_class"))
+    metadata = {
+        "url": upload_row.get("url"),
+        "is_direct": upload_row.get("is_direct"),
+    }
+    source_id = upsert_video_source(
+        cur,
+        provider_id=providers["prehrajto"],
+        external_id=upload_row["upload_id"],
+        film_id=film_id,
+        title=upload_row.get("title"),
+        duration_sec=upload_row.get("duration_sec"),
+        view_count=upload_row.get("view_count"),
+        resolution_hint=upload_row.get("resolution_hint"),
+        lang_class=lang_class,
+        audio_lang=audio_lang,
+        audio_detected_by="title_regex" if lang_class != "UNKNOWN" else None,
+        is_primary=(primary_upload_id is not None
+                    and upload_row["upload_id"] == primary_upload_id),
+        is_alive=upload_row.get("is_alive", True),
+        metadata=metadata,
+    )
+    for sub_lang in sub_langs:
+        upsert_subtitle(cur, source_id, sub_lang)
+    return source_id
+
+
+def dual_write_sledujteto_upload(cur, *, providers, film_id, upload_row,
+                                 primary_file_id=None) -> int:
+    """One-shot wrapper for the sledujteto importer.
+
+    `upload_row` keys:
+      file_id, title, duration_sec, resolution_hint, filesize_bytes,
+      lang_class, cdn, is_alive (default True)
+    """
+    audio_lang, lang_class, sub_langs = lang_class_to_audio_and_subs(
+        upload_row.get("lang_class"))
+    source_id = upsert_video_source(
+        cur,
+        provider_id=providers["sledujteto"],
+        external_id=str(upload_row["file_id"]),
+        film_id=film_id,
+        title=upload_row.get("title"),
+        duration_sec=upload_row.get("duration_sec"),
+        resolution_hint=upload_row.get("resolution_hint"),
+        filesize_bytes=upload_row.get("filesize_bytes"),
+        lang_class=lang_class,
+        audio_lang=audio_lang,
+        audio_detected_by="title_regex" if lang_class != "UNKNOWN" else None,
+        cdn=upload_row.get("cdn"),
+        is_primary=(primary_file_id is not None
+                    and upload_row["file_id"] == primary_file_id),
+        is_alive=upload_row.get("is_alive", True),
+    )
+    for sub_lang in sub_langs:
+        upsert_subtitle(cur, source_id, sub_lang)
+    return source_id
+
+
+def dual_write_sktorrent(cur, *, providers,
+                         film_id=None, episode_id=None, tv_episode_id=None,
+                         sktorrent_video_id: int,
+                         sktorrent_cdn: int | None = None,
+                         sktorrent_qualities: str | None = None,
+                         has_dub: bool = False,
+                         has_subtitles: bool = False) -> int:
+    """One-shot wrapper for sktorrent importers (auto-import + friends).
+
+    sktorrent is always 1:1 in legacy (one `sktorrent_video_id` per
+    parent row), so `is_primary` is unconditionally True.
+    """
+    audio_lang, lang_class, sub_langs = lang_class_to_audio_and_subs(
+        has_dub=has_dub, has_subtitles=has_subtitles)
+    metadata = {"qualities": sktorrent_qualities} if sktorrent_qualities else None
+    source_id = upsert_video_source(
+        cur,
+        provider_id=providers["sktorrent"],
+        external_id=str(sktorrent_video_id),
+        film_id=film_id,
+        episode_id=episode_id,
+        tv_episode_id=tv_episode_id,
+        cdn=str(sktorrent_cdn) if sktorrent_cdn is not None else None,
+        lang_class=lang_class,
+        audio_lang=audio_lang,
+        audio_detected_by="title_regex" if lang_class != "UNKNOWN" else None,
+        is_primary=True,
+        is_alive=True,
+        metadata=metadata,
+    )
+    for sub_lang in sub_langs:
+        upsert_subtitle(cur, source_id, sub_lang)
+    return source_id


### PR DESCRIPTION
<!-- claude-session: 9c42f99e-d1ab-4b4c-9d4d-e7d09129237a -->

Closes #610 (part of #607). Stacked on #616 (PR1) — base branch is `feat/607-schema-video-sources`, not `main`. Merge #616 first, then rebase/retarget this onto `main`.

## Summary

Phase 2 of the unified video-source refactor. Every importer that writes to a legacy per-provider table (`film_prehrajto_uploads` / `film_sledujteto_uploads` / sktorrent denormalized columns on films/episodes/tv_episodes) now also writes the equivalent row to the unified `video_sources` + `video_source_subtitles` schema, inside the same transaction.

Legacy writes remain unchanged and authoritative — the reader switch is PR3 (#611).

## Changes

### New

- `scripts/video_sources_helper.py` — shared helper.
  - `upsert_video_source(cur, **kwargs) → source_id` — single-row upsert with `ON CONFLICT (provider_id, external_id) DO UPDATE`. Row id stable across re-runs.
  - `upsert_subtitle(cur, source_id, lang, ...)` — subtitle child row.
  - `lang_class_to_audio_and_subs(lang_class, has_dub=, has_subtitles=)` — the single place (audio_lang, lang_class, sub_langs) is derived, so the DB CHECK `video_sources_lang_class_audio_consistency_check` is always satisfied.
  - Three one-shot wrappers: `dual_write_prehrajto_upload`, `dual_write_sledujteto_upload`, `dual_write_sktorrent` — keeps each importer's dual-write block to ~8 lines.

- `scripts/reconcile-video-sources.py` — drift detector. Exits 1 on any row-count / primary-pointer / rollup-array mismatch. Meant to run under cron during the dual-write phase; gates PR3 merge until `drift=0` on prod for several days.

### Modified (dual-write in the same TX as legacy write)

- `scripts/auto_import/enricher.py` — sktorrent films (UPDATE + INSERT paths)
- `scripts/auto_import/series_enricher.py` — sktorrent episodes
- `scripts/auto_import/tv_show_enricher.py` — sktorrent tv_episodes
- `scripts/backfill-sktorrent-langs.py` — has_dub/has_subtitles legacy fix
- `scripts/import-prehrajto-uploads.py` — prehrajto sitemap uploads
- `scripts/import-prehrajto-new-films.py` — new-film bootstrap
- `scripts/import-sledujteto-films.py` — bulk sledujteto import

## Design notes

- **Idempotence:** `ON CONFLICT (provider_id, external_id) DO UPDATE` keeps the row id stable, so `video_source_subtitles.source_id` stays valid across re-runs.
- **COALESCE primary semantics:** prehrajto's "our uploads" + match-import paths use `COALESCE` on the legacy primary pointer ("only claim if NULL"). The dual-write re-queries `films.prehrajto_primary_upload_id` AFTER the legacy UPDATE so `video_sources.is_primary` matches the final state, not the requested state.
- **sktorrent is 1:1 legacy:** `is_primary=TRUE` unconditionally. The partial unique index `uq_vs_primary_film` allows exactly one primary per (provider, owner) and will catch any duplicate.
- **Lang fallback:** sktorrent passes `has_dub`/`has_subtitles` booleans (no lang_class available); the helper maps them to `CZ_DUB` / `CZ_SUB` / `UNKNOWN` per CZ-audience convention. Other providers supply `lang_class` directly, so audio_lang and subtitle rows are derived deterministically.

## Verification

- `cargo check --all` ✓ (no Rust changes, sanity net for merge conflicts).
- Python `ast.parse` ✓ on all 9 modified / new scripts.
- **Re-run of PR1 backfill on dev:** produces the same 52 113 rows; reconciler reports all counts, primary pointers, and rollup arrays align modulo **24 legacy films with duplicate sktorrent_video_id** (pre-existing data-quality issue that the new UNIQUE constraint correctly surfaces — logged as `SKT MISSING`, not a dual-write bug).
- **Helper smoke test on dev:** inserting sktorrent + prehrajto + sledujteto rows for the same film fires the rollup trigger correctly, producing `audio_langs={cs,sk}` and `subtitle_langs={cs}` as expected; duplicate-primary INSERT hits the partial unique index.

## Test plan

- [ ] CI on this PR: Check & Clippy + Format + Test pass (nothing Rust-side changed, should be green).
- [ ] Copilot review on this PR (with #616 merged into base).
- [ ] After PR1 (#616) merges + backfill runs on prod:
  - Retarget this PR to `main` and rebase.
  - Deploy these scripts to prod (auto-import.py on Hetzner + any active importers).
  - Let auto-import run one cycle.
  - Run `scripts/reconcile-video-sources.py` on prod → expect drift=0 (modulo the pre-existing 24 sktorrent duplicates).
  - Monitor for a few days before merging PR3 (#611).