### PR TITLE
fix(films-list): header logo+title link on /filmy-online/?strana=N

### DIFF
--- a/cr-web/templates/films_list.html
+++ b/cr-web/templates/films_list.html
@@ -30,11 +30,19 @@
     <span>Filmy online</span>
 </a>
 {% when None %}
+    {% if page > 1 %}
+<a href="/filmy-online/" class="logo-group logo-link" style="display:flex;align-items:center;gap:0.5rem;">
+    <img src="/static/img/logo-filmy-a-serialy.svg?v=6"
+        alt="Logo Filmy online" title="Filmy online" class="header-emblem">
+    <span>Filmy online</span>
+</a>
+    {% else %}
 <div class="logo-group" style="display:flex;align-items:center;gap:0.5rem;">
     <img src="/static/img/logo-filmy-a-serialy.svg?v=6"
         alt="Logo Filmy online" title="Filmy online" class="header-emblem">
     <h1>Filmy online</h1>
 </div>
+    {% endif %}
 {% endmatch %}
 {% endblock %}
 

--- a/cr-web/templates/films_list.html
+++ b/cr-web/templates/films_list.html
@@ -31,10 +31,12 @@
 </a>
 {% when None %}
     {% if page > 1 %}
+{# h1 stays inside the link so paginated unfiltered pages keep a top-level
+   heading (the main content uses h2 for the unfiltered listing). #}
 <a href="/filmy-online/" class="logo-group logo-link" style="display:flex;align-items:center;gap:0.5rem;">
     <img src="/static/img/logo-filmy-a-serialy.svg?v=6"
         alt="Logo Filmy online" title="Filmy online" class="header-emblem">
-    <span>Filmy online</span>
+    <h1>Filmy online</h1>
 </a>
     {% else %}
 <div class="logo-group" style="display:flex;align-items:center;gap:0.5rem;">


### PR DESCRIPTION
<!-- claude-session: 9c42f99e-d1ab-4b4c-9d4d-e7d09129237a -->

## Summary
On `/filmy-online/` without any genre filter, the header logo and "Filmy online" heading were rendered as plain text on every page, including pagination pages 2..N — there was no way back to page 1 short of editing the URL.

Genre subpages (e.g. `/filmy-online/valecny/?strana=3&bez=sci-fi`) already render the header as a link to `/filmy-online/`. This PR extends the same behavior to the unfiltered listing when `page > 1`. Page 1 keeps the `<h1>` (no self-link) so the SEO heading semantics on the canonical landing page are unchanged.

## Test plan
- [x] Local: `/filmy-online/?strana=2` renders `<a href="/filmy-online/" class="logo-group logo-link">`, page 1 renders `<div>` + `<h1>`
- [x] Prod (cargo zigbuild → scp → restart): same HTML on `https://ceskarepublika.wiki/filmy-online/?strana=2` vs `/filmy-online/`
- [x] Playwright: clicked the header on page 2 → navigated to page 1; header reverts to non-linked `<h1>`
- [x] No console errors