### PR TITLE
feat(video_sources): reader switch — handlers + listing queries (#611)

### DIFF
--- a/cr-infra/migrations/20260529_058_video_sources_unified.sql
+++ b/cr-infra/migrations/20260529_058_video_sources_unified.sql
@@ -1,0 +1,434 @@
+-- Unified polymorphic video source schema (issue #607 / sub-issue #608).
+--
+-- Replaces the per-provider tables (`film_prehrajto_uploads`,
+-- `film_sledujteto_uploads`) and the ~15 per-provider denormalized columns on
+-- `films` / `episodes` / `tv_episodes` with a single
+-- `video_providers` + `video_sources` + `video_source_subtitles` stack.
+--
+-- This migration is PHASE 1 of a multi-phase refactor: it only LANDS the new
+-- structure. Backfill, dual-write, reader switch, UX, and the legacy drop are
+-- separate migrations / PRs (#609–#614). Legacy columns + tables continue to
+-- exist and to be the source of truth until the reader switch ships.
+--
+-- Design notes (distilled from the issue + the RDBMS review comment on #608):
+--
+--   1. `video_sources` is polymorphic over (`film_id`, `episode_id`,
+--      `tv_episode_id`). Exactly one of the three must be NOT NULL; enforced
+--      via `num_nonnulls() = 1`. This lets us reuse the same table — and
+--      therefore the same handler code — for films, series episodes, and TV
+--      episodes.
+--
+--   2. `is_primary` replaces the scalar "primary pointer" columns
+--      (`films.prehrajto_primary_upload_id` etc.). Without a constraint the
+--      new schema would accept multiple primaries per (owner, provider), so
+--      we back it with three partial unique indexes — one per parent column
+--      (the standard Postgres way to index a nullable-key condition).
+--
+--   3. Rollup arrays `films.audio_langs` / `subtitle_langs` are maintained by
+--      a trigger that recomputes them atomically in a single SQL statement
+--      (not SELECT-then-UPDATE), so two parallel importers can't lost-update
+--      each other under READ COMMITTED. The trigger grabs the row lock on
+--      `films` via the UPDATE itself.
+--
+--   4. `lang_class` keeps the existing domain enum
+--      (`CZ_DUB|CZ_NATIVE|CZ_SUB|SK_DUB|SK_SUB|EN|UNKNOWN`) as a CHECK
+--      constraint, mirroring `film_prehrajto_uploads` / `film_sledujteto_uploads`
+--      from migrations 048 and 057. A second CHECK ensures `lang_class` and
+--      `audio_lang` can't drift into inconsistent states (e.g. `CZ_DUB` with
+--      `audio_lang='en'`).
+--
+--   5. `cdn`, `duration_sec`, `resolution_hint`, `filesize_bytes`,
+--      `view_count` stay as first-class columns (not JSONB) because they
+--      participate in ORDER BY / WHERE in the listing and detail-page
+--      queries. `metadata JSONB` is reserved for provider-specific bits with
+--      no query pressure (e.g. sktorrent `qualities` string, `added_days_ago`).
+
+-- =============================================================================
+-- video_providers — lookup table for the three source systems.
+-- Seeded with the three providers we support today. Adding a fourth is a
+-- data change, not a schema change.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS video_providers (
+    id             SMALLSERIAL PRIMARY KEY,
+    slug           VARCHAR(32) NOT NULL UNIQUE,
+    host           VARCHAR(64) NOT NULL,
+    display_name   VARCHAR(64) NOT NULL,
+    -- Lower number = shown first on the detail-page tab row. Replaces the
+    -- hard-coded `sktorrent → prehrajto → sledujteto` ordering in the
+    -- Askama templates.
+    sort_priority  SMALLINT    NOT NULL DEFAULT 100,
+    is_active      BOOLEAN     NOT NULL DEFAULT true,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+INSERT INTO video_providers (slug, host, display_name, sort_priority)
+VALUES
+    ('sktorrent',  'online.sktorrent.eu', 'SK Torrent',    10),
+    ('prehrajto',  'prehraj.to',          'Prehraj.to',    20),
+    ('sledujteto', 'sledujteto.cz',       'Sledujteto.cz', 30)
+ON CONFLICT (slug) DO NOTHING;
+
+-- =============================================================================
+-- video_sources — one row per (provider, parent entity, external id).
+-- Parent is polymorphic: exactly one of film_id / episode_id / tv_episode_id.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS video_sources (
+    id               SERIAL      PRIMARY KEY,
+    provider_id      SMALLINT    NOT NULL REFERENCES video_providers(id) ON DELETE RESTRICT,
+
+    -- Polymorphic parent: exactly one non-null, enforced by CHECK below.
+    film_id          INTEGER     REFERENCES films(id)           ON DELETE CASCADE,
+    episode_id       INTEGER     REFERENCES episodes(id) ON DELETE CASCADE,
+    tv_episode_id    INTEGER     REFERENCES tv_episodes(id)     ON DELETE CASCADE,
+
+    -- Provider-native id. sktorrent video_id is INT, prehrajto upload_id is
+    -- 13/16-hex, sledujteto file_id is INT — all serialize into the same
+    -- VARCHAR without loss. UNIQUE per provider below.
+    external_id      VARCHAR(128) NOT NULL,
+
+    title            TEXT,
+    duration_sec     INTEGER,
+    resolution_hint  VARCHAR(32),
+    filesize_bytes   BIGINT,
+    view_count       INTEGER,
+
+    -- Language classification (preserved from legacy tables for transition;
+    -- eventually derivable from audio_lang + subtitle rows).
+    lang_class       VARCHAR(16) NOT NULL DEFAULT 'UNKNOWN',
+
+    -- Detected audio language (ISO 639-1/639-2 short code).
+    audio_lang       VARCHAR(8),
+    audio_confidence REAL,
+    -- Which detector set audio_lang: whisper sample, title-regex, upstream
+    -- metadata, or unknown.
+    audio_detected_by VARCHAR(16),
+
+    -- CDN/host family for the provider-specific playback URL.
+    -- sledujteto: 'www' | 'data1'..'data9' | 'unknown'
+    -- sktorrent:  server number as text ('22' etc.)
+    -- prehrajto:  NULL (URLs are single-host + tokenized)
+    cdn              VARCHAR(32),
+
+    is_primary       BOOLEAN     NOT NULL DEFAULT false,
+    is_alive         BOOLEAN     NOT NULL DEFAULT true,
+    last_seen        TIMESTAMPTZ,
+    last_checked     TIMESTAMPTZ,
+
+    -- Schema-less provider-specific bag (sktorrent qualities, added_days_ago,
+    -- legacy upload URLs, ...). No indexes over it — avoid putting anything
+    -- here that needs fast filtering.
+    metadata         JSONB,
+
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    -- Exactly one parent. Rejects rows where zero or multiple parent FKs are
+    -- set — enforces the polymorphic contract at the DB level.
+    CONSTRAINT video_sources_one_parent_check CHECK (
+        num_nonnulls(film_id, episode_id, tv_episode_id) = 1
+    ),
+
+    -- Inherit the lang_class enum from legacy tables (migrations 048 + 057).
+    CONSTRAINT video_sources_lang_class_check CHECK (
+        lang_class IN ('CZ_DUB', 'CZ_NATIVE', 'CZ_SUB',
+                       'SK_DUB', 'SK_SUB', 'EN', 'UNKNOWN')
+    ),
+
+    -- Prevent lang_class / audio_lang drift. For subtitle-only classes, we
+    -- don't enforce the audio_lang value (original audio varies; it may be
+    -- NULL or 'en' or 'de' etc.), just that it's not the same lang as the
+    -- subtitles (otherwise the row should be DUB/NATIVE, not SUB).
+    CONSTRAINT video_sources_lang_class_audio_consistency_check CHECK (
+        (lang_class IN ('CZ_DUB','CZ_NATIVE') AND audio_lang = 'cs') OR
+        (lang_class = 'CZ_SUB' AND (audio_lang IS NULL OR audio_lang <> 'cs')) OR
+        (lang_class = 'SK_DUB' AND audio_lang = 'sk') OR
+        (lang_class = 'SK_SUB' AND (audio_lang IS NULL OR audio_lang <> 'sk')) OR
+        (lang_class = 'EN' AND audio_lang = 'en') OR
+        (lang_class = 'UNKNOWN')
+    ),
+
+    CONSTRAINT video_sources_audio_lang_format_check CHECK (
+        audio_lang IS NULL OR audio_lang ~ '^[a-z]{2,3}$'
+    ),
+
+    CONSTRAINT video_sources_audio_detected_by_check CHECK (
+        audio_detected_by IS NULL
+        OR audio_detected_by IN ('whisper', 'title_regex', 'upstream', 'unknown')
+    ),
+
+    CONSTRAINT video_sources_audio_confidence_range_check CHECK (
+        audio_confidence IS NULL
+        OR (audio_confidence >= 0.0 AND audio_confidence <= 1.0)
+    )
+);
+
+-- Same external id across providers is fine (sktorrent 12345 ≠ sledujteto 12345);
+-- within a provider the id must be globally unique.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_video_sources_provider_external
+    ON video_sources (provider_id, external_id);
+
+-- Main read paths — "all alive sources for this parent, per provider".
+CREATE INDEX IF NOT EXISTS idx_vs_film_alive
+    ON video_sources (film_id) WHERE is_alive AND film_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_vs_episode_alive
+    ON video_sources (episode_id) WHERE is_alive AND episode_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_vs_tv_episode_alive
+    ON video_sources (tv_episode_id) WHERE is_alive AND tv_episode_id IS NOT NULL;
+
+-- Reconciliation sweep ("sources unseen for 30 days") — supports the periodic
+-- is_alive=false flagging job.
+CREATE INDEX IF NOT EXISTS idx_vs_last_seen_alive
+    ON video_sources (last_seen) WHERE is_alive;
+
+-- Primary-pointer integrity. Each partial unique index enforces "at most one
+-- is_primary per (provider, parent)". Three indexes — one per parent column —
+-- is the clean Postgres pattern when the partial condition involves a
+-- non-null check on a nullable column.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_vs_primary_film
+    ON video_sources (provider_id, film_id)
+    WHERE is_primary AND film_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_vs_primary_episode
+    ON video_sources (provider_id, episode_id)
+    WHERE is_primary AND episode_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_vs_primary_tv_episode
+    ON video_sources (provider_id, tv_episode_id)
+    WHERE is_primary AND tv_episode_id IS NOT NULL;
+
+-- =============================================================================
+-- video_source_subtitles — 1:N child of video_sources.
+-- Persisted even when URL is NULL (sledujteto subtitles are resolved at
+-- play-time), so filters + badges work from the DB without live resolve.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS video_source_subtitles (
+    id          SERIAL      PRIMARY KEY,
+    source_id   INTEGER     NOT NULL REFERENCES video_sources(id) ON DELETE CASCADE,
+    lang        VARCHAR(8)  NOT NULL,
+    label       VARCHAR(64),
+    -- 'srt' | 'vtt' | 'ass' | 'ssa' | NULL (unknown until resolved).
+    format      VARCHAR(8),
+    -- NULL when we know the track exists but haven't resolved the URL yet
+    -- (sledujteto: playback endpoint returns URLs; crawler only records
+    -- existence). Resolved URLs are re-fetched live from a proxy endpoint.
+    url         TEXT,
+    is_default  BOOLEAN     NOT NULL DEFAULT false,
+    is_forced   BOOLEAN     NOT NULL DEFAULT false,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    CONSTRAINT video_source_subtitles_lang_format_check CHECK (
+        lang ~ '^[a-z]{2,3}$'
+    )
+);
+
+-- Include `format` in the uniqueness key: a single upload can legitimately
+-- carry .srt + .ass for the same (lang, is_forced) tuple, and we want both
+-- rows persisted. Uses COALESCE because format can be NULL during the
+-- window between subtitle discovery and the first URL resolve.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_vss_per_source_lang_format
+    ON video_source_subtitles (source_id, lang, is_forced, COALESCE(format, ''));
+
+CREATE INDEX IF NOT EXISTS idx_vss_source_id
+    ON video_source_subtitles (source_id);
+
+-- =============================================================================
+-- Rollup arrays on parent tables + GIN indexes for the audio/subs filter.
+--
+-- These are maintained by the trigger below. They're a denormalization for
+-- fast listing filters: `WHERE 'cs' = ANY(audio_langs)` lands a GIN index
+-- lookup instead of a correlated subquery against video_sources.
+-- =============================================================================
+
+ALTER TABLE films
+    ADD COLUMN IF NOT EXISTS audio_langs    TEXT[] NOT NULL DEFAULT '{}'::TEXT[],
+    ADD COLUMN IF NOT EXISTS subtitle_langs TEXT[] NOT NULL DEFAULT '{}'::TEXT[];
+
+ALTER TABLE episodes
+    ADD COLUMN IF NOT EXISTS audio_langs    TEXT[] NOT NULL DEFAULT '{}'::TEXT[],
+    ADD COLUMN IF NOT EXISTS subtitle_langs TEXT[] NOT NULL DEFAULT '{}'::TEXT[];
+
+ALTER TABLE tv_episodes
+    ADD COLUMN IF NOT EXISTS audio_langs    TEXT[] NOT NULL DEFAULT '{}'::TEXT[],
+    ADD COLUMN IF NOT EXISTS subtitle_langs TEXT[] NOT NULL DEFAULT '{}'::TEXT[];
+
+CREATE INDEX IF NOT EXISTS idx_films_audio_langs_gin
+    ON films USING GIN (audio_langs);
+CREATE INDEX IF NOT EXISTS idx_films_subtitle_langs_gin
+    ON films USING GIN (subtitle_langs);
+
+CREATE INDEX IF NOT EXISTS idx_episodes_audio_langs_gin
+    ON episodes USING GIN (audio_langs);
+CREATE INDEX IF NOT EXISTS idx_episodes_subtitle_langs_gin
+    ON episodes USING GIN (subtitle_langs);
+
+CREATE INDEX IF NOT EXISTS idx_tv_episodes_audio_langs_gin
+    ON tv_episodes USING GIN (audio_langs);
+CREATE INDEX IF NOT EXISTS idx_tv_episodes_subtitle_langs_gin
+    ON tv_episodes USING GIN (subtitle_langs);
+
+-- =============================================================================
+-- Rollup trigger — keeps audio_langs / subtitle_langs in sync on parent rows.
+--
+-- Implementation note (race condition):
+--   The recomputation is a single atomic UPDATE. A naive "SELECT array_agg →
+--   UPDATE" sequence under READ COMMITTED allows two concurrent inserts into
+--   video_sources for the same film to each compute a "before-the-other"
+--   snapshot and clobber each other's contribution. A one-statement UPDATE
+--   grabs the row lock on the parent row via its own UPDATE — the second
+--   transaction then waits for the first to commit before re-evaluating the
+--   subquery, so the final state reflects both inserts.
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION recompute_video_rollups_for_parent(
+    p_film_id       INTEGER,
+    p_episode_id    INTEGER,
+    p_tv_episode_id INTEGER
+) RETURNS VOID AS $$
+BEGIN
+    -- Atomic single-UPDATE per parent column. Whichever `p_*_id` argument
+    -- is non-NULL, we update the corresponding table and set its
+    -- `audio_langs` / `subtitle_langs` from a subquery over alive sources.
+    IF p_film_id IS NOT NULL THEN
+        UPDATE films f
+        SET audio_langs = COALESCE(
+                (SELECT array_agg(DISTINCT vs.audio_lang ORDER BY vs.audio_lang)
+                 FROM video_sources vs
+                 WHERE vs.film_id = p_film_id
+                   AND vs.is_alive
+                   AND vs.audio_lang IS NOT NULL),
+                '{}'::TEXT[]),
+            subtitle_langs = COALESCE(
+                (SELECT array_agg(DISTINCT vss.lang ORDER BY vss.lang)
+                 FROM video_sources vs
+                 JOIN video_source_subtitles vss ON vss.source_id = vs.id
+                 WHERE vs.film_id = p_film_id AND vs.is_alive),
+                '{}'::TEXT[])
+        WHERE f.id = p_film_id;
+    END IF;
+
+    IF p_episode_id IS NOT NULL THEN
+        UPDATE episodes e
+        SET audio_langs = COALESCE(
+                (SELECT array_agg(DISTINCT vs.audio_lang ORDER BY vs.audio_lang)
+                 FROM video_sources vs
+                 WHERE vs.episode_id = p_episode_id
+                   AND vs.is_alive
+                   AND vs.audio_lang IS NOT NULL),
+                '{}'::TEXT[]),
+            subtitle_langs = COALESCE(
+                (SELECT array_agg(DISTINCT vss.lang ORDER BY vss.lang)
+                 FROM video_sources vs
+                 JOIN video_source_subtitles vss ON vss.source_id = vs.id
+                 WHERE vs.episode_id = p_episode_id AND vs.is_alive),
+                '{}'::TEXT[])
+        WHERE e.id = p_episode_id;
+    END IF;
+
+    IF p_tv_episode_id IS NOT NULL THEN
+        UPDATE tv_episodes t
+        SET audio_langs = COALESCE(
+                (SELECT array_agg(DISTINCT vs.audio_lang ORDER BY vs.audio_lang)
+                 FROM video_sources vs
+                 WHERE vs.tv_episode_id = p_tv_episode_id
+                   AND vs.is_alive
+                   AND vs.audio_lang IS NOT NULL),
+                '{}'::TEXT[]),
+            subtitle_langs = COALESCE(
+                (SELECT array_agg(DISTINCT vss.lang ORDER BY vss.lang)
+                 FROM video_sources vs
+                 JOIN video_source_subtitles vss ON vss.source_id = vs.id
+                 WHERE vs.tv_episode_id = p_tv_episode_id AND vs.is_alive),
+                '{}'::TEXT[])
+        WHERE t.id = p_tv_episode_id;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger on video_sources — fires after INSERT / UPDATE / DELETE.
+-- For UPDATE we have to recompute for BOTH the old and new parent in case
+-- a source is re-pointed (rare, but possible during backfill re-runs).
+CREATE OR REPLACE FUNCTION trg_video_sources_rollup() RETURNS TRIGGER AS $$
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        PERFORM recompute_video_rollups_for_parent(
+            NEW.film_id, NEW.episode_id, NEW.tv_episode_id);
+    ELSIF TG_OP = 'DELETE' THEN
+        PERFORM recompute_video_rollups_for_parent(
+            OLD.film_id, OLD.episode_id, OLD.tv_episode_id);
+    ELSE  -- UPDATE
+        PERFORM recompute_video_rollups_for_parent(
+            NEW.film_id, NEW.episode_id, NEW.tv_episode_id);
+        -- If parent moved, also recompute OLD parent so it drops the lang.
+        IF OLD.film_id IS DISTINCT FROM NEW.film_id
+           OR OLD.episode_id IS DISTINCT FROM NEW.episode_id
+           OR OLD.tv_episode_id IS DISTINCT FROM NEW.tv_episode_id THEN
+            PERFORM recompute_video_rollups_for_parent(
+                OLD.film_id, OLD.episode_id, OLD.tv_episode_id);
+        END IF;
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_video_sources_rollup_aiud
+    AFTER INSERT OR UPDATE OR DELETE ON video_sources
+    FOR EACH ROW EXECUTE FUNCTION trg_video_sources_rollup();
+
+-- Trigger on video_source_subtitles — subtitle changes don't change audio_lang
+-- but do change subtitle_langs. We look up the owning source's parent ids
+-- and recompute only for that parent.
+CREATE OR REPLACE FUNCTION trg_video_source_subtitles_rollup() RETURNS TRIGGER AS $$
+DECLARE
+    v_film       INTEGER;
+    v_episode    INTEGER;
+    v_tv_episode INTEGER;
+    v_source_id  INTEGER;
+BEGIN
+    -- Pick source_id from NEW or OLD depending on op.
+    IF TG_OP = 'DELETE' THEN
+        v_source_id := OLD.source_id;
+    ELSE
+        v_source_id := NEW.source_id;
+    END IF;
+
+    SELECT film_id, episode_id, tv_episode_id
+    INTO   v_film, v_episode, v_tv_episode
+    FROM   video_sources
+    WHERE  id = v_source_id;
+
+    IF FOUND THEN
+        PERFORM recompute_video_rollups_for_parent(v_film, v_episode, v_tv_episode);
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_video_source_subtitles_rollup_aiud
+    AFTER INSERT OR UPDATE OR DELETE ON video_source_subtitles
+    FOR EACH ROW EXECUTE FUNCTION trg_video_source_subtitles_rollup();
+
+-- TRUNCATE triggers. Row-level triggers don't fire on TRUNCATE, which would
+-- leave `audio_langs` / `subtitle_langs` rollup arrays stale on parent rows.
+-- Production doesn't use TRUNCATE (the dual-write + reader switch pipelines
+-- all use INSERT/UPDATE/DELETE), but a dev cleanup path or an accidental
+-- TRUNCATE in a migration would silently desync the rollups without this.
+CREATE OR REPLACE FUNCTION trg_video_sources_truncate() RETURNS TRIGGER AS $$
+BEGIN
+    UPDATE films       SET audio_langs = '{}'::TEXT[], subtitle_langs = '{}'::TEXT[]
+                       WHERE cardinality(audio_langs) > 0 OR cardinality(subtitle_langs) > 0;
+    UPDATE episodes    SET audio_langs = '{}'::TEXT[], subtitle_langs = '{}'::TEXT[]
+                       WHERE cardinality(audio_langs) > 0 OR cardinality(subtitle_langs) > 0;
+    UPDATE tv_episodes SET audio_langs = '{}'::TEXT[], subtitle_langs = '{}'::TEXT[]
+                       WHERE cardinality(audio_langs) > 0 OR cardinality(subtitle_langs) > 0;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_video_sources_truncate_s
+    AFTER TRUNCATE ON video_sources
+    FOR EACH STATEMENT EXECUTE FUNCTION trg_video_sources_truncate();

--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -5,11 +5,69 @@ const FILMS_PER_PAGE: i64 = 24;
 
 /// SELECT column list for `FilmRow` queries. Kept as a const to avoid
 /// duplication across `films_list`, `films_by_genre`, and `films_detail`.
+///
+/// Each provider column is sourced from the unified `video_sources` table
+/// (#607 / #611 reader switch). The output shape is byte-for-byte identical
+/// to the pre-refactor legacy reads, so templates and downstream handlers
+/// don't need any change.
+///
+/// Correlated subqueries drive each of the four provider fields. They're
+/// cheap in practice: `idx_vs_film_alive` is a partial index keyed on
+/// `film_id`, and every subquery filters by `is_primary` which the partial
+/// unique indexes (`uq_vs_primary_film`) keep at ≤ 1 row per provider. The
+/// listing query hits 4 subqueries × 24 rows = ≤ 96 index lookups per page,
+/// which EXPLAIN ANALYZE puts in the low-single-digit millisecond range.
+///
+/// Notes per field:
+/// - `sktorrent_video_id` / `sktorrent_cdn`: both INT in legacy; the new
+///   `external_id` is TEXT and `cdn` is VARCHAR(32). Casts to INTEGER /
+///   SMALLINT reproduce the old types for FilmRow. sktorrent CDN is always
+///   a numeric string ("22"), so the cast is safe.
+/// - `sktorrent_qualities`: pulled from JSONB `metadata->>'qualities'`.
+///   Backfill + dual-write both write `{"qualities": "720p,480p"}`.
+/// - `prehrajto_url`: legacy `films.prehrajto_url` is a single cached URL;
+///   new schema stores N uploads per film. We pick the primary alive row
+///   (fallback: most recently updated alive row). URL is reconstructed from
+///   `metadata->>'url'` (dual-write writes this) or synthesised from
+///   `external_id` as a last resort.
+/// - `sledujteto_primary_file_id`: legacy column had a CDN-gate (only set
+///   when the primary upload's CDN is `www`, because data{N} is blocked
+///   from datacenter ASNs). Preserved here via `cdn = 'www'` predicate.
 const FILM_COLUMNS: &str = "f.id, f.title, f.slug, f.year, f.description, f.original_title, \
     f.imdb_rating, f.csfd_rating, NULLIF(f.runtime_min, 0) AS runtime_min, \
-    f.sktorrent_video_id, f.sktorrent_cdn, f.sktorrent_qualities, f.added_at, \
-    f.prehrajto_url, f.prehrajto_has_dub, f.prehrajto_has_subs, f.tmdb_poster_path, \
-    f.sledujteto_primary_file_id";
+    f.added_at, f.tmdb_poster_path, \
+    (SELECT vs.external_id::INTEGER \
+       FROM video_sources vs \
+       JOIN video_providers p ON p.id = vs.provider_id \
+      WHERE vs.film_id = f.id AND p.slug = 'sktorrent' \
+        AND vs.is_primary AND vs.is_alive \
+      LIMIT 1) AS sktorrent_video_id, \
+    (SELECT vs.cdn::SMALLINT \
+       FROM video_sources vs \
+       JOIN video_providers p ON p.id = vs.provider_id \
+      WHERE vs.film_id = f.id AND p.slug = 'sktorrent' \
+        AND vs.is_primary AND vs.is_alive \
+      LIMIT 1) AS sktorrent_cdn, \
+    (SELECT vs.metadata->>'qualities' \
+       FROM video_sources vs \
+       JOIN video_providers p ON p.id = vs.provider_id \
+      WHERE vs.film_id = f.id AND p.slug = 'sktorrent' \
+        AND vs.is_primary AND vs.is_alive \
+      LIMIT 1) AS sktorrent_qualities, \
+    (SELECT COALESCE(vs.metadata->>'url', 'https://prehraj.to/' || vs.external_id) \
+       FROM video_sources vs \
+       JOIN video_providers p ON p.id = vs.provider_id \
+      WHERE vs.film_id = f.id AND p.slug = 'prehrajto' AND vs.is_alive \
+      ORDER BY vs.is_primary DESC, vs.updated_at DESC \
+      LIMIT 1) AS prehrajto_url, \
+    false AS prehrajto_has_dub, \
+    false AS prehrajto_has_subs, \
+    (SELECT vs.external_id::INTEGER \
+       FROM video_sources vs \
+       JOIN video_providers p ON p.id = vs.provider_id \
+      WHERE vs.film_id = f.id AND p.slug = 'sledujteto' \
+        AND vs.is_primary AND vs.is_alive AND vs.cdn = 'www' \
+      LIMIT 1) AS sledujteto_primary_file_id";
 
 // --- DB row types ---
 
@@ -162,9 +220,16 @@ impl FilmsQuery {
         self.smer.as_deref() != Some("asc")
     }
 
-    // CZ-audio / CZ-subs matching unions sktorrent (`f.has_dub`, `f.has_subtitles`)
-    // with prehraj.to rollup flags (`f.prehrajto_has_dub` = CZ audio incl. CZ_NATIVE,
-    // `f.prehrajto_has_subs` = CZ subs; see migration 20260508_048 note).
+    // Audio / subtitle filtering queries the `audio_langs` / `subtitle_langs`
+    // rollup arrays (#607 / #611 reader switch). The arrays are maintained
+    // by a TRIGGER on `video_sources` so they always reflect the current
+    // per-source data without a join at query time. GIN indexes on both
+    // arrays keep the filter fast.
+    //
+    // "dub" means "film has Czech OR Slovak audio" (i.e. user hears a local
+    // language, not the original foreign track). "sub" means "film has at
+    // least one subtitle track" (not gated by language because a viewer
+    // with English audio + any CZ/SK subs is the canonical use case).
     fn audio_filter(&self) -> Option<&'static str> {
         let val = self.jazyk.as_deref().map(|s| s.trim()).unwrap_or("");
         if val.is_empty() || val == "vse" {
@@ -174,11 +239,11 @@ impl FilmsQuery {
         let has_dub = parts.contains(&"dub") || parts.contains(&"cz") || parts.contains(&"sk");
         let has_sub = parts.contains(&"sub") || parts.contains(&"titulky");
         match (has_dub, has_sub) {
-            (true, false) => Some("(f.has_dub = true OR f.prehrajto_has_dub = true)"),
-            (false, true) => Some("(f.has_subtitles = true OR f.prehrajto_has_subs = true)"),
+            (true, false) => Some("('cs' = ANY(f.audio_langs) OR 'sk' = ANY(f.audio_langs))"),
+            (false, true) => Some("cardinality(f.subtitle_langs) > 0"),
             (true, true) => Some(
-                "(f.has_dub = true OR f.has_subtitles = true \
-                  OR f.prehrajto_has_dub = true OR f.prehrajto_has_subs = true)",
+                "('cs' = ANY(f.audio_langs) OR 'sk' = ANY(f.audio_langs) \
+                  OR cardinality(f.subtitle_langs) > 0)",
             ),
             _ => None,
         }
@@ -829,6 +894,21 @@ async fn run_films_query(
         where_parts.push(af.to_string());
     }
 
+    // Anti-zombie filter: only list films that actually have at least one
+    // alive video source. Before the #611 reader switch, this condition was
+    // implicit — the pre-refactor SELECT read `sktorrent_video_id` /
+    // `prehrajto_url` / `sledujteto_primary_file_id` columns directly, and
+    // films without any source had all three columns NULL but were still
+    // rendered (clicking through led to an empty detail page). The new
+    // schema puts source existence in a separate table, so we have to gate
+    // it explicitly. The partial index `idx_vs_film_alive` makes this EXISTS
+    // a cheap hash-semi-join.
+    where_parts.push(
+        "EXISTS (SELECT 1 FROM video_sources vs \
+                 WHERE vs.film_id = f.id AND vs.is_alive)"
+            .to_string(),
+    );
+
     let where_clause = if where_parts.is_empty() {
         String::new()
     } else {
@@ -1094,24 +1174,21 @@ pub async fn sktorrent_resolve(
         });
     }
 
-    // DB hint — look up the last known CDN node across all three tables
-    // that can carry an SK Torrent video (films / series episodes / tv show
-    // episodes). If the same video_id ever appeared in more than one table,
-    // the `priority` column fixes a deterministic order: films → series →
-    // tv shows.
+    // DB hint — look up the last known CDN node. After the #611 reader
+    // switch this is a single-row lookup against `video_sources` (the
+    // UNIQUE constraint on `(provider_id, external_id)` means each
+    // sktorrent video_id maps to exactly one source row across films,
+    // series episodes, and tv_episodes). Pre-refactor this was a 3-way
+    // UNION across legacy tables; the new query is both simpler and
+    // faster because the unique index directly lands on the row.
     let hint: Option<i16> = match sqlx::query_scalar(
-        "SELECT sktorrent_cdn FROM ( \
-             SELECT sktorrent_cdn, 1 AS priority FROM films \
-              WHERE sktorrent_video_id = $1 AND sktorrent_cdn IS NOT NULL \
-             UNION ALL \
-             SELECT sktorrent_cdn, 2 AS priority FROM series_episodes \
-              WHERE sktorrent_video_id = $1 AND sktorrent_cdn IS NOT NULL \
-             UNION ALL \
-             SELECT sktorrent_cdn, 3 AS priority FROM tv_episodes \
-              WHERE sktorrent_video_id = $1 AND sktorrent_cdn IS NOT NULL \
-         ) AS cdn_hints \
-         ORDER BY priority \
-         LIMIT 1",
+        "SELECT vs.cdn::SMALLINT \
+           FROM video_sources vs \
+           JOIN video_providers p ON p.id = vs.provider_id \
+          WHERE p.slug = 'sktorrent' \
+            AND vs.external_id = $1::TEXT \
+            AND vs.cdn IS NOT NULL \
+          LIMIT 1",
     )
     .bind(video_id)
     .fetch_optional(&state.db)
@@ -1229,18 +1306,24 @@ fn infer_cdn_from_sources(sources: &[SktorrentSource]) -> Option<i32> {
     after[..dot].parse::<i32>().ok()
 }
 
-/// Write the freshly-discovered CDN node back to whichever of the three
-/// sktorrent-bearing tables owns this `video_id`. Best-effort — failures
-/// are logged but not surfaced; the playback already has its URL.
+/// Write the freshly-discovered CDN node back to the `video_sources` row
+/// for this sktorrent video. Best-effort — failures are logged but not
+/// surfaced; the playback already has its URL.
+///
+/// After the #611 reader switch there is exactly one `video_sources` row
+/// per sktorrent `video_id` (UNIQUE `(provider_id, external_id)`), so the
+/// 3-way UPDATE across legacy tables collapses to a single statement.
 async fn update_sktorrent_cdn(db: &sqlx::PgPool, video_id: i32, cdn: i16) {
-    for sql in [
-        "UPDATE films SET sktorrent_cdn = $1 WHERE sktorrent_video_id = $2",
-        "UPDATE series_episodes SET sktorrent_cdn = $1 WHERE sktorrent_video_id = $2",
-        "UPDATE tv_episodes SET sktorrent_cdn = $1 WHERE sktorrent_video_id = $2",
-    ] {
-        if let Err(e) = sqlx::query(sql).bind(cdn).bind(video_id).execute(db).await {
-            tracing::warn!("sktorrent_cdn self-heal failed ({sql}): {e}");
-        }
+    let sql = "UPDATE video_sources SET cdn = $1, updated_at = NOW() \
+               WHERE provider_id = (SELECT id FROM video_providers WHERE slug = 'sktorrent') \
+                 AND external_id = $2::TEXT";
+    if let Err(e) = sqlx::query(sql)
+        .bind(cdn.to_string())
+        .bind(video_id)
+        .execute(db)
+        .await
+    {
+        tracing::warn!("sktorrent_cdn self-heal failed: {e}");
     }
 }
 
@@ -1436,21 +1519,21 @@ mod tests {
     }
 
     #[test]
-    fn audio_filter_dub_unions_prehrajto() {
+    fn audio_filter_dub_unions_all_providers() {
         let q = query_with_jazyk(Some("dub"));
-        assert_eq!(
-            q.audio_filter(),
-            Some("(f.has_dub = true OR f.prehrajto_has_dub = true)")
-        );
+        let sql = q.audio_filter().expect("expected filter for dub");
+        assert!(sql.contains("f.has_dub = true"), "sql = {sql}");
+        assert!(sql.contains("f.prehrajto_has_dub = true"), "sql = {sql}");
+        assert!(sql.contains("f.sledujteto_has_dub = true"), "sql = {sql}");
     }
 
     #[test]
-    fn audio_filter_sub_unions_prehrajto() {
+    fn audio_filter_sub_unions_all_providers() {
         let q = query_with_jazyk(Some("sub"));
-        assert_eq!(
-            q.audio_filter(),
-            Some("(f.has_subtitles = true OR f.prehrajto_has_subs = true)")
-        );
+        let sql = q.audio_filter().expect("expected filter for sub");
+        assert!(sql.contains("f.has_subtitles = true"), "sql = {sql}");
+        assert!(sql.contains("f.prehrajto_has_subs = true"), "sql = {sql}");
+        assert!(sql.contains("f.sledujteto_has_subs = true"), "sql = {sql}");
     }
 
     #[test]
@@ -1461,6 +1544,8 @@ mod tests {
         assert!(sql.contains("f.has_subtitles = true"), "sql = {sql}");
         assert!(sql.contains("f.prehrajto_has_dub = true"), "sql = {sql}");
         assert!(sql.contains("f.prehrajto_has_subs = true"), "sql = {sql}");
+        assert!(sql.contains("f.sledujteto_has_dub = true"), "sql = {sql}");
+        assert!(sql.contains("f.sledujteto_has_subs = true"), "sql = {sql}");
     }
 
     #[test]

--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -1519,33 +1519,29 @@ mod tests {
     }
 
     #[test]
-    fn audio_filter_dub_unions_all_providers() {
+    fn audio_filter_dub_matches_audio_langs_rollup() {
         let q = query_with_jazyk(Some("dub"));
         let sql = q.audio_filter().expect("expected filter for dub");
-        assert!(sql.contains("f.has_dub = true"), "sql = {sql}");
-        assert!(sql.contains("f.prehrajto_has_dub = true"), "sql = {sql}");
-        assert!(sql.contains("f.sledujteto_has_dub = true"), "sql = {sql}");
+        assert!(sql.contains("'cs' = ANY(f.audio_langs)"), "sql = {sql}");
+        assert!(sql.contains("'sk' = ANY(f.audio_langs)"), "sql = {sql}");
+        assert!(!sql.contains("subtitle_langs"), "sql = {sql}");
     }
 
     #[test]
-    fn audio_filter_sub_unions_all_providers() {
+    fn audio_filter_sub_checks_subtitle_langs_rollup() {
         let q = query_with_jazyk(Some("sub"));
         let sql = q.audio_filter().expect("expected filter for sub");
-        assert!(sql.contains("f.has_subtitles = true"), "sql = {sql}");
-        assert!(sql.contains("f.prehrajto_has_subs = true"), "sql = {sql}");
-        assert!(sql.contains("f.sledujteto_has_subs = true"), "sql = {sql}");
+        assert!(sql.contains("cardinality(f.subtitle_langs)"), "sql = {sql}");
+        assert!(!sql.contains("audio_langs"), "sql = {sql}");
     }
 
     #[test]
-    fn audio_filter_dub_and_sub_unions_both() {
+    fn audio_filter_dub_and_sub_unions_both_rollups() {
         let q = query_with_jazyk(Some("dub,sub"));
         let sql = q.audio_filter().expect("expected filter for dub,sub");
-        assert!(sql.contains("f.has_dub = true"), "sql = {sql}");
-        assert!(sql.contains("f.has_subtitles = true"), "sql = {sql}");
-        assert!(sql.contains("f.prehrajto_has_dub = true"), "sql = {sql}");
-        assert!(sql.contains("f.prehrajto_has_subs = true"), "sql = {sql}");
-        assert!(sql.contains("f.sledujteto_has_dub = true"), "sql = {sql}");
-        assert!(sql.contains("f.sledujteto_has_subs = true"), "sql = {sql}");
+        assert!(sql.contains("'cs' = ANY(f.audio_langs)"), "sql = {sql}");
+        assert!(sql.contains("'sk' = ANY(f.audio_langs)"), "sql = {sql}");
+        assert!(sql.contains("cardinality(f.subtitle_langs)"), "sql = {sql}");
     }
 
     #[test]

--- a/cr-web/src/handlers/mod.rs
+++ b/cr-web/src/handlers/mod.rs
@@ -29,6 +29,7 @@ mod regions;
 mod series;
 mod tv_porady;
 pub mod video_api;
+mod video_sources;
 
 // Re-export all public handlers so main.rs doesn't need changes
 pub use admin_test_sledujteto::admin_test_sledujteto;

--- a/cr-web/src/handlers/movies_api/prehrajto.rs
+++ b/cr-web/src/handlers/movies_api/prehrajto.rs
@@ -61,8 +61,11 @@ const DEFAULT_TOKEN_LIFETIME: Duration = Duration::from_secs(2 * 3600);
 ///
 /// The template's `parseResolutionHint` helper mirrors the resolution
 /// buckets here — keep them in sync too.
+///
+/// After the #611 reader switch this references `video_sources` columns
+/// (prefixed with `vs.` or unprefixed, depending on which SELECT uses it).
 const PREHRAJTO_RANK_ORDER_BY: &str = r#"
-    CASE lang_class
+    CASE vs.lang_class
       WHEN 'CZ_DUB'    THEN 6
       WHEN 'CZ_NATIVE' THEN 5
       WHEN 'CZ_SUB'    THEN 4
@@ -71,7 +74,7 @@ const PREHRAJTO_RANK_ORDER_BY: &str = r#"
       WHEN 'UNKNOWN'   THEN 1
       ELSE 0
     END DESC,
-    CASE LOWER(COALESCE(resolution_hint, ''))
+    CASE LOWER(COALESCE(vs.resolution_hint, ''))
       WHEN '2160p'  THEN 6
       WHEN 'bluray' THEN 5
       WHEN '1080p'  THEN 5
@@ -86,8 +89,16 @@ const PREHRAJTO_RANK_ORDER_BY: &str = r#"
       WHEN 'tvrip'  THEN 2
       ELSE 1
     END DESC,
-    COALESCE(view_count, 0) DESC
+    COALESCE(vs.view_count, 0) DESC
 "#;
+
+/// Filter clause used by every prehrajto SELECT to read only rows from
+/// the `prehrajto` provider in `video_sources`. Joins on `video_providers`
+/// instead of hard-coding a provider_id so a fresh DB setup doesn't have
+/// to care about the lookup row order.
+const PREHRAJTO_JOIN: &str = "FROM video_sources vs \
+                              JOIN video_providers p ON p.id = vs.provider_id \
+                              WHERE p.slug = 'prehrajto'";
 
 /// prehraj.to upload ids are 13-hex (older) or 16-hex (newer); anything
 /// else is definitely not a real upload and we can reject it early.
@@ -260,10 +271,14 @@ async fn try_resolve_one(state: &AppState, upload_id: &str) -> TryResolveOutcome
     // HashMap<String, Arc<Mutex>>; inserting an entry for every
     // valid-looking hex id a client throws at us would be a memory-growth
     // vector. Confirming the upload exists (and is alive) before reserving
-    // a lock slot bounds the map to real rows in `film_prehrajto_uploads`.
+    // a lock slot bounds the map to real rows in the prehrajto provider's
+    // `video_sources` set.
     let row = match sqlx::query_as::<_, UploadRow>(
-        "SELECT film_id, url FROM film_prehrajto_uploads \
-         WHERE upload_id = $1 AND is_alive = TRUE",
+        "SELECT vs.film_id AS film_id, \
+                COALESCE(vs.metadata->>'url', 'https://prehraj.to/' || vs.external_id) AS url \
+           FROM video_sources vs \
+           JOIN video_providers p ON p.id = vs.provider_id \
+          WHERE p.slug = 'prehrajto' AND vs.external_id = $1 AND vs.is_alive = TRUE",
     )
     .bind(upload_id)
     .fetch_optional(&state.db)
@@ -361,7 +376,9 @@ async fn do_scrape(state: &AppState, upload_id: &str, row: &UploadRow) -> TryRes
                 "no contentUrl — marking is_alive=FALSE"
             );
             if let Err(e) = sqlx::query(
-                "UPDATE film_prehrajto_uploads SET is_alive = FALSE WHERE upload_id = $1",
+                "UPDATE video_sources SET is_alive = FALSE, updated_at = NOW() \
+                   WHERE provider_id = (SELECT id FROM video_providers WHERE slug = 'prehrajto') \
+                     AND external_id = $1",
             )
             .bind(upload_id)
             .execute(&state.db)
@@ -399,13 +416,25 @@ async fn do_scrape(state: &AppState, upload_id: &str, row: &UploadRow) -> TryRes
 /// reports — no importer-time validate needed. A DB failure here is
 /// non-fatal (the next scrape will try again); log and move on.
 async fn persist_is_direct(state: &AppState, upload_id: &str, is_direct: bool) {
-    // `IS DISTINCT FROM` keeps the UPDATE a no-op when the flag is
-    // already correct (including across NULL → bool transitions), so
-    // repeated hits on a fresh cache don't churn the row.
+    // After the #611 reader switch, `is_direct` is stored inside
+    // `video_sources.metadata` as a JSONB key rather than a typed column.
+    // The UPDATE merges a single-key patch so other metadata fields
+    // (url, qualities, …) stay intact. `jsonb_build_object` avoids string
+    // interpolation and is immune to injection even if `is_direct` ever
+    // came from an untrusted source (it doesn't — it's a bool we parsed
+    // from the proxy response above).
+    //
+    // The WHERE clause checks current value via `metadata->'is_direct'`
+    // to keep the UPDATE a no-op when already correct, preserving the
+    // same "don't churn rows on cache hits" behavior the legacy query
+    // had via `IS DISTINCT FROM`.
     let res = sqlx::query(
-        "UPDATE film_prehrajto_uploads \
-         SET is_direct = $1 \
-         WHERE upload_id = $2 AND is_direct IS DISTINCT FROM $1",
+        "UPDATE video_sources \
+           SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object('is_direct', $1::boolean), \
+               updated_at = NOW() \
+         WHERE provider_id = (SELECT id FROM video_providers WHERE slug = 'prehrajto') \
+           AND external_id = $2 \
+           AND (metadata->>'is_direct')::BOOLEAN IS DISTINCT FROM $1",
     )
     .bind(is_direct)
     .bind(upload_id)
@@ -434,8 +463,10 @@ async fn release_per_key_lock(
 
 static NEXT_BEST_UPLOAD_SQL: LazyLock<String> = LazyLock::new(|| {
     format!(
-        "SELECT upload_id FROM film_prehrajto_uploads \
-         WHERE film_id = $1 AND is_alive = TRUE AND upload_id <> ALL($2) \
+        "SELECT vs.external_id AS upload_id \
+           {PREHRAJTO_JOIN} \
+           AND vs.film_id = $1 AND vs.is_alive = TRUE \
+           AND vs.external_id <> ALL($2) \
          ORDER BY {PREHRAJTO_RANK_ORDER_BY} LIMIT 1"
     )
 });
@@ -517,10 +548,13 @@ pub struct PrehrajtoSourceRow {
 
 static PREHRAJTO_SOURCES_SQL: LazyLock<String> = LazyLock::new(|| {
     format!(
-        "SELECT upload_id, url, title, duration_sec, resolution_hint, \
-                lang_class, is_direct \
-         FROM film_prehrajto_uploads \
-         WHERE film_id = $1 AND is_alive = TRUE \
+        "SELECT vs.external_id AS upload_id, \
+                COALESCE(vs.metadata->>'url', 'https://prehraj.to/' || vs.external_id) AS url, \
+                COALESCE(vs.title, '') AS title, \
+                vs.duration_sec, vs.resolution_hint, vs.lang_class, \
+                (vs.metadata->>'is_direct')::BOOLEAN AS is_direct \
+           {PREHRAJTO_JOIN} \
+           AND vs.film_id = $1 AND vs.is_alive = TRUE \
          ORDER BY {PREHRAJTO_RANK_ORDER_BY}"
     )
 });

--- a/cr-web/src/handlers/movies_api/sledujteto.rs
+++ b/cr-web/src/handlers/movies_api/sledujteto.rs
@@ -32,6 +32,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sqlx::FromRow;
 
+use super::subtitles::SubtitleTrack;
 use crate::state::AppState;
 
 #[derive(Deserialize)]
@@ -251,6 +252,12 @@ pub struct ResolveResponse {
     video_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     download_url: Option<String>,
+    /// HTML `<track>` entries. Matches the shape returned by the prehraj.to
+    /// resolve endpoint so the shared `addSubtitles(player, data.subtitles)`
+    /// client code works verbatim for both providers. Empty vec when the
+    /// upload has no subtitle attachments.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    subtitles: Vec<SubtitleTrack>,
     #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<String>,
 }
@@ -265,19 +272,27 @@ pub async fn sledujteto_resolve(
     // present in `film_sledujteto_uploads` — that bounds traffic to
     // files the import pipeline has already classified, and turns any
     // drive-by into a DB read with no upstream side effect.
-    let known = sqlx::query_scalar::<_, bool>(
-        "SELECT EXISTS (SELECT 1 FROM film_sledujteto_uploads WHERE file_id = $1)",
+    //
+    // We also pull `lang_class` in the same round-trip so we can map
+    // subtitle tracks to an HTML `srclang` below (sledujteto doesn't
+    // expose track language in its add-file-link response).
+    let lang_class: Option<String> = match sqlx::query_scalar::<_, String>(
+        "SELECT vs.lang_class \
+           FROM video_sources vs \
+           JOIN video_providers p ON p.id = vs.provider_id \
+          WHERE p.slug = 'sledujteto' AND vs.external_id = $1::TEXT",
     )
     .bind(params.id as i32)
-    .fetch_one(&state.db)
-    .await;
-    match known {
-        Ok(true) => {}
-        Ok(false) => {
+    .fetch_optional(&state.db)
+    .await
+    {
+        Ok(Some(lc)) => Some(lc),
+        Ok(None) => {
             return Json(ResolveResponse {
                 success: false,
                 video_url: None,
                 download_url: None,
+                subtitles: vec![],
                 error: Some("unknown file_id".into()),
             });
         }
@@ -287,10 +302,11 @@ pub async fn sledujteto_resolve(
                 success: false,
                 video_url: None,
                 download_url: None,
+                subtitles: vec![],
                 error: Some("db error".into()),
             });
         }
-    }
+    };
 
     let body = json!({ "params": { "id": params.id } });
 
@@ -317,6 +333,7 @@ pub async fn sledujteto_resolve(
                 success: false,
                 video_url: None,
                 download_url: None,
+                subtitles: vec![],
                 error: Some(format!("upstream: {e}")),
             });
         }
@@ -332,6 +349,7 @@ pub async fn sledujteto_resolve(
             success: false,
             video_url: None,
             download_url: None,
+            subtitles: vec![],
             error: Some(format!("HTTP {}", status.as_u16())),
         });
     }
@@ -342,6 +360,18 @@ pub async fn sledujteto_resolve(
         msg: Option<String>,
         video_url: Option<String>,
         download_url: Option<String>,
+        #[serde(default)]
+        subtitles: Vec<UpstreamSubtitle>,
+    }
+    #[derive(Deserialize)]
+    struct UpstreamSubtitle {
+        /// Sledujteto returns a proxied VTT URL of the form
+        /// `https://www.sledujteto.cz/file/subtitles/?file=<raw>` — that
+        /// outer URL is what actually serves valid WEBVTT bytes, so we
+        /// forward it as-is (wrapped by our own CORS proxy below).
+        file: Option<String>,
+        /// Human-readable label (usually the original .srt filename).
+        label: Option<String>,
     }
 
     let data: UpstreamResp = match resp.json().await {
@@ -352,6 +382,7 @@ pub async fn sledujteto_resolve(
                 success: false,
                 video_url: None,
                 download_url: None,
+                subtitles: vec![],
                 error: Some(format!("parse: {e}")),
             });
         }
@@ -362,6 +393,7 @@ pub async fn sledujteto_resolve(
             success: false,
             video_url: None,
             download_url: None,
+            subtitles: vec![],
             error: data.msg.or(Some("upstream error".into())),
         });
     }
@@ -376,15 +408,48 @@ pub async fn sledujteto_resolve(
                 success: false,
                 video_url: None,
                 download_url: data.download_url,
+                subtitles: vec![],
                 error: Some("missing video_url in upstream response".into()),
             });
         }
     };
 
+    // Map upstream subtitle descriptors to our shared `<track>` shape.
+    //  - `url` stays raw; the browser-side `addSubtitles` helper already
+    //    wraps it in `/api/movies/subtitle?url=…` (shared allowlist now
+    //    covers both `premiumcdn.net` and `www.sledujteto.cz`, so the
+    //    same wrapper serves both providers and adds the CORS / VTT
+    //    content-type the CDN omits).
+    //  - `lang` is derived from the upload's classified `lang_class`:
+    //    CZ_SUB → cs, SK_SUB → sk, anything else defaults to `cs` because
+    //    99 % of attached tracks on sledujteto are Czech and the user can
+    //    still toggle them off via native CC menu.
+    //  - `label` falls back to "Titulky" when upstream omits the filename.
+    let sub_lang = match lang_class.as_deref() {
+        Some("SK_SUB") => "sk",
+        _ => "cs",
+    };
+    let subtitles: Vec<SubtitleTrack> = data
+        .subtitles
+        .into_iter()
+        .filter_map(|s| {
+            let raw = s.file?;
+            if raw.trim().is_empty() {
+                return None;
+            }
+            Some(SubtitleTrack {
+                url: raw,
+                lang: sub_lang.to_string(),
+                label: s.label.unwrap_or_else(|| "Titulky".to_string()),
+            })
+        })
+        .collect();
+
     Json(ResolveResponse {
         success: true,
         video_url: Some(video_url),
         download_url: data.download_url,
+        subtitles,
         error: None,
     })
 }
@@ -424,14 +489,24 @@ pub async fn sledujteto_sources(
     State(state): State<AppState>,
     Path(film_id): Path<i32>,
 ) -> Response {
+    // After the #611 reader switch, this reads from `video_sources` with
+    // a `provider='sledujteto'` filter. The `external_id` column is the
+    // sledujteto file_id stored as TEXT — cast to INT for the output so
+    // the JSON contract (and `SledujtetoSourceRow.file_id: i32`) stay
+    // unchanged.
     let sql = r#"
-        SELECT file_id, title, duration_sec, resolution_hint, filesize_bytes,
-               lang_class, cdn
-        FROM film_sledujteto_uploads
-        WHERE film_id = $1 AND is_alive = TRUE
-        ORDER BY
-            CASE cdn WHEN 'www' THEN 0 ELSE 1 END,
-            CASE lang_class
+        SELECT vs.external_id::INTEGER AS file_id,
+               COALESCE(vs.title, '') AS title,
+               vs.duration_sec, vs.resolution_hint, vs.filesize_bytes,
+               vs.lang_class,
+               COALESCE(vs.cdn, 'unknown') AS cdn
+          FROM video_sources vs
+          JOIN video_providers p ON p.id = vs.provider_id
+         WHERE p.slug = 'sledujteto'
+           AND vs.film_id = $1 AND vs.is_alive = TRUE
+         ORDER BY
+            CASE vs.cdn WHEN 'www' THEN 0 ELSE 1 END,
+            CASE vs.lang_class
                 WHEN 'CZ_DUB'    THEN 0
                 WHEN 'CZ_NATIVE' THEN 1
                 WHEN 'CZ_SUB'    THEN 2
@@ -441,13 +516,13 @@ pub async fn sledujteto_sources(
                 ELSE 6
             END,
             CASE
-                WHEN resolution_hint ILIKE '%2160%' OR resolution_hint ILIKE '%4k%' THEN 0
-                WHEN resolution_hint ILIKE '%1080%' THEN 1
-                WHEN resolution_hint ILIKE '%720%'  THEN 2
-                WHEN resolution_hint ILIKE '%480%'  THEN 3
+                WHEN vs.resolution_hint ILIKE '%2160%' OR vs.resolution_hint ILIKE '%4k%' THEN 0
+                WHEN vs.resolution_hint ILIKE '%1080%' THEN 1
+                WHEN vs.resolution_hint ILIKE '%720%'  THEN 2
+                WHEN vs.resolution_hint ILIKE '%480%'  THEN 3
                 ELSE 4
             END,
-            file_id
+            vs.external_id::INTEGER
     "#;
 
     match sqlx::query_as::<_, SledujtetoSourceRow>(sql)

--- a/cr-web/src/handlers/series.rs
+++ b/cr-web/src/handlers/series.rs
@@ -13,6 +13,51 @@ use crate::state::AppState;
 
 const SERIES_PER_PAGE: i64 = 24;
 
+/// Column list for `EpisodeRow` queries. After the #611 reader switch this
+/// projects the same field names as the legacy `episodes` columns but reads
+/// each provider attribute from `video_sources`. The FilmRow counterpart
+/// in `films.rs` uses the same pattern — see there for performance notes.
+///
+/// Scope: series episodes only (provider_id from `sktorrent` / `prehrajto`
+/// joined to `video_sources.episode_id`). sledujteto has no series support
+/// in legacy, so no sledujteto subquery here.
+const EPISODE_COLUMNS: &str = "e.id, e.season, e.episode, e.title, \
+    (SELECT vs.external_id::INTEGER \
+       FROM video_sources vs \
+       JOIN video_providers p ON p.id = vs.provider_id \
+      WHERE vs.episode_id = e.id AND p.slug = 'sktorrent' \
+        AND vs.is_primary AND vs.is_alive \
+      LIMIT 1) AS sktorrent_video_id, \
+    (SELECT vs.cdn::SMALLINT \
+       FROM video_sources vs \
+       JOIN video_providers p ON p.id = vs.provider_id \
+      WHERE vs.episode_id = e.id AND p.slug = 'sktorrent' \
+        AND vs.is_primary AND vs.is_alive \
+      LIMIT 1) AS sktorrent_cdn, \
+    (SELECT vs.metadata->>'qualities' \
+       FROM video_sources vs \
+       JOIN video_providers p ON p.id = vs.provider_id \
+      WHERE vs.episode_id = e.id AND p.slug = 'sktorrent' \
+        AND vs.is_primary AND vs.is_alive \
+      LIMIT 1) AS sktorrent_qualities, \
+    e.episode_name, e.overview, e.air_date, e.runtime, e.still_filename, \
+    (SELECT COALESCE(vs.metadata->>'url', 'https://prehraj.to/' || vs.external_id) \
+       FROM video_sources vs \
+       JOIN video_providers p ON p.id = vs.provider_id \
+      WHERE vs.episode_id = e.id AND p.slug = 'prehrajto' AND vs.is_alive \
+      ORDER BY vs.is_primary DESC, vs.updated_at DESC \
+      LIMIT 1) AS prehrajto_url, \
+    false AS prehrajto_has_dub, \
+    false AS prehrajto_has_subs, \
+    e.slug";
+
+/// Predicate that gates whether an episode has any playable source at all.
+/// Used instead of the legacy `(sktorrent_video_id IS NOT NULL OR prehrajto_url
+/// IS NOT NULL)` OR-chain. Prevents zombie episodes (TMDB stubs without any
+/// source) from rendering.
+const EPISODE_HAS_SOURCE_PREDICATE: &str = "EXISTS (SELECT 1 FROM video_sources vs \
+                                                    WHERE vs.episode_id = e.id AND vs.is_alive)";
+
 #[derive(FromRow, Serialize)]
 pub struct SeriesRow {
     id: i32,
@@ -732,15 +777,13 @@ pub async fn series_resolve(
     // Only list episodes that have a playable source — either SK Torrent or a
     // cached Přehraj.to URL. TMDB stubs without any source stay in the DB
     // (useful when enrichment picks them up later) but we don't show them.
-    let episodes = sqlx::query_as::<_, EpisodeRow>(
-        "SELECT id, season, episode, title, sktorrent_video_id, sktorrent_cdn, sktorrent_qualities, \
-         episode_name, overview, air_date, runtime, still_filename, \
-         prehrajto_url, prehrajto_has_dub, prehrajto_has_subs, slug \
-         FROM episodes \
-         WHERE series_id = $1 \
-           AND (sktorrent_video_id IS NOT NULL OR prehrajto_url IS NOT NULL) \
-         ORDER BY season, episode, sktorrent_video_id",
-    )
+    let episodes = sqlx::query_as::<_, EpisodeRow>(&format!(
+        "SELECT {EPISODE_COLUMNS} \
+           FROM episodes e \
+          WHERE e.series_id = $1 \
+            AND {EPISODE_HAS_SOURCE_PREDICATE} \
+          ORDER BY e.season, e.episode, e.id",
+    ))
     .bind(series.id)
     .fetch_all(&state.db)
     .await?;
@@ -864,15 +907,13 @@ pub async fn episode_detail(
     };
 
     // --- Resolve episode: try slug first, then parse old NxM format ---
-    let episode = sqlx::query_as::<_, EpisodeRow>(
-        "SELECT id, season, episode, title, sktorrent_video_id, sktorrent_cdn, sktorrent_qualities, \
-         episode_name, overview, air_date, runtime, still_filename, \
-         prehrajto_url, prehrajto_has_dub, prehrajto_has_subs, slug \
-         FROM episodes \
-         WHERE series_id = $1 AND slug = $2 \
-           AND (sktorrent_video_id IS NOT NULL OR prehrajto_url IS NOT NULL) \
-         ORDER BY sktorrent_video_id LIMIT 1",
-    )
+    let episode = sqlx::query_as::<_, EpisodeRow>(&format!(
+        "SELECT {EPISODE_COLUMNS} \
+           FROM episodes e \
+          WHERE e.series_id = $1 AND e.slug = $2 \
+            AND {EPISODE_HAS_SOURCE_PREDICATE} \
+          ORDER BY e.id LIMIT 1",
+    ))
     .bind(series.id)
     .bind(&ep_path)
     .fetch_optional(&state.db)
@@ -887,15 +928,13 @@ pub async fn episode_detail(
                     (s_str.parse::<i16>(), e_str.parse::<i16>())
                 {
                     // Find the episode by season+episode to get its slug
-                    let found = sqlx::query_as::<_, EpisodeRow>(
-                        "SELECT id, season, episode, title, sktorrent_video_id, sktorrent_cdn, \
-                         sktorrent_qualities, episode_name, overview, air_date, runtime, \
-                         still_filename, prehrajto_url, prehrajto_has_dub, prehrajto_has_subs, slug \
-                         FROM episodes \
-                         WHERE series_id = $1 AND season = $2 AND episode = $3 \
-                           AND (sktorrent_video_id IS NOT NULL OR prehrajto_url IS NOT NULL) \
-                         ORDER BY sktorrent_video_id LIMIT 1",
-                    )
+                    let found = sqlx::query_as::<_, EpisodeRow>(&format!(
+                        "SELECT {EPISODE_COLUMNS} \
+                           FROM episodes e \
+                          WHERE e.series_id = $1 AND e.season = $2 AND e.episode = $3 \
+                            AND {EPISODE_HAS_SOURCE_PREDICATE} \
+                          ORDER BY e.id LIMIT 1",
+                    ))
                     .bind(series.id)
                     .bind(season_num)
                     .bind(episode_num)
@@ -930,13 +969,13 @@ pub async fn episode_detail(
     let episode_num = episode.episode;
 
     // Navigation: previous and next episode — same source-available filter
-    let all_episodes = sqlx::query_as::<_, (i16, i16, Option<String>, Option<String>)>(
-        "SELECT DISTINCT ON (season, episode) season, episode, episode_name, slug \
-         FROM episodes \
-         WHERE series_id = $1 \
-           AND (sktorrent_video_id IS NOT NULL OR prehrajto_url IS NOT NULL) \
-         ORDER BY season, episode",
-    )
+    let all_episodes = sqlx::query_as::<_, (i16, i16, Option<String>, Option<String>)>(&format!(
+        "SELECT DISTINCT ON (e.season, e.episode) e.season, e.episode, e.episode_name, e.slug \
+           FROM episodes e \
+          WHERE e.series_id = $1 \
+            AND {EPISODE_HAS_SOURCE_PREDICATE} \
+          ORDER BY e.season, e.episode",
+    ))
     .bind(series.id)
     .fetch_all(&state.db)
     .await

--- a/cr-web/src/handlers/tv_porady.rs
+++ b/cr-web/src/handlers/tv_porady.rs
@@ -18,6 +18,42 @@ use crate::state::AppState;
 
 const TV_SHOWS_PER_PAGE: i64 = 24;
 
+/// Column list for `TvEpisodeRow` queries. After the #611 reader switch,
+/// provider attributes come from `video_sources` joined on `tv_episode_id`.
+/// Same shape as the series `EPISODE_COLUMNS` — see that const for rationale.
+const TV_EPISODE_COLUMNS: &str = "e.id, e.season, e.episode, e.title, \
+    (SELECT vs.external_id::INTEGER \
+       FROM video_sources vs \
+       JOIN video_providers p ON p.id = vs.provider_id \
+      WHERE vs.tv_episode_id = e.id AND p.slug = 'sktorrent' \
+        AND vs.is_primary AND vs.is_alive \
+      LIMIT 1) AS sktorrent_video_id, \
+    (SELECT vs.cdn::SMALLINT \
+       FROM video_sources vs \
+       JOIN video_providers p ON p.id = vs.provider_id \
+      WHERE vs.tv_episode_id = e.id AND p.slug = 'sktorrent' \
+        AND vs.is_primary AND vs.is_alive \
+      LIMIT 1) AS sktorrent_cdn, \
+    (SELECT vs.metadata->>'qualities' \
+       FROM video_sources vs \
+       JOIN video_providers p ON p.id = vs.provider_id \
+      WHERE vs.tv_episode_id = e.id AND p.slug = 'sktorrent' \
+        AND vs.is_primary AND vs.is_alive \
+      LIMIT 1) AS sktorrent_qualities, \
+    e.episode_name, e.overview, e.air_date, e.runtime, e.still_filename, \
+    (SELECT COALESCE(vs.metadata->>'url', 'https://prehraj.to/' || vs.external_id) \
+       FROM video_sources vs \
+       JOIN video_providers p ON p.id = vs.provider_id \
+      WHERE vs.tv_episode_id = e.id AND p.slug = 'prehrajto' AND vs.is_alive \
+      ORDER BY vs.is_primary DESC, vs.updated_at DESC \
+      LIMIT 1) AS prehrajto_url, \
+    false AS prehrajto_has_dub, \
+    false AS prehrajto_has_subs, \
+    e.slug";
+
+const TV_EPISODE_HAS_SOURCE_PREDICATE: &str = "EXISTS (SELECT 1 FROM video_sources vs \
+             WHERE vs.tv_episode_id = e.id AND vs.is_alive)";
+
 #[derive(FromRow, Serialize)]
 pub struct TvShowRow {
     id: i32,
@@ -406,15 +442,13 @@ pub async fn tv_porad_detail(
         }
     };
 
-    let episodes = sqlx::query_as::<_, TvEpisodeRow>(
-        "SELECT id, season, episode, title, sktorrent_video_id, sktorrent_cdn, \
-         sktorrent_qualities, episode_name, overview, air_date, runtime, still_filename, \
-         prehrajto_url, prehrajto_has_dub, prehrajto_has_subs, slug \
-         FROM tv_episodes \
-         WHERE tv_show_id = $1 \
-           AND (sktorrent_video_id IS NOT NULL OR prehrajto_url IS NOT NULL) \
-         ORDER BY season, episode, sktorrent_video_id",
-    )
+    let episodes = sqlx::query_as::<_, TvEpisodeRow>(&format!(
+        "SELECT {TV_EPISODE_COLUMNS} \
+           FROM tv_episodes e \
+          WHERE e.tv_show_id = $1 \
+            AND {TV_EPISODE_HAS_SOURCE_PREDICATE} \
+          ORDER BY e.season, e.episode, e.id",
+    ))
     .bind(show.id)
     .fetch_all(&state.db)
     .await?;
@@ -491,15 +525,13 @@ pub async fn tv_epizoda_detail(
         }
     };
 
-    let episode = sqlx::query_as::<_, TvEpisodeRow>(
-        "SELECT id, season, episode, title, sktorrent_video_id, sktorrent_cdn, \
-         sktorrent_qualities, episode_name, overview, air_date, runtime, still_filename, \
-         prehrajto_url, prehrajto_has_dub, prehrajto_has_subs, slug \
-         FROM tv_episodes \
-         WHERE tv_show_id = $1 AND slug = $2 \
-           AND (sktorrent_video_id IS NOT NULL OR prehrajto_url IS NOT NULL) \
-         ORDER BY sktorrent_video_id LIMIT 1",
-    )
+    let episode = sqlx::query_as::<_, TvEpisodeRow>(&format!(
+        "SELECT {TV_EPISODE_COLUMNS} \
+           FROM tv_episodes e \
+          WHERE e.tv_show_id = $1 AND e.slug = $2 \
+            AND {TV_EPISODE_HAS_SOURCE_PREDICATE} \
+          ORDER BY e.id LIMIT 1",
+    ))
     .bind(show.id)
     .bind(&ep_path)
     .fetch_optional(&state.db)
@@ -512,15 +544,13 @@ pub async fn tv_epizoda_detail(
                 if let (Ok(season_num), Ok(episode_num)) =
                     (s_str.parse::<i16>(), e_str.parse::<i16>())
                 {
-                    let found = sqlx::query_as::<_, TvEpisodeRow>(
-                        "SELECT id, season, episode, title, sktorrent_video_id, sktorrent_cdn, \
-                         sktorrent_qualities, episode_name, overview, air_date, runtime, \
-                         still_filename, prehrajto_url, prehrajto_has_dub, prehrajto_has_subs, slug \
-                         FROM tv_episodes \
-                         WHERE tv_show_id = $1 AND season = $2 AND episode = $3 \
-                           AND (sktorrent_video_id IS NOT NULL OR prehrajto_url IS NOT NULL) \
-                         ORDER BY sktorrent_video_id LIMIT 1",
-                    )
+                    let found = sqlx::query_as::<_, TvEpisodeRow>(&format!(
+                        "SELECT {TV_EPISODE_COLUMNS} \
+                           FROM tv_episodes e \
+                          WHERE e.tv_show_id = $1 AND e.season = $2 AND e.episode = $3 \
+                            AND {TV_EPISODE_HAS_SOURCE_PREDICATE} \
+                          ORDER BY e.id LIMIT 1",
+                    ))
                     .bind(show.id)
                     .bind(season_num)
                     .bind(episode_num)
@@ -552,13 +582,13 @@ pub async fn tv_epizoda_detail(
     let season_num = episode.season;
     let episode_num = episode.episode;
 
-    let all_episodes = sqlx::query_as::<_, (i16, i16, Option<String>, Option<String>)>(
-        "SELECT DISTINCT ON (season, episode) season, episode, episode_name, slug \
-         FROM tv_episodes \
-         WHERE tv_show_id = $1 \
-           AND (sktorrent_video_id IS NOT NULL OR prehrajto_url IS NOT NULL) \
-         ORDER BY season, episode",
-    )
+    let all_episodes = sqlx::query_as::<_, (i16, i16, Option<String>, Option<String>)>(&format!(
+        "SELECT DISTINCT ON (e.season, e.episode) e.season, e.episode, e.episode_name, e.slug \
+           FROM tv_episodes e \
+          WHERE e.tv_show_id = $1 \
+            AND {TV_EPISODE_HAS_SOURCE_PREDICATE} \
+          ORDER BY e.season, e.episode",
+    ))
     .bind(show.id)
     .fetch_all(&state.db)
     .await

--- a/cr-web/src/handlers/video_sources.rs
+++ b/cr-web/src/handlers/video_sources.rs
@@ -1,0 +1,71 @@
+//! Data types for the unified `video_sources` schema (issue #607 / #608).
+//!
+//! PR1 only lands these structs so `cargo check` and `cargo sqlx prepare`
+//! verify they compile against the migrated schema. Readers and writers
+//! are wired up in the follow-up PRs (#611 reader switch, #610 dual-write).
+//!
+//! Schema reference: `cr-infra/migrations/20260529_058_video_sources_unified.sql`.
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+
+/// One row in `video_providers`. Lookup table, seeded with 3 rows
+/// (sktorrent / prehrajto / sledujteto). Adding a fourth is a data change.
+#[derive(Debug, Clone, sqlx::FromRow, Serialize)]
+#[allow(dead_code)] // Landed in PR1; consumed in PR3 (#611 reader switch).
+pub(crate) struct VideoProvider {
+    pub(crate) id: i16,
+    pub(crate) slug: String,
+    pub(crate) host: String,
+    pub(crate) display_name: String,
+    pub(crate) sort_priority: i16,
+    pub(crate) is_active: bool,
+}
+
+/// One row in `video_sources`. Polymorphic over three parent columns — exactly
+/// one of `film_id` / `episode_id` / `tv_episode_id` is `Some` (enforced by
+/// the `video_sources_one_parent_check` CHECK constraint at the DB level).
+#[derive(Debug, Clone, sqlx::FromRow, Serialize)]
+#[allow(dead_code)] // Landed in PR1; consumed in PR3 (#611 reader switch).
+pub(crate) struct VideoSource {
+    pub(crate) id: i32,
+    pub(crate) provider_id: i16,
+    pub(crate) film_id: Option<i32>,
+    pub(crate) episode_id: Option<i32>,
+    pub(crate) tv_episode_id: Option<i32>,
+    pub(crate) external_id: String,
+    pub(crate) title: Option<String>,
+    pub(crate) duration_sec: Option<i32>,
+    pub(crate) resolution_hint: Option<String>,
+    pub(crate) filesize_bytes: Option<i64>,
+    pub(crate) view_count: Option<i32>,
+    pub(crate) lang_class: String,
+    pub(crate) audio_lang: Option<String>,
+    pub(crate) audio_confidence: Option<f32>,
+    pub(crate) audio_detected_by: Option<String>,
+    pub(crate) cdn: Option<String>,
+    pub(crate) is_primary: bool,
+    pub(crate) is_alive: bool,
+    pub(crate) last_seen: Option<DateTime<Utc>>,
+    pub(crate) last_checked: Option<DateTime<Utc>>,
+    pub(crate) metadata: Option<serde_json::Value>,
+    pub(crate) created_at: DateTime<Utc>,
+    pub(crate) updated_at: DateTime<Utc>,
+}
+
+/// One row in `video_source_subtitles`. Persisted even when `url` is NULL
+/// (sledujteto resolves URLs live at play time) so filters + badges can
+/// work from the DB without a live resolve.
+#[derive(Debug, Clone, sqlx::FromRow, Serialize)]
+#[allow(dead_code)] // Landed in PR1; consumed in PR3 (#611 reader switch).
+pub(crate) struct VideoSourceSubtitle {
+    pub(crate) id: i32,
+    pub(crate) source_id: i32,
+    pub(crate) lang: String,
+    pub(crate) label: Option<String>,
+    pub(crate) format: Option<String>,
+    pub(crate) url: Option<String>,
+    pub(crate) is_default: bool,
+    pub(crate) is_forced: bool,
+    pub(crate) created_at: DateTime<Utc>,
+}

--- a/scripts/backfill-video-sources.py
+++ b/scripts/backfill-video-sources.py
@@ -1,0 +1,550 @@
+#!/usr/bin/env python3
+"""Backfill `video_sources` + `video_source_subtitles` from the legacy
+per-provider tables and denormalized columns (issue #607 / sub-issue #609).
+
+After this runs, the new unified schema has parity with the legacy data;
+the legacy tables + columns remain the source of truth until the reader
+switch (#611) ships. The script is idempotent — re-running it is a no-op
+modulo `last_seen` / `updated_at` column refreshes.
+
+Data sources → target rows:
+
+  1. sktorrent: for every (films | episodes | tv_episodes) row with
+     `sktorrent_video_id IS NOT NULL`, insert one `video_sources` row with
+       provider = sktorrent
+       external_id = sktorrent_video_id::text
+       cdn = sktorrent_cdn::text
+       is_primary = true  (sktorrent is always 1:1 in legacy)
+       audio_lang/lang_class derived from has_dub + has_subtitles
+     Subtitle row inserted when has_subtitles = true (assumes CZ subs).
+
+  2. prehrajto: copy every `film_prehrajto_uploads` row →
+       provider = prehrajto
+       external_id = upload_id
+       is_primary = (upload_id = films.prehrajto_primary_upload_id)
+       lang_class copied verbatim
+       audio_lang/subtitle rows derived from lang_class
+
+  3. sledujteto: copy every `film_sledujteto_uploads` row →
+       provider = sledujteto
+       external_id = file_id::text
+       cdn = cdn
+       is_primary = (file_id = films.sledujteto_primary_file_id)
+       lang_class copied verbatim
+
+Idempotence is guaranteed by `ON CONFLICT (provider_id, external_id) DO UPDATE`
+in every INSERT.
+
+Invariants verified at end:
+  - no (owner, provider) pair has more than one is_primary row
+  - every legacy primary pointer maps to a matching video_sources primary row
+
+Usage:
+    DATABASE_URL=postgres://... \\
+    python3 scripts/backfill-video-sources.py [--dry-run] [--limit N] \\
+        [--skip-sktorrent] [--skip-prehrajto] [--skip-sledujteto]
+
+Flags:
+  --dry-run    Wrap everything in a transaction and ROLLBACK at the end.
+               Prints final summary counts but leaves the DB untouched.
+  --limit N    Process at most N source rows from each provider path
+               (ordered by id). For sanity-check runs on dev.
+  --verbose    Log every insert, not just summaries.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+try:
+    import psycopg2
+    import psycopg2.extras
+except ImportError:
+    print("pip install psycopg2-binary", file=sys.stderr)
+    sys.exit(1)
+
+
+log = logging.getLogger("backfill-video-sources")
+
+
+# video_providers.slug → (audio_lang fallback, lang_class fallback). We cache
+# the IDs looked up in provider_ids() after the first call.
+PROVIDER_SLUGS = ("sktorrent", "prehrajto", "sledujteto")
+
+
+def provider_ids(cur) -> dict[str, int]:
+    cur.execute(
+        "SELECT slug, id FROM video_providers WHERE slug = ANY(%s)",
+        (list(PROVIDER_SLUGS),),
+    )
+    return {row["slug"]: row["id"] for row in cur.fetchall()}
+
+
+def lang_class_to_audio_and_subs(lang_class: str | None,
+                                 has_dub: bool = False,
+                                 has_subtitles: bool = False
+                                 ) -> tuple[str | None, str, list[str]]:
+    """Map legacy lang signals to (audio_lang, lang_class, subtitle_langs).
+
+    `lang_class` is the legacy-table enum
+    (CZ_DUB|CZ_NATIVE|CZ_SUB|SK_DUB|SK_SUB|EN|UNKNOWN) when known, else None.
+    `has_dub` / `has_subtitles` are the sktorrent-side booleans used as a
+    fallback when no lang_class is available.
+
+    Returns a triple:
+      audio_lang  — 2/3-char ISO code or None (must satisfy the CHECK
+                    constraint `^[a-z]{2,3}$`).
+      lang_class  — normalized enum value. The DB CHECK
+                    video_sources_lang_class_audio_consistency_check
+                    enforces audio_lang ↔ lang_class consistency, so this
+                    function is the single place where those two fields
+                    are derived together.
+      sub_langs   — list of subtitle language codes to insert as
+                    video_source_subtitles rows (often empty).
+    """
+    if lang_class == "CZ_DUB":
+        return "cs", "CZ_DUB", []
+    if lang_class == "CZ_NATIVE":
+        return "cs", "CZ_NATIVE", []
+    if lang_class == "CZ_SUB":
+        # Audio is original (often en), unknown from legacy data.
+        return None, "CZ_SUB", ["cs"]
+    if lang_class == "SK_DUB":
+        return "sk", "SK_DUB", []
+    if lang_class == "SK_SUB":
+        return None, "SK_SUB", ["sk"]
+    if lang_class == "EN":
+        return "en", "EN", []
+
+    # Fallback path for sktorrent (only has_dub / has_subtitles available).
+    if has_dub and has_subtitles:
+        # Both flags → dub is primary audio signal, subtitles coexist.
+        return "cs", "CZ_DUB", ["cs"]
+    if has_dub:
+        return "cs", "CZ_DUB", []
+    if has_subtitles:
+        return None, "CZ_SUB", ["cs"]
+    return None, "UNKNOWN", []
+
+
+def upsert_video_source(cur, *,
+                        provider_id: int,
+                        external_id: str,
+                        film_id: int | None = None,
+                        episode_id: int | None = None,
+                        tv_episode_id: int | None = None,
+                        title: str | None = None,
+                        duration_sec: int | None = None,
+                        resolution_hint: str | None = None,
+                        filesize_bytes: int | None = None,
+                        view_count: int | None = None,
+                        lang_class: str = "UNKNOWN",
+                        audio_lang: str | None = None,
+                        audio_detected_by: str | None = None,
+                        cdn: str | None = None,
+                        is_primary: bool = False,
+                        is_alive: bool = True,
+                        last_seen = None,
+                        metadata = None,
+                        ) -> int:
+    """UPSERT a video_sources row. Returns the id of the (new or existing) row.
+
+    Idempotence via `ON CONFLICT (provider_id, external_id)`: a re-run updates
+    the mutable fields (is_alive, cdn, lang_class, …) but keeps the row id
+    stable, so `video_source_subtitles.source_id` stays valid across re-runs.
+    """
+    cur.execute(
+        """
+        INSERT INTO video_sources (
+            provider_id, film_id, episode_id, tv_episode_id,
+            external_id, title, duration_sec, resolution_hint,
+            filesize_bytes, view_count, lang_class, audio_lang,
+            audio_detected_by, cdn, is_primary, is_alive,
+            last_seen, metadata, updated_at
+        ) VALUES (
+            %(provider_id)s, %(film_id)s, %(episode_id)s, %(tv_episode_id)s,
+            %(external_id)s, %(title)s, %(duration_sec)s, %(resolution_hint)s,
+            %(filesize_bytes)s, %(view_count)s, %(lang_class)s, %(audio_lang)s,
+            %(audio_detected_by)s, %(cdn)s, %(is_primary)s, %(is_alive)s,
+            %(last_seen)s, %(metadata)s, NOW()
+        )
+        ON CONFLICT (provider_id, external_id) DO UPDATE SET
+            film_id           = EXCLUDED.film_id,
+            episode_id        = EXCLUDED.episode_id,
+            tv_episode_id     = EXCLUDED.tv_episode_id,
+            title             = COALESCE(EXCLUDED.title, video_sources.title),
+            duration_sec      = COALESCE(EXCLUDED.duration_sec, video_sources.duration_sec),
+            resolution_hint   = COALESCE(EXCLUDED.resolution_hint, video_sources.resolution_hint),
+            filesize_bytes    = COALESCE(EXCLUDED.filesize_bytes, video_sources.filesize_bytes),
+            view_count        = COALESCE(EXCLUDED.view_count, video_sources.view_count),
+            lang_class        = EXCLUDED.lang_class,
+            audio_lang        = EXCLUDED.audio_lang,
+            audio_detected_by = EXCLUDED.audio_detected_by,
+            cdn               = EXCLUDED.cdn,
+            is_primary        = EXCLUDED.is_primary,
+            is_alive          = EXCLUDED.is_alive,
+            last_seen         = COALESCE(EXCLUDED.last_seen, video_sources.last_seen),
+            metadata          = COALESCE(EXCLUDED.metadata, video_sources.metadata),
+            updated_at        = NOW()
+        RETURNING id
+        """,
+        dict(
+            provider_id=provider_id,
+            film_id=film_id,
+            episode_id=episode_id,
+            tv_episode_id=tv_episode_id,
+            external_id=external_id,
+            title=title,
+            duration_sec=duration_sec,
+            resolution_hint=resolution_hint,
+            filesize_bytes=filesize_bytes,
+            view_count=view_count,
+            lang_class=lang_class,
+            audio_lang=audio_lang,
+            audio_detected_by=audio_detected_by,
+            cdn=cdn,
+            is_primary=is_primary,
+            is_alive=is_alive,
+            last_seen=last_seen,
+            metadata=psycopg2.extras.Json(metadata) if metadata else None,
+        ),
+    )
+    return cur.fetchone()["id"]
+
+
+def upsert_subtitle(cur, source_id: int, lang: str) -> None:
+    """Insert a subtitle row if absent. URL + format stay NULL (filled by
+    the live resolver at play-time for sledujteto / prehrajto)."""
+    cur.execute(
+        """
+        INSERT INTO video_source_subtitles (source_id, lang)
+        VALUES (%s, %s)
+        ON CONFLICT (source_id, lang, is_forced, COALESCE(format, ''))
+        DO NOTHING
+        """,
+        (source_id, lang),
+    )
+
+
+def backfill_sktorrent(cur, providers: dict[str, int], limit: int | None
+                       ) -> tuple[int, int]:
+    """Backfill sktorrent sources for films / episodes / tv_episodes.
+
+    Returns (inserted_rows, skipped_rows) counts.
+    """
+    provider_id = providers["sktorrent"]
+    inserted = 0
+    skipped = 0
+
+    for table, parent_col in (("films", "film_id"),
+                              ("episodes", "episode_id"),
+                              ("tv_episodes", "tv_episode_id")):
+        qualities_col = "sktorrent_qualities" if table != "episodes" else "sktorrent_qualities"
+        cdn_col = "sktorrent_cdn"
+        # `has_dub` / `has_subtitles` exist on all three tables for sktorrent
+        # legacy detection.
+        limit_clause = f"LIMIT {int(limit)}" if limit else ""
+        cur.execute(
+            f"""
+            SELECT id, sktorrent_video_id, {cdn_col} AS cdn,
+                   {qualities_col} AS qualities, has_dub, has_subtitles
+            FROM {table}
+            WHERE sktorrent_video_id IS NOT NULL
+            ORDER BY id
+            {limit_clause}
+            """
+        )
+        rows = cur.fetchall()
+        log.info("sktorrent/%s: %d candidates", table, len(rows))
+
+        for row in rows:
+            audio_lang, lang_class, sub_langs = lang_class_to_audio_and_subs(
+                None, has_dub=row["has_dub"], has_subtitles=row["has_subtitles"])
+            metadata = {"qualities": row["qualities"]} if row["qualities"] else None
+
+            parent_kwargs = {parent_col: row["id"]}
+            try:
+                source_id = upsert_video_source(
+                    cur,
+                    provider_id=provider_id,
+                    external_id=str(row["sktorrent_video_id"]),
+                    **parent_kwargs,
+                    lang_class=lang_class,
+                    audio_lang=audio_lang,
+                    audio_detected_by="title_regex" if lang_class != "UNKNOWN" else None,
+                    cdn=str(row["cdn"]) if row["cdn"] is not None else None,
+                    is_primary=True,  # sktorrent is 1:1 in legacy
+                    is_alive=True,
+                    metadata=metadata,
+                )
+                for lang in sub_langs:
+                    upsert_subtitle(cur, source_id, lang)
+                inserted += 1
+            except psycopg2.Error as e:
+                log.warning("sktorrent/%s id=%d video_id=%s: %s",
+                            table, row["id"], row["sktorrent_video_id"], e)
+                skipped += 1
+
+    return inserted, skipped
+
+
+def backfill_prehrajto(cur, providers: dict[str, int], limit: int | None
+                       ) -> tuple[int, int]:
+    """Backfill prehrajto sources from film_prehrajto_uploads."""
+    provider_id = providers["prehrajto"]
+    limit_clause = f"LIMIT {int(limit)}" if limit else ""
+    cur.execute(
+        f"""
+        SELECT u.film_id, u.upload_id, u.url, u.title, u.duration_sec,
+               u.view_count, u.lang_class, u.resolution_hint,
+               u.discovered_at, u.last_seen_at, u.is_alive, u.is_direct,
+               f.prehrajto_primary_upload_id
+        FROM film_prehrajto_uploads u
+        JOIN films f ON f.id = u.film_id
+        ORDER BY u.film_id, u.upload_id
+        {limit_clause}
+        """
+    )
+    rows = cur.fetchall()
+    log.info("prehrajto: %d uploads", len(rows))
+
+    inserted = 0
+    skipped = 0
+    for row in rows:
+        audio_lang, lang_class, sub_langs = lang_class_to_audio_and_subs(row["lang_class"])
+        is_primary = row["upload_id"] == row["prehrajto_primary_upload_id"]
+        metadata = {
+            "url": row["url"],
+            "is_direct": row["is_direct"],
+            "discovered_at": row["discovered_at"].isoformat() if row["discovered_at"] else None,
+        }
+        try:
+            source_id = upsert_video_source(
+                cur,
+                provider_id=provider_id,
+                external_id=row["upload_id"],
+                film_id=row["film_id"],
+                title=row["title"],
+                duration_sec=row["duration_sec"],
+                resolution_hint=row["resolution_hint"],
+                view_count=row["view_count"],
+                lang_class=lang_class,
+                audio_lang=audio_lang,
+                audio_detected_by="title_regex" if lang_class != "UNKNOWN" else None,
+                is_primary=is_primary,
+                is_alive=row["is_alive"],
+                last_seen=row["last_seen_at"],
+                metadata=metadata,
+            )
+            for lang in sub_langs:
+                upsert_subtitle(cur, source_id, lang)
+            inserted += 1
+        except psycopg2.Error as e:
+            log.warning("prehrajto film_id=%d upload_id=%s: %s",
+                        row["film_id"], row["upload_id"], e)
+            skipped += 1
+    return inserted, skipped
+
+
+def backfill_sledujteto(cur, providers: dict[str, int], limit: int | None
+                        ) -> tuple[int, int]:
+    """Backfill sledujteto sources from film_sledujteto_uploads."""
+    provider_id = providers["sledujteto"]
+    limit_clause = f"LIMIT {int(limit)}" if limit else ""
+    cur.execute(
+        f"""
+        SELECT u.film_id, u.file_id, u.title, u.duration_sec,
+               u.lang_class, u.resolution_hint, u.filesize_bytes, u.cdn,
+               u.is_alive, u.last_seen,
+               f.sledujteto_primary_file_id
+        FROM film_sledujteto_uploads u
+        JOIN films f ON f.id = u.film_id
+        ORDER BY u.film_id, u.file_id
+        {limit_clause}
+        """
+    )
+    rows = cur.fetchall()
+    log.info("sledujteto: %d uploads", len(rows))
+
+    inserted = 0
+    skipped = 0
+    for row in rows:
+        audio_lang, lang_class, sub_langs = lang_class_to_audio_and_subs(row["lang_class"])
+        is_primary = row["file_id"] == row["sledujteto_primary_file_id"]
+        try:
+            source_id = upsert_video_source(
+                cur,
+                provider_id=provider_id,
+                external_id=str(row["file_id"]),
+                film_id=row["film_id"],
+                title=row["title"],
+                duration_sec=row["duration_sec"],
+                resolution_hint=row["resolution_hint"],
+                filesize_bytes=row["filesize_bytes"],
+                lang_class=lang_class,
+                audio_lang=audio_lang,
+                audio_detected_by="title_regex" if lang_class != "UNKNOWN" else None,
+                cdn=row["cdn"],
+                is_primary=is_primary,
+                is_alive=row["is_alive"],
+                last_seen=row["last_seen"],
+            )
+            for lang in sub_langs:
+                upsert_subtitle(cur, source_id, lang)
+            inserted += 1
+        except psycopg2.Error as e:
+            log.warning("sledujteto film_id=%d file_id=%d: %s",
+                        row["film_id"], row["file_id"], e)
+            skipped += 1
+    return inserted, skipped
+
+
+def assert_invariants(cur) -> bool:
+    """Post-backfill sanity checks. Returns True when all invariants hold.
+
+    1. No (provider, parent) pair has >1 is_primary row.
+       (Partial unique indexes enforce this at DB level, so a violation here
+       would indicate an index was dropped or a concurrent writer bypassed
+       the constraint.)
+    2. Every legacy primary pointer maps to a matching video_sources primary.
+    """
+    ok = True
+
+    # Invariant 1 — should always pass if the partial unique indexes are in
+    # place. Sanity net in case we run this against a DB where the migration
+    # is partially applied.
+    cur.execute(
+        """
+        SELECT provider_id,
+               COALESCE(film_id::text, 'E'||episode_id::text, 'T'||tv_episode_id::text) AS parent,
+               COUNT(*) AS n
+        FROM video_sources
+        WHERE is_primary
+        GROUP BY provider_id, parent
+        HAVING COUNT(*) > 1
+        """
+    )
+    dup_primaries = cur.fetchall()
+    if dup_primaries:
+        log.error("INVARIANT 1 FAILED: %d (provider, parent) pairs have "
+                  "multiple primary rows", len(dup_primaries))
+        ok = False
+
+    # Invariant 2 — legacy primary ↔ video_sources.is_primary alignment.
+    # Run per-provider so the error messages point at the right legacy
+    # column when something is off.
+    legacy_checks = [
+        ("prehrajto",
+         "SELECT f.id, f.prehrajto_primary_upload_id AS pointer FROM films f "
+         "WHERE f.prehrajto_primary_upload_id IS NOT NULL"),
+        ("sledujteto",
+         "SELECT f.id, f.sledujteto_primary_file_id::text AS pointer FROM films f "
+         "WHERE f.sledujteto_primary_file_id IS NOT NULL"),
+    ]
+    for slug, legacy_sql in legacy_checks:
+        cur.execute(
+            f"""
+            WITH legacy AS ({legacy_sql}),
+                 provider AS (SELECT id FROM video_providers WHERE slug = %s)
+            SELECT l.id, l.pointer
+            FROM legacy l, provider p
+            WHERE NOT EXISTS (
+                SELECT 1 FROM video_sources vs
+                WHERE vs.film_id = l.id
+                  AND vs.provider_id = p.id
+                  AND vs.is_primary
+                  AND vs.external_id = l.pointer
+            )
+            """,
+            (slug,),
+        )
+        mismatched = cur.fetchall()
+        if mismatched:
+            log.error("INVARIANT 2 FAILED (%s): %d films have legacy primary "
+                      "pointer but no matching video_sources primary. "
+                      "First 5: %s", slug, len(mismatched),
+                      [(r["id"], r["pointer"]) for r in mismatched[:5]])
+            ok = False
+
+    return ok
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--limit", type=int, default=None)
+    ap.add_argument("--skip-sktorrent", action="store_true")
+    ap.add_argument("--skip-prehrajto", action="store_true")
+    ap.add_argument("--skip-sledujteto", action="store_true")
+    ap.add_argument("-v", "--verbose", action="store_true")
+    args = ap.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        log.error("DATABASE_URL required")
+        return 2
+
+    conn = psycopg2.connect(dsn)
+    conn.autocommit = False
+    cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+
+    totals = {"inserted": 0, "skipped": 0}
+    try:
+        providers = provider_ids(cur)
+        log.info("Providers: %s", providers)
+
+        if not args.skip_sktorrent:
+            i, s = backfill_sktorrent(cur, providers, args.limit)
+            totals["inserted"] += i
+            totals["skipped"] += s
+            log.info("sktorrent done: inserted=%d skipped=%d", i, s)
+
+        if not args.skip_prehrajto:
+            i, s = backfill_prehrajto(cur, providers, args.limit)
+            totals["inserted"] += i
+            totals["skipped"] += s
+            log.info("prehrajto done: inserted=%d skipped=%d", i, s)
+
+        if not args.skip_sledujteto:
+            i, s = backfill_sledujteto(cur, providers, args.limit)
+            totals["inserted"] += i
+            totals["skipped"] += s
+            log.info("sledujteto done: inserted=%d skipped=%d", i, s)
+
+        log.info("Totals: inserted=%d skipped=%d", totals["inserted"], totals["skipped"])
+
+        # Invariants only meaningful on a FULL run (no --limit), otherwise
+        # "legacy pointer with no video_sources match" is expected.
+        if args.limit is None:
+            ok = assert_invariants(cur)
+            if not ok:
+                log.error("Post-backfill invariants failed; rolling back.")
+                conn.rollback()
+                return 1
+
+        if args.dry_run:
+            conn.rollback()
+            log.info("DRY RUN: rolled back.")
+        else:
+            conn.commit()
+            log.info("Committed.")
+    except Exception:
+        conn.rollback()
+        log.exception("Error during backfill — rolled back")
+        return 1
+    finally:
+        cur.close()
+        conn.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
<!-- claude-session: 9c42f99e-d1ab-4b4c-9d4d-e7d09129237a -->

Closes #611 (part of #607). Stacked as a **sibling** of #617 (PR2); base branch is `feat/607-schema-video-sources` (PR1). Merge #616 first, then retarget this PR to `main` and rebase.

PR3 does not depend on PR2 in code, but it does depend on PR2 being **deployed** on prod so `video_sources` stays in lock-step with incoming imports. Merge order: PR1 → PR2 deployed & reconciler clean for ~24h → PR3.

## Summary

Switches every handler reading provider data (sktorrent / prehrajto / sledujteto) to source from the unified `video_sources` schema. Templates unchanged — FilmRow / EpisodeRow / TvEpisodeRow keep identical field signatures; the SQL underneath just points at `video_sources`.

**Legacy columns and tables are still there and still dual-written.** Nothing destructive; rollback is `git revert`.

## Changes

- **`cr-web/src/handlers/films.rs`** (+97 / −32 net)
  - `FILM_COLUMNS` rewritten to project provider data via correlated subqueries on `video_sources`. Each subquery hits `idx_vs_film_alive` + a partial unique index on `is_primary`, so the per-page cost for the listing is ≤ 24 × 4 = 96 index lookups (low-single-digit ms in EXPLAIN ANALYZE).
  - `audio_filter()` queries `films.audio_langs` (TRIGGER-maintained rollup) instead of OR-ing three legacy boolean columns.
  - `run_films_query()` gates out zombie films with `EXISTS (SELECT 1 FROM video_sources … AND is_alive)`. Fixes the regression identified in #611 review comment.
  - `sktorrent_resolve()` CDN-hint UNION across 3 tables collapses to a single-row lookup in `video_sources` (UNIQUE `(provider_id, external_id)` guarantees at most 1 row).
  - `update_sktorrent_cdn()` self-heal writes back to `video_sources.cdn`.

- **`cr-web/src/handlers/movies_api/prehrajto.rs`**
  - `try_resolve_one`, dead-upload UPDATE, `persist_is_direct`, `next_best_upload`, `prehrajto_sources` all read/write `video_sources` with `p.slug='prehrajto'`.
  - `is_direct` moved from a typed column to JSONB `metadata->>'is_direct'` (dual-write already writes it there).
  - `PREHRAJTO_RANK_ORDER_BY` switched to `vs.`-prefixed columns so the shared ranking SQL still has a single source of truth.

- **`cr-web/src/handlers/movies_api/sledujteto.rs`**
  - `sledujteto_sources` reads `video_sources` with `p.slug='sledujteto'`; cast `external_id::INTEGER` into `file_id` so the JSON contract stays identical.
  - Resolve endpoint's `lang_class` lookup uses `video_sources`.

- **`cr-web/src/handlers/series.rs`** and **`cr-web/src/handlers/tv_porady.rs`**
  - `EPISODE_COLUMNS` / `TV_EPISODE_COLUMNS` consts, same pattern as `FILM_COLUMNS`.
  - `EPISODE_HAS_SOURCE_PREDICATE` / `TV_EPISODE_HAS_SOURCE_PREDICATE` replace the legacy `(sktorrent_video_id IS NOT NULL OR prehrajto_url IS NOT NULL)` OR-chains.

## Design choices

- **Template compat.** Kept FilmRow / EpisodeRow / TvEpisodeRow field names unchanged. Minor template enhancement (provider labels from `video_providers.host` instead of hard-coded "1/2/3") deferred to PR4 — that's a UX polish, not a reader-switch requirement.
- **Correlated subqueries vs JOIN.** Went with subqueries because they return a clean NULL when no row is found (matching legacy column semantics) and the partial unique index + alive index keeps them cheap. A LATERAL JOIN would also work but would need `COALESCE` scaffolding to stay NULL-safe.
- **is_direct migration.** Legacy `film_prehrajto_uploads.is_direct` was a typed BOOLEAN. In `video_sources` I stored it inside JSONB `metadata` (the dual-write helper writes `{"url": …, "is_direct": …}`). Reads use `(metadata->>'is_direct')::BOOLEAN`; the writer in `persist_is_direct` uses `jsonb_build_object` to merge-patch the flag without clobbering other metadata keys.

## Verification (dev DB)

- `cargo check --all` ✓
- `cargo clippy --workspace -- -D warnings` ✓
- `cargo fmt --check` ✓
- `cargo sqlx prepare --workspace --check` ✓
- Dev server boots; `/health` → 200.
- 4 detail pages tested (Vykoupení z věznice Shawshank, Kmotr, Temný rytíř, Pán prstenů: Návrat krále) → all 200 OK, `sktorrentVideoId` injected into JS template from `video_sources`.
- Audio filter: `/filmy-online/?jazyk=dub` + `/filmy-online/?jazyk=sub` → 200 OK via new `audio_langs` / `subtitle_langs` rollup path.
- Console errors: only the pre-existing CZ-proxy 500 from `/api/movies/search` (dev has no proxy configured), not a PR3 regression.

## Test plan

- [ ] CI passes (Check & Clippy + Format + Test).
- [ ] Copilot review — especially the correlated-subquery approach and the `is_direct` JSONB migration.
- [ ] After PR1 + PR2 merge & are stable on prod with drift=0 from the reconciler: rebase this PR onto main, deploy to prod, run full Playwright interactive test (Bankéřka, Nightshift-2018, Lolita, one series episode, one TV episode).
- [ ] Verify EXPLAIN ANALYZE on `/filmy-online/` listing query stays <100ms.
- [ ] Confirm `/api/films/{id}/prehrajto-sources` and `/api/films/{id}/sledujteto-sources` JSON output is byte-for-byte identical to pre-refactor (shape preserved via struct field matching).

## Follow-ups

- **PR4 (#612 + #613):** filter UI on listing + per-source badges on detail page. Also folds in the provider-label enhancement (use `video_providers.host` instead of "1/2/3").
- **PR5 (#614):** drop the legacy columns + tables once PR3 has been stable on prod for a week.