### PR TITLE
feat(audioknihy): add Patrik Hartl - Malý pražský erotikon (2024)

### DIFF
--- a/cr-infra/migrations/20260531_060_add_audiobook_hartl_erotikon.sql
+++ b/cr-infra/migrations/20260531_060_add_audiobook_hartl_erotikon.sql
@@ -1,0 +1,4 @@
+INSERT INTO audiobooks (title, author, narrator, year, duration, archive_id, cover_filename)
+VALUES
+    ('Malý pražský erotikon', 'Patrik Hartl', 'David Novotný', 2024, '16h 6m', 'patrik-hartl-maly-prazsky-erotikon-cz', 'cover.jpg')
+ON CONFLICT (archive_id) DO NOTHING;


### PR DESCRIPTION
<!-- claude-session: 98d65447-0cc0-4c98-a612-a9b5c0699023 -->

## Summary
- Uploads 32 audio chapters + cover to archive.org as `patrik-hartl-maly-prazsky-erotikon-cz`
- Adds DB row via migration `060_add_audiobook_hartl_erotikon`
- Audiobook: *Malý pražský erotikon* (Patrik Hartl, čte David Novotný, 2024, 16h 6m)

## Test plan
- [x] Local `cargo check` ✓
- [x] Local `cargo run -p cr-web` — `/audioknihy/` lists the new card with title/author/narrator/year/duration
- [x] Cross-compile `cargo zigbuild --release --target aarch64-unknown-linux-musl`
- [x] Deployed to prod (replaced `/opt/cr/cr-web-bin`, restarted `cr-web-1`)
- [x] Migration applied automatically on startup (logs: `Database migrations applied`)
- [x] Playwright on `https://ceskarepublika.wiki/audioknihy/`:
  - Card visible with cover from archive.org
  - Click expands player; 32 chapters loaded via archive.org metadata API
  - First chapter auto-plays (audio src `https://archive.org/download/patrik-hartl-.../01%20-%201975%20-%20koncem%20panevnim.mp3`)
  - "Další" button advances to chapter 2 (verified)
  - 0 console errors / warnings
- [x] Production health check: 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)