### PR TITLE
feat(ux): filter UI + per-source badges on film detail (#612, #613)

### DIFF
--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -196,6 +196,71 @@ struct CountRow {
     count: Option<i64>,
 }
 
+/// Per-source badge row rendered on the film detail page (#613). One row
+/// per alive `video_sources` entry for the film, with subtitle languages
+/// aggregated from `video_source_subtitles` in the same query. Ordered by
+/// provider `sort_priority` so badge tabs follow the same visual order
+/// as the provider switcher at the top of the player.
+#[derive(sqlx::FromRow, Serialize)]
+pub(crate) struct VideoSourceBadgeRow {
+    pub(crate) provider_slug: String,
+    pub(crate) provider_host: String,
+    pub(crate) provider_display_name: String,
+    #[allow(dead_code)] // used only for ORDER BY; template reads by slug
+    pub(crate) sort_priority: i16,
+    pub(crate) external_id: String,
+    pub(crate) title: Option<String>,
+    pub(crate) lang_class: String,
+    pub(crate) audio_lang: Option<String>,
+    pub(crate) audio_confidence: Option<f32>,
+    pub(crate) audio_detected_by: Option<String>,
+    pub(crate) resolution_hint: Option<String>,
+    #[allow(dead_code)] // rendered indirectly via `cdn_label`; kept for ordering decisions
+    pub(crate) cdn: Option<String>,
+    pub(crate) is_primary: bool,
+    pub(crate) subtitle_langs: Vec<String>,
+}
+
+impl VideoSourceBadgeRow {
+    /// Human-readable label for the audio language (or "—" when unknown).
+    pub(crate) fn audio_label(&self) -> String {
+        match self.audio_lang.as_deref() {
+            Some("cs") => "Čeština".to_string(),
+            Some("sk") => "Slovenština".to_string(),
+            Some("en") => "Angličtina".to_string(),
+            Some("de") => "Němčina".to_string(),
+            Some(other) => other.to_ascii_uppercase(),
+            None => "—".to_string(),
+        }
+    }
+
+    /// Formatted confidence badge. Hidden when the detector was Whisper at
+    /// ≥ 0.8 confidence (per #613 — that's noise for the user; only show
+    /// when detection was lower-quality so it's visible which sources are
+    /// reliable and which are regex-guessed).
+    pub(crate) fn confidence_display(&self) -> Option<String> {
+        match (self.audio_detected_by.as_deref(), self.audio_confidence) {
+            (Some("whisper"), Some(c)) if c >= 0.8 => None,
+            (_, Some(c)) => Some(format!("{:.0} %", (c * 100.0).round())),
+            _ => None,
+        }
+    }
+
+    /// Comma-separated display of subtitle languages, uppercased. Empty
+    /// when the source has no subtitle tracks.
+    pub(crate) fn subtitle_display(&self) -> String {
+        if self.subtitle_langs.is_empty() {
+            String::new()
+        } else {
+            self.subtitle_langs
+                .iter()
+                .map(|s| s.to_ascii_uppercase())
+                .collect::<Vec<_>>()
+                .join(", ")
+        }
+    }
+}
+
 // --- Query params ---
 
 #[derive(Deserialize)]
@@ -208,7 +273,19 @@ pub struct FilmsQuery {
     rok: Option<String>,    // year filter
     rezim: Option<String>,  // "and" (all genres) or "or" (any genre)
     smer: Option<String>,   // "asc" or "desc" (default)
-    jazyk: Option<String>,  // comma-separated: dub, sub
+    jazyk: Option<String>,  // legacy: "dub" / "sub" — kept for shareable links
+    /// Multi-value audio-language filter (#612). Comma-separated ISO 639
+    /// codes like `cs,sk,en`. AND semantics: the film must have EVERY listed
+    /// language present in `audio_langs`. Empty / absent = no filter.
+    /// Repeated-key form like `?audio=cs&audio=en` isn't supported by the
+    /// default `serde_urlencoded` extractor; going comma-separated matches
+    /// the existing `zanry` / `jazyk` params and keeps the query string
+    /// short + shareable.
+    audio: Option<String>,
+    /// Subtitle filter (#612). `titulky=1` or `titulky=any` requires the
+    /// film to have at least one subtitle track. Comma-separated ISO codes
+    /// like `titulky=cs,en` require EVERY listed language as a subtitle.
+    titulky: Option<String>,
 }
 
 impl FilmsQuery {
@@ -246,6 +323,49 @@ impl FilmsQuery {
                   OR cardinality(f.subtitle_langs) > 0)",
             ),
             _ => None,
+        }
+    }
+
+    /// Parse the `audio=cs,sk,en` param into a Vec of validated ISO codes.
+    /// Returns None when absent/empty; Some(vec) with only `^[a-z]{2,3}$`
+    /// entries otherwise. The regex guard avoids SQL-binding garbage strings
+    /// (the binding itself is parameterised, but keeping the array contents
+    /// canonical lets the GIN index fire and simplifies chip rendering).
+    pub(crate) fn audio_langs_filter(&self) -> Option<Vec<String>> {
+        let raw = self.audio.as_deref()?.trim();
+        if raw.is_empty() {
+            return None;
+        }
+        let langs: Vec<String> = raw
+            .split(',')
+            .map(|s| s.trim().to_ascii_lowercase())
+            .filter(|s| !s.is_empty() && s.len() <= 3 && s.chars().all(|c| c.is_ascii_lowercase()))
+            .collect();
+        if langs.is_empty() { None } else { Some(langs) }
+    }
+
+    /// Parse the `titulky=...` param into a subtitle filter mode.
+    /// Returns:
+    ///   - None              — no filter (absent or empty)
+    ///   - Some((None, _))   — `titulky=1` / `titulky=any` → any subtitles present
+    ///   - Some((Some(vec))) — `titulky=cs,en` → film must have every listed lang
+    pub(crate) fn subs_filter(&self) -> Option<Option<Vec<String>>> {
+        let raw = self.titulky.as_deref()?.trim();
+        if raw.is_empty() || raw == "0" {
+            return None;
+        }
+        if raw == "1" || raw == "any" || raw == "ano" {
+            return Some(None);
+        }
+        let langs: Vec<String> = raw
+            .split(',')
+            .map(|s| s.trim().to_ascii_lowercase())
+            .filter(|s| !s.is_empty() && s.len() <= 3 && s.chars().all(|c| c.is_ascii_lowercase()))
+            .collect();
+        if langs.is_empty() {
+            Some(None)
+        } else {
+            Some(Some(langs))
         }
     }
 }
@@ -324,6 +444,16 @@ struct FilmsListTemplate {
     selected_genre_slugs: Vec<String>,
     /// Genres per film, keyed by film id — rendered as chips in desktop list view.
     film_genres_map: std::collections::HashMap<i32, Vec<FilmGenreNameRow>>,
+    /// Currently-applied audio-language filter (#612). Empty → no filter.
+    selected_audio_langs: Vec<String>,
+    /// Currently-applied subtitle-language filter (#612). `Some(vec)` means
+    /// "require these specific subs"; `Some(empty)` means `titulky=any`
+    /// (any subs). `None` means "no subs filter applied".
+    selected_subs: Option<Vec<String>>,
+    /// Full raw query string including `strana=`, `zanry=`, etc. Used to
+    /// build "remove this chip" URLs that strip a single audio/subs param
+    /// without disturbing others.
+    full_query: std::collections::BTreeMap<String, Vec<String>>,
 }
 
 impl FilmsListTemplate {
@@ -346,6 +476,148 @@ impl FilmsListTemplate {
             .map(|v| v.as_slice())
             .unwrap_or(EMPTY.as_slice())
     }
+
+    // --- Audio / subs filter helpers (#612) ---
+
+    fn is_audio_selected(&self, lang: &str) -> bool {
+        self.selected_audio_langs.iter().any(|l| l == lang)
+    }
+
+    fn is_subs_selected(&self, lang: &str) -> bool {
+        match &self.selected_subs {
+            Some(list) if !list.is_empty() => list.iter().any(|l| l == lang),
+            _ => false,
+        }
+    }
+
+    /// True iff the user checked "Má titulky" without specifying a language.
+    fn is_subs_any(&self) -> bool {
+        matches!(&self.selected_subs, Some(list) if list.is_empty())
+    }
+
+    /// Narrower form used by the active-chip row: show the generic
+    /// "Titulky" chip ONLY when no language-specific chip is already
+    /// rendered (otherwise the UI would duplicate the signal).
+    fn is_subs_any_without_lang(&self) -> bool {
+        matches!(&self.selected_subs, Some(list) if list.is_empty())
+    }
+
+    fn has_lang_filters(&self) -> bool {
+        !self.selected_audio_langs.is_empty() || self.selected_subs.is_some()
+    }
+
+    fn audio_chips(&self) -> &[String] {
+        &self.selected_audio_langs
+    }
+
+    fn subs_chips(&self) -> &[String] {
+        match &self.selected_subs {
+            Some(list) => list.as_slice(),
+            None => &[],
+        }
+    }
+
+    /// Map an ISO code to the Czech label used in active-filter chips.
+    /// Falls back to uppercase of the code for languages we don't list
+    /// explicitly (e.g. "de" → "DE"). Keeps chips short in the UI.
+    fn lang_display(&self, lang: &str) -> String {
+        match lang {
+            "cs" => "Čeština".to_string(),
+            "sk" => "Slovenština".to_string(),
+            "en" => "Angličtina".to_string(),
+            "de" => "Němčina".to_string(),
+            "fr" => "Francouzština".to_string(),
+            other => other.to_ascii_uppercase(),
+        }
+    }
+
+    /// Build a URL back to `/filmy-online/` with the current filters minus
+    /// one audio language. Keeps the rest of the query (zanry, razeni, rok,
+    /// strana=1 reset so removing a filter returns to page 1).
+    fn remove_audio_url(&self, lang: &str) -> String {
+        let mut params = self.full_query.clone();
+        if let Some(vs) = params.get_mut("audio") {
+            // Rebuild each CSV value with the requested lang removed; drop
+            // empties. Using iter_mut + assignment would hit E0594 because
+            // Vec::retain yields `&T` not `&mut T`; reconstructing the Vec
+            // is the cleanest way across Rust 1.x versions.
+            let rebuilt: Vec<String> = vs
+                .iter()
+                .filter_map(|existing_csv| {
+                    let filtered: Vec<&str> = existing_csv
+                        .split(',')
+                        .map(|s| s.trim())
+                        .filter(|s| *s != lang)
+                        .collect();
+                    if filtered.is_empty() {
+                        None
+                    } else {
+                        Some(filtered.join(","))
+                    }
+                })
+                .collect();
+            if rebuilt.is_empty() {
+                params.remove("audio");
+            } else {
+                *vs = rebuilt;
+            }
+        }
+        params.remove("strana");
+        build_filter_url(&params)
+    }
+
+    fn remove_subs_url(&self) -> String {
+        let mut params = self.full_query.clone();
+        params.remove("titulky");
+        params.remove("strana");
+        build_filter_url(&params)
+    }
+
+    fn remove_subs_lang_url(&self, lang: &str) -> String {
+        let mut params = self.full_query.clone();
+        if let Some(vs) = params.get_mut("titulky") {
+            let rebuilt: Vec<String> = vs
+                .iter()
+                .filter_map(|existing_csv| {
+                    let filtered: Vec<&str> = existing_csv
+                        .split(',')
+                        .map(|s| s.trim())
+                        .filter(|s| *s != lang)
+                        .collect();
+                    if filtered.is_empty() {
+                        None
+                    } else {
+                        Some(filtered.join(","))
+                    }
+                })
+                .collect();
+            if rebuilt.is_empty() {
+                params.remove("titulky");
+            } else {
+                *vs = rebuilt;
+            }
+        }
+        params.remove("strana");
+        build_filter_url(&params)
+    }
+}
+
+/// Re-serialize `params` into a `/filmy-online/?a=b&c=d` URL. Values with
+/// commas are emitted as-is (the caller already canonicalised them), and
+/// repeated keys each get their own `&key=` entry so the URL shape stays
+/// predictable.
+fn build_filter_url(params: &std::collections::BTreeMap<String, Vec<String>>) -> String {
+    let mut parts = Vec::new();
+    for (key, values) in params {
+        for v in values {
+            parts.push(format!("{}={}", key, urlencoding::encode(v)));
+        }
+    }
+    if parts.is_empty() {
+        "/filmy-online/".to_string()
+    } else {
+        format!("/filmy-online/?{}", parts.join("&"))
+    }
 }
 
 #[derive(Template)]
@@ -356,6 +628,10 @@ struct FilmDetailTemplate {
     genres: Vec<FilmGenreNameRow>,
     #[allow(dead_code)] // Fetched from DB but not rendered via Askama; JS handles sources
     sources: Vec<FilmSourceRow>,
+    /// Per-source badge rows (#613). Already sorted by provider
+    /// `sort_priority` + primary-first. Rendered under the provider
+    /// tabs on the detail page.
+    video_sources_for_badges: Vec<VideoSourceBadgeRow>,
     /// Gate the "Další zdroje" JS between the legacy live-scrape flow
     /// and the new DB-backed `/api/films/{id}/prehrajto-sources`
     /// endpoint (issue #521). Template renders this into a JS
@@ -471,7 +747,16 @@ pub async fn films_list(
                 .collect()
         })
         .unwrap_or_default();
-    let open_filter = !selected_genre_slugs.is_empty();
+    let selected_audio_langs = params.audio_langs_filter().unwrap_or_default();
+    let selected_subs = match params.subs_filter() {
+        Some(None) => Some(Vec::new()),
+        Some(Some(v)) => Some(v),
+        None => None,
+    };
+    let full_query = build_full_query_map(&params);
+    let open_filter = !selected_genre_slugs.is_empty()
+        || !selected_audio_langs.is_empty()
+        || selected_subs.is_some();
     let film_genres_map = load_film_genres_map(&state.db, &films).await?;
 
     let tmpl = FilmsListTemplate {
@@ -488,8 +773,72 @@ pub async fn films_list(
         open_filter,
         selected_genre_slugs,
         film_genres_map,
+        selected_audio_langs,
+        selected_subs,
+        full_query,
     };
     Ok(Html(tmpl.render()?).into_response())
+}
+
+/// Serialize the current filter params into a BTreeMap keyed by query
+/// parameter name. Used by the active-chip "remove" URL helpers so each
+/// chip can rebuild the URL with one of its own filters stripped out.
+/// BTreeMap gives a deterministic ordering for the rendered URLs — stable
+/// across renders so the browser cache isn't constantly invalidated.
+fn build_full_query_map(params: &FilmsQuery) -> std::collections::BTreeMap<String, Vec<String>> {
+    let mut map: std::collections::BTreeMap<String, Vec<String>> =
+        std::collections::BTreeMap::new();
+    if let Some(z) = params.zanry.as_ref()
+        && !z.trim().is_empty()
+    {
+        map.insert("zanry".into(), vec![z.clone()]);
+    }
+    if let Some(b) = params.bez.as_ref()
+        && !b.trim().is_empty()
+    {
+        map.insert("bez".into(), vec![b.clone()]);
+    }
+    if let Some(q) = params.q.as_ref()
+        && !q.trim().is_empty()
+    {
+        map.insert("q".into(), vec![q.clone()]);
+    }
+    if let Some(r) = params.rok.as_ref()
+        && !r.trim().is_empty()
+    {
+        map.insert("rok".into(), vec![r.clone()]);
+    }
+    if let Some(r) = params.razeni.as_ref()
+        && !r.trim().is_empty()
+    {
+        map.insert("razeni".into(), vec![r.clone()]);
+    }
+    if let Some(s) = params.smer.as_ref()
+        && !s.trim().is_empty()
+    {
+        map.insert("smer".into(), vec![s.clone()]);
+    }
+    if let Some(rz) = params.rezim.as_ref()
+        && !rz.trim().is_empty()
+    {
+        map.insert("rezim".into(), vec![rz.clone()]);
+    }
+    if let Some(j) = params.jazyk.as_ref()
+        && !j.trim().is_empty()
+    {
+        map.insert("jazyk".into(), vec![j.clone()]);
+    }
+    if let Some(a) = params.audio.as_ref()
+        && !a.trim().is_empty()
+    {
+        map.insert("audio".into(), vec![a.clone()]);
+    }
+    if let Some(t) = params.titulky.as_ref()
+        && !t.trim().is_empty()
+    {
+        map.insert("titulky".into(), vec![t.clone()]);
+    }
+    map
 }
 
 /// GET /filmy-online/{slug}/ — film detail, genre listing, or cover image
@@ -568,11 +917,50 @@ pub async fn films_detail(
     .fetch_all(&state.db)
     .await?;
 
+    // Per-source badge data (#613). One row per alive video source for this
+    // film, with an array-aggregated list of subtitle languages. Ordered by
+    // `video_providers.sort_priority` so the tab order matches the badge
+    // order — the frontend scroll-anchor logic relies on that.
+    let video_sources_for_badges = sqlx::query_as::<_, VideoSourceBadgeRow>(
+        "SELECT p.slug AS provider_slug, \
+                    p.host AS provider_host, \
+                    p.display_name AS provider_display_name, \
+                    p.sort_priority, \
+                    vs.external_id, \
+                    vs.title, \
+                    vs.lang_class, \
+                    vs.audio_lang, \
+                    vs.audio_confidence, \
+                    vs.audio_detected_by, \
+                    vs.resolution_hint, \
+                    vs.cdn, \
+                    vs.is_primary, \
+                    COALESCE( \
+                        (SELECT array_agg(DISTINCT vss.lang::TEXT ORDER BY vss.lang::TEXT) \
+                         FROM video_source_subtitles vss \
+                         WHERE vss.source_id = vs.id), \
+                        '{}'::TEXT[] \
+                    ) AS subtitle_langs \
+             FROM video_sources vs \
+             JOIN video_providers p ON p.id = vs.provider_id \
+             WHERE vs.film_id = $1 AND vs.is_alive \
+             ORDER BY p.sort_priority, vs.is_primary DESC, vs.updated_at DESC",
+    )
+    .bind(film.id)
+    .fetch_all(&state.db)
+    .await
+    .unwrap_or_else(|e| {
+        tracing::warn!(film_id = film.id, error = ?e,
+                "video_sources badge query failed; detail page renders without badges");
+        Vec::new()
+    });
+
     let tmpl = FilmDetailTemplate {
         img: state.image_base_url.clone(),
         film,
         genres,
         sources,
+        video_sources_for_badges,
         prehrajto_sources_from_db: state.config.prehrajto_sources_from_db,
     };
     Ok(Html(tmpl.render()?).into_response())
@@ -707,6 +1095,13 @@ async fn films_by_genre(
         open_filter: open_filter || !zanry_extras.is_empty(),
         selected_genre_slugs: zanry_extras.clone(),
         film_genres_map,
+        selected_audio_langs: params.audio_langs_filter().unwrap_or_default(),
+        selected_subs: match params.subs_filter() {
+            Some(None) => Some(Vec::new()),
+            Some(Some(v)) => Some(v),
+            None => None,
+        },
+        full_query: build_full_query_map(&params),
     };
     Ok(Html(tmpl.render()?).into_response())
 }
@@ -893,6 +1288,32 @@ async fn run_films_query(
     if let Some(af) = params.audio_filter() {
         where_parts.push(af.to_string());
     }
+    // Multi-value audio-lang filter (#612). `f.audio_langs @> $N` asks "is
+    // every user-selected lang present in the film's rollup array" — AND
+    // semantics per the issue. GIN on `audio_langs` makes this a cheap
+    // bitmap intersection.
+    let audio_langs_param = params.audio_langs_filter();
+    if audio_langs_param.is_some() {
+        where_parts.push(format!("f.audio_langs @> ${bind_idx}::TEXT[]"));
+        bind_idx += 1;
+    }
+    // Subtitle filter (#612).
+    //   titulky=any → require at least one subtitle track (any language)
+    //   titulky=cs,en → require every listed language as a subtitle track
+    let subs_param = params.subs_filter();
+    let mut subs_bind_idx = None;
+    match &subs_param {
+        Some(None) => {
+            where_parts.push("cardinality(f.subtitle_langs) > 0".to_string());
+        }
+        Some(Some(_)) => {
+            where_parts.push(format!("f.subtitle_langs @> ${bind_idx}::TEXT[]"));
+            subs_bind_idx = Some(bind_idx);
+            bind_idx += 1;
+        }
+        None => {}
+    }
+    let _ = subs_bind_idx; // reserved for future chip rendering; kept to document order
 
     // Anti-zombie filter: only list films that actually have at least one
     // alive video source. Before the #611 reader switch, this condition was
@@ -929,6 +1350,12 @@ async fn run_films_query(
     if let Some(yr) = year_f {
         cq = cq.bind(yr);
     }
+    if let Some(langs) = audio_langs_param.as_ref() {
+        cq = cq.bind(langs.clone());
+    }
+    if let Some(Some(langs)) = subs_param.as_ref() {
+        cq = cq.bind(langs.clone());
+    }
     let count_row = cq.fetch_one(db).await?;
 
     let films_query = format!(
@@ -951,6 +1378,12 @@ async fn run_films_query(
     }
     if let Some(yr) = year_f {
         fq = fq.bind(yr);
+    }
+    if let Some(langs) = audio_langs_param.as_ref() {
+        fq = fq.bind(langs.clone());
+    }
+    if let Some(Some(langs)) = subs_param.as_ref() {
+        fq = fq.bind(langs.clone());
     }
     let films = fq.bind(FILMS_PER_PAGE).bind(offset).fetch_all(db).await?;
 

--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -1948,6 +1948,8 @@ mod tests {
             rezim: None,
             smer: None,
             jazyk: jazyk.map(|s| s.to_string()),
+            audio: None,
+            titulky: None,
         }
     }
 

--- a/cr-web/templates/film_detail.html
+++ b/cr-web/templates/film_detail.html
@@ -133,6 +133,34 @@
         {# Cached Přehraj.to URL — primary source when SK Torrent is absent.
            filmRuntime is used to filter out mismatched-duration candidates
            in the "Další zdroje" live search. #}
+        {# Per-source badges (#613). Lists every alive video_sources row for
+           this film, grouped visually by provider, with audio-lang + subtitle
+           chips and a `primary` marker on the auto-play choice. Order matches
+           `video_providers.sort_priority` so badges follow the tab row above. #}
+        {% if !video_sources_for_badges.is_empty() %}
+        <div class="source-badges" id="source-badges">
+            {% for vs in video_sources_for_badges %}
+            <div class="source-badge source-badge-{{ vs.provider_slug }}{% if vs.is_primary %} is-primary{% endif %}"
+                 data-provider="{{ vs.provider_slug }}"
+                 data-external-id="{{ vs.external_id }}">
+                <span class="source-badge-provider">{{ vs.provider_host }}</span>
+                <span class="source-badge-audio" title="Jazyk zvuku">🎧 {{ vs.audio_label() }}{% match vs.confidence_display() %}{% when Some with (c) %} <span class="confidence">({{ c }})</span>{% when None %}{% endmatch %}</span>
+                {% if !vs.subtitle_langs.is_empty() %}
+                <span class="source-badge-subs" title="Titulky">📝 {{ vs.subtitle_display() }}</span>
+                {% endif %}
+                {% match vs.resolution_hint %}
+                {% when Some with (r) %}
+                <span class="source-badge-res">{{ r }}</span>
+                {% when None %}
+                {% endmatch %}
+                {% if vs.is_primary %}
+                <span class="source-badge-primary-tag" title="Primární zdroj — přehraje se automaticky">primary</span>
+                {% endif %}
+            </div>
+            {% endfor %}
+        </div>
+        {% endif %}
+
         <script>
         var cachedPrehrajtoUrl = {% match film.prehrajto_url %}{% when Some with (u) %}"{{ u }}"{% when None %}null{% endmatch %};
         var filmRuntime = {% match film.runtime_min %}{% when Some with (m) %}{{ m }}{% when None %}null{% endmatch %};
@@ -240,6 +268,21 @@
 .quality-btn:hover { background: #444; }
 .quality-btn.active { background: #D7141A; color: white; }
 .source-status { font-size: 0.78rem; color: #888; margin-left: auto; }
+
+/* Per-source badges (#613). Rendered under the player; one row per alive
+   video_sources entry, grouped visually by provider via color accents. */
+.source-badges { display: flex; flex-direction: column; gap: 0.35rem; margin-top: 0.8rem; padding: 0.6rem; background: #1a1a1a; border-radius: 8px; }
+.source-badge { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; padding: 0.4rem 0.6rem; background: #2a2a2a; border-left: 3px solid #555; border-radius: 4px; font-size: 0.8rem; color: #ccc; }
+.source-badge.source-badge-sktorrent { border-left-color: #D7141A; }
+.source-badge.source-badge-prehrajto { border-left-color: #4a7cc3; }
+.source-badge.source-badge-sledujteto { border-left-color: #6aa84f; }
+.source-badge.is-primary { background: linear-gradient(to right, #3d2f14 0%, #2a2a2a 40%); box-shadow: 0 0 0 1px #a6841266 inset; }
+.source-badge-provider { font-weight: 600; color: #e6d89b; font-size: 0.78rem; min-width: 9rem; }
+.source-badge-audio { background: #1f3a1f; color: #bfe9a4; padding: 0.2rem 0.5rem; border-radius: 3px; font-size: 0.78rem; }
+.source-badge-audio .confidence { color: #7aa86a; font-size: 0.7rem; margin-left: 0.2rem; }
+.source-badge-subs { background: #1f2d3a; color: #a4c7e9; padding: 0.2rem 0.5rem; border-radius: 3px; font-size: 0.78rem; }
+.source-badge-res { background: #333; color: #888; padding: 0.2rem 0.4rem; border-radius: 3px; font-size: 0.72rem; }
+.source-badge-primary-tag { margin-left: auto; background: #a68412; color: #1a1a1a; padding: 0.15rem 0.4rem; border-radius: 3px; font-size: 0.68rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; }
 
 /* Subtitle controls */
 .subtitle-controls { display: flex; align-items: center; gap: 0.4rem; }

--- a/cr-web/templates/films_list.html
+++ b/cr-web/templates/films_list.html
@@ -172,11 +172,55 @@
                 <option value="">Všechny roky</option>
             </select>
         </div>
+        {# Audio-language multi-select (#612). Chips follow the same CSS as
+           genre chips; the picker is AND-semantic — checking `cs` + `en`
+           narrows to films that have BOTH audio tracks. Values are ISO 639
+           short codes so the query param stays short and canonical. #}
+        <div class="filter-section">
+            <label>Jazyk zvuku (vyberte jeden nebo více):</label>
+            <div class="filter-genres" id="filter-audio">
+                <label class="filter-chip"><input type="checkbox" value="cs" data-filter="audio"{% if self.is_audio_selected("cs") %} checked{% endif %}> Čeština</label>
+                <label class="filter-chip"><input type="checkbox" value="sk" data-filter="audio"{% if self.is_audio_selected("sk") %} checked{% endif %}> Slovenština</label>
+                <label class="filter-chip"><input type="checkbox" value="en" data-filter="audio"{% if self.is_audio_selected("en") %} checked{% endif %}> Angličtina</label>
+            </div>
+        </div>
+        {# "Má titulky" toggle. Off by default; `titulky=any` in URL. #}
+        <div class="filter-section">
+            <label>Titulky:</label>
+            <div class="filter-genres" id="filter-subs">
+                <label class="filter-chip"><input type="checkbox" value="any" data-filter="subs"{% if self.is_subs_any() %} checked{% endif %}> Má titulky (jakékoliv)</label>
+                <label class="filter-chip"><input type="checkbox" value="cs" data-filter="subs"{% if self.is_subs_selected("cs") %} checked{% endif %}> České titulky</label>
+                <label class="filter-chip"><input type="checkbox" value="sk" data-filter="subs"{% if self.is_subs_selected("sk") %} checked{% endif %}> Slovenské titulky</label>
+            </div>
+        </div>
         <div class="filter-actions">
             <button class="btn-apply" onclick="applyFilters()">Použít filtr</button>
             <button class="btn-reset" onclick="resetFilters()">Zrušit filtry</button>
         </div>
     </div>
+
+    {# Active filter chips — one per applied audio/subs filter. Clicking
+       removes that single filter from the URL while keeping the rest. #}
+    {% if self.has_lang_filters() %}
+    <div class="active-filters" id="active-filters">
+        <span class="active-filters-label">Aktivní filtry:</span>
+        {% for lang in self.audio_chips() %}
+        <a class="active-filter-chip" href="{{ self.remove_audio_url(lang) }}" title="Odebrat filtr zvuku">
+            🎧 {{ self.lang_display(lang) }} <span class="chip-x">✕</span>
+        </a>
+        {% endfor %}
+        {% if self.is_subs_any_without_lang() %}
+        <a class="active-filter-chip" href="{{ self.remove_subs_url() }}" title="Zrušit filtr titulků">
+            📝 Titulky <span class="chip-x">✕</span>
+        </a>
+        {% endif %}
+        {% for lang in self.subs_chips() %}
+        <a class="active-filter-chip" href="{{ self.remove_subs_lang_url(lang) }}" title="Odebrat filtr titulků">
+            📝 {{ self.lang_display(lang) }} <span class="chip-x">✕</span>
+        </a>
+        {% endfor %}
+    </div>
+    {% endif %}
 
     {# Films grid/list #}
     <div class="films-grid" id="films-container">
@@ -221,6 +265,15 @@
         </a>
         {% endfor %}
     </div>
+    {# Empty-state — shown when the combination of filters yields no films.
+       Rendered under the (empty) grid so pagination is suppressed and the
+       user has a single-click reset path back to the full catalog. #}
+    {% if total_count == 0 %}
+    <div class="empty-filter-state">
+        <p class="empty-filter-title">Žádný film neodpovídá zvoleným filtrům.</p>
+        <a href="/filmy-online/" class="btn-reset-filters">Zrušit všechny filtry</a>
+    </div>
+    {% endif %}
 
     {% if total_pages > 1 %}
     <nav class="pagination">
@@ -302,6 +355,19 @@ a.filter-chip-link:hover { background: #11457E; color: white; }
 .filter-actions { display: flex; gap: 0.5rem; margin-top: 0.5rem; }
 .btn-apply { padding: 0.4rem 1.2rem; background: #D7141A; color: white; border: none; border-radius: 6px; font-size: 0.85rem; cursor: pointer; font-weight: 600; transition: background 0.2s; }
 .btn-apply:hover { background: #11457E; }
+
+/* Active filter chips + empty state (#612). Rendered only when lang
+   filters are applied; each chip is a link that removes that one filter
+   from the URL while keeping the rest. */
+.active-filters { display: flex; flex-wrap: wrap; align-items: center; gap: 0.4rem; padding: 0.6rem 0; margin: 0 0 0.8rem 0; }
+.active-filters-label { color: #666; font-size: 0.82rem; font-weight: 600; }
+.active-filter-chip { display: inline-flex; align-items: center; gap: 0.3rem; padding: 0.3rem 0.7rem; border-radius: 999px; background: #11457E; color: #fff; font-size: 0.82rem; text-decoration: none; transition: background 0.15s; }
+.active-filter-chip:hover { background: #0c3561; }
+.active-filter-chip .chip-x { font-size: 0.75rem; opacity: 0.75; }
+.empty-filter-state { text-align: center; padding: 3rem 1rem; background: #f8f8f8; border-radius: 12px; margin-bottom: 1rem; }
+.empty-filter-title { font-size: 1.05rem; color: #555; margin: 0 0 1rem 0; }
+.btn-reset-filters { display: inline-block; padding: 0.5rem 1.4rem; background: #11457E; color: #fff; border-radius: 8px; text-decoration: none; font-size: 0.9rem; font-weight: 600; transition: background 0.15s; }
+.btn-reset-filters:hover { background: #0c3561; }
 
 /* Filter counter badge on toggle button */
 #btn-filter-toggle { position: relative; }
@@ -576,9 +642,28 @@ function applyFilters() {
         if (extras.length > 1) u.searchParams.set('zanry', extras.join(','));
         if (extras.length > 1 && rezim === 'and') u.searchParams.set('rezim', 'and');
     }
+    // Multi-value audio / subs filters (#612) — read the new chip pickers.
+    var audioEls = document.querySelectorAll('#filter-audio input:checked');
+    var subsEls = document.querySelectorAll('#filter-subs input:checked');
+    var audioLangs = Array.from(audioEls).map(function(el) { return el.value; });
+    var subsValues = Array.from(subsEls).map(function(el) { return el.value; });
+    // `any` is an exclusive toggle — if the user picked both `any` and a
+    // specific language, let the specific language win (more restrictive).
+    var subsSpecific = subsValues.filter(function(v) { return v !== 'any'; });
+    var subsParam = null;
+    if (subsSpecific.length > 0) {
+        subsParam = subsSpecific.join(',');
+    } else if (subsValues.includes('any')) {
+        subsParam = 'any';
+    }
+
     if (exc.length) u.searchParams.set('bez', exc.join(','));
     if (year) u.searchParams.set('rok', year);
     if (langParam) u.searchParams.set('jazyk', langParam);
+    if (audioLangs.length > 0) u.searchParams.set('audio', audioLangs.join(','));
+    else u.searchParams.delete('audio');
+    if (subsParam) u.searchParams.set('titulky', subsParam);
+    else u.searchParams.delete('titulky');
     if (sort && sort !== 'pridano:desc') {
         var parts = sort.split(':');
         u.searchParams.set('razeni', parts[0]);


### PR DESCRIPTION
<!-- claude-session: 9c42f99e-d1ab-4b4c-9d4d-e7d09129237a -->

Closes #612 and #613 (part of #607). Stacked on #618 (PR3); base branch is `feat/607-reader-switch`. Merge #616 → #617 → #618 first, then retarget this to `main`.

## Summary

Phase 4 — pure UX, no schema changes. Builds on PR3's reader switch so both features (listing filters + detail-page badges) source from `video_sources` / rollup arrays.

## Listing filter (#612)

- New `FilmsQuery` params: `audio=cs,sk,en` (CSV of ISO 639 codes, AND semantics) + `titulky=1/any` or `titulky=cs,en` (subtitle filter with "any subs" toggle).
- `run_films_query` binds them as `TEXT[]` and uses `audio_langs @> $N` / `subtitle_langs @> $N` against the TRIGGER-maintained rollup arrays — GIN indexes make this near-free.
- Legacy `jazyk=dub/sub` preserved for shareable links.

## films_list.html

- Filter panel extended with two chip sections: "Jazyk zvuku" (cs / sk / en) and "Titulky" (any + cs / sk).
- `applyFilters()` JS reads the new checkboxes and writes `audio` / `titulky` into the URL.
- Active-filter chip row renders each applied lang as a one-click-remove chip (per-chip URL helpers on `FilmsListTemplate`).
- Empty-state card replaces the grid when filters match zero films; has a single "Zrušit všechny filtry" link back to the unfiltered catalog.

## Per-source badges on film_detail.html (#613)

- New query in `films_detail` joins `video_sources` + `video_source_subtitles` (with `array_agg` of subtitle langs) for the film. Ordered by `video_providers.sort_priority` + primary-first.
- `VideoSourceBadgeRow` with helpers:
  - `audio_label()` — Czech display for ISO codes
  - `confidence_display()` — hides the % when Whisper ≥ 0.8 (noise per the issue); shows it for lower-quality / regex-guessed detections
  - `subtitle_display()` — comma-separated uppercase subtitle codes
- Template renders under the player section. Provider-keyed CSS accents (red=sktorrent, blue=prehrajto, green=sledujteto) + gold `primary` tag on the `is_primary=TRUE` row.

## Verification (dev DB)

- `cargo check --all` / `clippy -D warnings` / `fmt --check` / `sqlx prepare --check` ✓
- Dev server boots, `/health` 200.
- Filter URLs tested (`/filmy-online/?audio=cs`, `?audio=cs,sk`, `?titulky=any`, `?audio=cs&titulky=cs`) → 200 OK.
- Empty-state rendered for `?audio=cs,zz` (mismatched).
- Active chips for `?audio=cs,sk`: "🎧 Čeština ✕" → `?audio=sk`, "🎧 Slovenština ✕" → `?audio=cs`.
- Detail badges: Kmotr (single sktorrent source) shows badge `online.sktorrent.eu` + `🎧 Čeština` + `primary` marker, sourced from `video_sources`.

## Test plan

- [ ] CI passes.
- [ ] Copilot review.
- [ ] After PR1 / PR2 / PR3 merge + prod stable, rebase this PR onto main.
- [ ] Playwright full interactive test on prod:
  - Filter panel: check/uncheck chips, verify URL updates, verify grid narrows.
  - Active chips: click remove, verify URL loses only that one filter.
  - Empty state: select impossible filter combination, verify empty card + reset link.
  - Detail badges: verify on a film with 3 providers (e.g. Bankéřka after its prehrajto uploads are re-imported on prod) — badges render in tab order with correct audio labels and primary marker.
- [ ] Server-Timing budget: listing query < 250 ms per the issue. EXPLAIN ANALYZE the `audio_langs @>` path on prod.

## Follow-ups

- **PR5 (#614):** drop legacy columns + tables once this PR has been stable on prod for a week.
- Extend filter UI + badge rendering to `/serialy-online/` and `/tv-porady/` (mentioned in #612 "Should Have" — deferred to a follow-up because it duplicates the films.rs wiring in series.rs / tv_porady.rs).