### PR TITLE
docs(video_sources): fix stale SQL comment on helper parent check

### DIFF
--- a/scripts/video_sources_helper.py
+++ b/scripts/video_sources_helper.py
@@ -204,9 +204,9 @@ def upsert_video_source(cur, *,
         -- video_ids across films, and any importer that encounters such a
         -- collision should preserve the existing parent binding rather than
         -- silently re-point the row (which would corrupt rollups on the old
-        -- parent via the subtitles trigger cascade). The caller compares
-        -- the returned parent IDs against the incoming ones and logs the
-        -- mismatch instead.
+        -- parent via the subtitles trigger cascade). The Python code below
+        -- compares the returned parent IDs against the incoming ones and
+        -- logs the mismatch instead.
         ON CONFLICT (provider_id, external_id) DO UPDATE SET
             title             = COALESCE(EXCLUDED.title, video_sources.title),
             duration_sec      = COALESCE(EXCLUDED.duration_sec, video_sources.duration_sec),


### PR DESCRIPTION
<!-- claude-session: 9c42f99e-d1ab-4b4c-9d4d-e7d09129237a -->

Single-line doc fix from Copilot PR #621 review — the SQL comment said \"the caller compares the returned parent IDs\", but PR #621 moved that comparison INTO `upsert_video_source` itself. Update wording to \"the Python code below\" so future maintainers don't grep for caller-side logging that isn't there.

## Test plan

- [ ] No runtime change. Reconciler / importers untouched.