### PR TITLE
fix(sledujteto): drop non-www uploads at import time

### DIFF
--- a/scripts/import-sledujteto-films.py
+++ b/scripts/import-sledujteto-films.py
@@ -393,17 +393,20 @@ def build_upload_rows(
             continue
         upload_id = int(src["upload_id"])
         audio = audio_by_upload.get(upload_id)
-        # Only `www.sledujteto.cz` uploads serve 206 Partial Content from
-        # Hetzner (our prod ASN); `data{N}.sledujteto.cz` uploads redirect
-        # datacenter traffic to an invalid-file HTML page and the browser
-        # errors out with MEDIA_ERR_SRC_NOT_SUPPORTED. Those uploads have
-        # no playback value for us, so we drop them at ingest — keeping
-        # both `film_sledujteto_uploads` and `video_sources` free of
-        # unplayable rows.
+        # Drop uploads whose playback host is `data{N}.sledujteto.cz` —
+        # from Hetzner's datacenter ASN those redirect to an invalid-file
+        # HTML page and the <video> element errors out with
+        # MEDIA_ERR_SRC_NOT_SUPPORTED. Only `www.sledujteto.cz` serves
+        # 206 Partial Content for us. We match on the `data` prefix
+        # rather than "anything != www" so that uploads whose classifier
+        # returned "unknown" (cdn_type missing + no audio detection yet)
+        # stay in — they may resolve to `www` once audio detection runs
+        # and dropping them pre-emptively would cost real coverage.
         cdn = cdn_from_sources(src, audio)
-        if cdn != "www":
+        if cdn.startswith("data"):
             log.debug(
-                "film_id=%d upload=%d: skipping non-www CDN %r (unplayable from Hetzner)",
+                "film_id=%d upload=%d: skipping data-CDN upload %r "
+                "(unplayable from Hetzner)",
                 film_id, upload_id, cdn,
             )
             continue

--- a/scripts/import-sledujteto-films.py
+++ b/scripts/import-sledujteto-films.py
@@ -393,6 +393,20 @@ def build_upload_rows(
             continue
         upload_id = int(src["upload_id"])
         audio = audio_by_upload.get(upload_id)
+        # Only `www.sledujteto.cz` uploads serve 206 Partial Content from
+        # Hetzner (our prod ASN); `data{N}.sledujteto.cz` uploads redirect
+        # datacenter traffic to an invalid-file HTML page and the browser
+        # errors out with MEDIA_ERR_SRC_NOT_SUPPORTED. Those uploads have
+        # no playback value for us, so we drop them at ingest — keeping
+        # both `film_sledujteto_uploads` and `video_sources` free of
+        # unplayable rows.
+        cdn = cdn_from_sources(src, audio)
+        if cdn != "www":
+            log.debug(
+                "film_id=%d upload=%d: skipping non-www CDN %r (unplayable from Hetzner)",
+                film_id, upload_id, cdn,
+            )
+            continue
         title = src.get("name") or ""
         lang_class = merge_lang_class(
             title=title,
@@ -411,7 +425,7 @@ def build_upload_rows(
             "resolution_hint": normalize_resolution(src.get("resolution")),
             "filesize_bytes": parse_filesize(src.get("filesize")),
             "lang_class": lang_class,
-            "cdn": cdn_from_sources(src, audio),
+            "cdn": cdn,
         })
     return rows
 


### PR DESCRIPTION
<!-- claude-session: 9c42f99e-d1ab-4b4c-9d4d-e7d09129237a -->

Closes #624 follow-up.

## Summary
- Filter out `data{N}.sledujteto.cz` uploads in `scripts/import-sledujteto-films.py` before they reach `film_sledujteto_uploads` / `video_sources` — datacenter ASNs like Hetzner cannot play them (redirect to invalid-file HTML).
- Prevents the regression behind #624 from recurring on the next import run. Prod was already cleaned up manually (692 rows deleted across both tables, triggers recomputed rollups).

## Test plan
- [x] Python syntax check on the patched script (`ast.parse`).
- [x] Prod SQL cleanup: `DELETE FROM video_sources WHERE provider_id=sledujteto AND cdn IN ('data10','data11')` → 692 rows, and same on `film_sledujteto_uploads` → 692 rows.
- [x] Playwright on prod — Blue Moon (previously 2 sledujteto dataN rows) now shows only tabs "1" (sktorrent) + "2" (prehraj.to), no sledujteto. Zdroje list has 6 rows (1 sktorrent + 5 prehraj.to).
- [x] Rollup verification: post-DELETE `SELECT COUNT(*) FROM … cdn IN ('data10','data11')` returns 0 on both tables.