### PR TITLE
feat(audioknihy): add Zdeněk Svěrák - Povídky a Nové povídky (2016)

### DIFF
--- a/cr-infra/migrations/20260601_061_add_audiobook_sverak_povidky.sql
+++ b/cr-infra/migrations/20260601_061_add_audiobook_sverak_povidky.sql
@@ -1,0 +1,4 @@
+INSERT INTO audiobooks (title, author, narrator, year, duration, archive_id, cover_filename)
+VALUES
+    ('Povídky a Nové povídky – Komplet', 'Zdeněk Svěrák', 'Zdeněk Svěrák, Daniela Kolářová, Libuše Šafránková', 2016, '8h 47m', 'zdenek-sverak-povidky-komplet-cz', 'cover.jpg')
+ON CONFLICT (archive_id) DO NOTHING;


### PR DESCRIPTION
<!-- claude-session: 98d65447-0cc0-4c98-a612-a9b5c0699023 -->

## Summary
- Uploads 19 audio chapters + cover to archive.org as `zdenek-sverak-povidky-komplet-cz`
- Adds DB row via migration `061_add_audiobook_sverak_povidky`
- Audiobook: *Povídky a Nové povídky – Komplet* (Zdeněk Svěrák, čtou Zdeněk Svěrák, Daniela Kolářová, Libuše Šafránková, 2016, 8h 47m)

## Test plan
- [x] Local `cargo check` ✓
- [x] Local migration apply on cr_dev — row inserted, page lists card
- [x] Cross-compile `cargo zigbuild --release --target aarch64-unknown-linux-musl`
- [x] Deployed to prod (replaced `/opt/cr/cr-web-bin`, restarted `cr-web-1`)
- [x] Migration applied automatically on startup (logs: `Database migrations applied`)
- [x] Playwright on `https://ceskarepublika.wiki/audioknihy/`:
  - Card visible with cover + author/narrator/year/duration
  - Click expands player; 19 chapters loaded via archive.org metadata API
  - First chapter auto-plays (audio src `https://archive.org/download/zdenek-sverak-povidky-komplet-cz/01%20Za%20Premkem%20Bastyrem.mp3`)
  - 0 console errors / warnings
- [x] Production health check: 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)