### PR TITLE
fix(video_sources): 3 more Copilot follow-ups on PR #620

### DIFF
--- a/cr-web/src/handlers/movies_api/subtitles.rs
+++ b/cr-web/src/handlers/movies_api/subtitles.rs
@@ -49,11 +49,20 @@ pub async fn movies_subtitle(
         return (StatusCode::FORBIDDEN, "URL not allowed").into_response();
     }
 
+    // Referer matches the provider host — prehraj.to for premiumcdn.net
+    // subs, sledujteto.cz for its own /file/subtitles/ endpoint — because
+    // both sides do origin/referer checks at the CDN layer. A cross-origin
+    // Referer would look like scraping and surface as intermittent 403s.
+    let referer = if is_sledujteto {
+        "https://www.sledujteto.cz/"
+    } else {
+        "https://prehraj.to/"
+    };
     let resp = state
         .http_client
         .get(parsed.as_str())
         .header("User-Agent", "Mozilla/5.0")
-        .header("Referer", "https://prehraj.to/")
+        .header("Referer", referer)
         .timeout(std::time::Duration::from_secs(15))
         .send()
         .await;

--- a/scripts/backfill-video-sources.py
+++ b/scripts/backfill-video-sources.py
@@ -54,6 +54,7 @@ Flags:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import logging
 import os
 import sys
@@ -408,14 +409,17 @@ def backfill_prehrajto(cur, providers: dict[str, int], limit: int | None
         log.info("prehrajto/%s fallback: %d rows (stable URL only)",
                  table, len(fallback_rows))
         for row in fallback_rows:
-            # External id: last non-empty path segment of the URL. Keeps the
-            # (provider_id, external_id) UNIQUE tight per row so re-runs are
-            # idempotent even though we don't have a real upload_id.
+            # External id: SHA-1 of the full URL (including query string) so
+            # different URLs never collide — previous version used the
+            # trailing path segment, truncated to 128 chars, which could
+            # collide across uploads that share the same filename. Re-running
+            # the backfill with the same URL produces the same hash, so
+            # idempotence is preserved.
             url = row["prehrajto_url"]
-            segment = url.rstrip("/").rsplit("/", 1)[-1]
-            if not segment:
+            if not url:
                 continue
-            external_id = f"legacy_url:{segment}"[:128]
+            url_hash = hashlib.sha1(url.encode("utf-8")).hexdigest()
+            external_id = f"legacy_url:{url_hash}"
             try:
                 upsert_video_source(
                     cur,

--- a/scripts/video_sources_helper.py
+++ b/scripts/video_sources_helper.py
@@ -47,6 +47,8 @@ Schema reference: cr-infra/migrations/20260529_058_video_sources_unified.sql
 """
 from __future__ import annotations
 
+import logging
+
 try:
     import psycopg2.extras
 except ImportError:
@@ -197,10 +199,15 @@ def upsert_video_source(cur, *,
             %(audio_confidence)s, %(audio_detected_by)s, %(cdn)s,
             %(is_primary)s, %(is_alive)s, %(last_seen)s, %(metadata)s, NOW()
         )
+        -- Safety: never silently move a source row to a different parent.
+        -- Same rule as backfill — legacy sktorrent has known duplicate
+        -- video_ids across films, and any importer that encounters such a
+        -- collision should preserve the existing parent binding rather than
+        -- silently re-point the row (which would corrupt rollups on the old
+        -- parent via the subtitles trigger cascade). The caller compares
+        -- the returned parent IDs against the incoming ones and logs the
+        -- mismatch instead.
         ON CONFLICT (provider_id, external_id) DO UPDATE SET
-            film_id           = EXCLUDED.film_id,
-            episode_id        = EXCLUDED.episode_id,
-            tv_episode_id     = EXCLUDED.tv_episode_id,
             title             = COALESCE(EXCLUDED.title, video_sources.title),
             duration_sec      = COALESCE(EXCLUDED.duration_sec, video_sources.duration_sec),
             resolution_hint   = COALESCE(EXCLUDED.resolution_hint, video_sources.resolution_hint),
@@ -216,7 +223,7 @@ def upsert_video_source(cur, *,
             last_seen         = COALESCE(EXCLUDED.last_seen, video_sources.last_seen),
             metadata          = COALESCE(EXCLUDED.metadata, video_sources.metadata),
             updated_at        = NOW()
-        RETURNING id
+        RETURNING id, film_id, episode_id, tv_episode_id
         """,
         dict(
             provider_id=provider_id,
@@ -242,7 +249,26 @@ def upsert_video_source(cur, *,
     )
     result = cur.fetchone()
     # Handle both DictCursor (row["id"]) and plain cursor (row[0]).
-    return result["id"] if hasattr(result, "keys") else result[0]
+    if hasattr(result, "keys"):
+        got = (result["id"], result["film_id"], result["episode_id"],
+               result["tv_episode_id"])
+    else:
+        got = (result[0], result[1], result[2], result[3])
+    got_id, got_film, got_ep, got_tv = got
+    # Detect the "moved between parents" case — we preserved the original
+    # parent binding; the caller's incoming parent was different. Log it so
+    # the operator can clean the legacy duplicate. This is the same check
+    # as in backfill-video-sources.py.
+    if (got_film != film_id or got_ep != episode_id
+            or got_tv != tv_episode_id):
+        logging.getLogger(__name__).warning(
+            "video_sources row id=%d kept on original parent "
+            "(film=%s episode=%s tv_ep=%s); incoming (film=%s episode=%s "
+            "tv_ep=%s) not re-pointed",
+            got_id, got_film, got_ep, got_tv,
+            film_id, episode_id, tv_episode_id,
+        )
+    return got_id
 
 
 def upsert_subtitle(cur, source_id: int, lang: str,


### PR DESCRIPTION
<!-- claude-session: 9c42f99e-d1ab-4b4c-9d4d-e7d09129237a -->

Second follow-up round, addressing the 3 Copilot comments on PR #620. All three hit production code paths that are already live, already deployed to prod ahead of this PR per the 4-stage workflow.

## Changes

- **video_sources_helper.py** — apply the same ON CONFLICT parent-preservation rule we shipped in backfill-video-sources.py (PR #620). The shared upsert that every dual-write importer uses no longer silently re-points a row to a different parent on collision. Returned parent IDs are compared against the incoming ones; mismatches are logged.

- **subtitles.rs** — pick `Referer` header based on the parsed host. `sledujteto.cz` subtitles get `https://www.sledujteto.cz/`, `premiumcdn.net` stays on `https://prehraj.to/`. Prevents cross-origin 403s on the newly-allowlisted sledujteto subtitle endpoint.

- **backfill-video-sources.py** — SHA-1 the full URL to derive `external_id` for the `prehrajto_url` legacy fallback. Previous trailing-segment approach could collide across different URLs that shared a filename. Still idempotent (same URL → same hash).

## Verification

- `cargo check --workspace` / `clippy -D warnings` / `fmt --check` / `cargo test --workspace` ✓
- Binary deployed to prod, `/health` 200
- Scripts copied to /opt/cr/scripts/ on prod; all importers using helper will pick up the parent-preservation fix on next run.

## Test plan

- [ ] CI green.
- [ ] Manual Playwright verify on a sledujteto-subtitle film (next upload cycle) to confirm Referer change did not regress subs.