### PR TITLE
fix(auto-import): remove --max-new 50 cap on cron

### DIFF
--- a/deploy/systemd/cr-auto-import.service
+++ b/deploy/systemd/cr-auto-import.service
@@ -18,10 +18,10 @@ EnvironmentFile=/opt/cr/.env
 # rewrite it to 127.0.0.1 (the cr-db container publishes 5432 there).
 # This keeps ONE source of truth for the password while letting both
 # the Rust container and host-side scripts share the file.
-# --max-new 0 = unlimited per run. SK Torrent uploads ~100 new videos/day; a
-# 50/day cap created a permanent backlog (e.g. Euforie S03E03 missing 2026-04-29).
-# The scanner stops naturally at the checkpoint, so unlimited is bounded by
-# what's actually new since the last successful run.
+# --max-new 0 = unlimited per run. The scanner stops at the DB checkpoint,
+# so the per-run volume is bounded by what's genuinely new since the last
+# successful run. A finite cap caused a permanent backlog when daily uploads
+# exceeded the cap. Postmortem: PR #629.
 ExecStart=/bin/bash -c 'DATABASE_URL=$${DATABASE_URL//@db:/@127.0.0.1:} exec /usr/bin/python3 -u /opt/cr/scripts/auto-import.py --trigger cron --max-new 0'
 StandardOutput=append:/var/log/cr-auto-import.log
 StandardError=append:/var/log/cr-auto-import.log

--- a/deploy/systemd/cr-auto-import.service
+++ b/deploy/systemd/cr-auto-import.service
@@ -18,7 +18,11 @@ EnvironmentFile=/opt/cr/.env
 # rewrite it to 127.0.0.1 (the cr-db container publishes 5432 there).
 # This keeps ONE source of truth for the password while letting both
 # the Rust container and host-side scripts share the file.
-ExecStart=/bin/bash -c 'DATABASE_URL=$${DATABASE_URL//@db:/@127.0.0.1:} exec /usr/bin/python3 -u /opt/cr/scripts/auto-import.py --trigger cron --max-new 50'
+# --max-new 0 = unlimited per run. SK Torrent uploads ~100 new videos/day; a
+# 50/day cap created a permanent backlog (e.g. Euforie S03E03 missing 2026-04-29).
+# The scanner stops naturally at the checkpoint, so unlimited is bounded by
+# what's actually new since the last successful run.
+ExecStart=/bin/bash -c 'DATABASE_URL=$${DATABASE_URL//@db:/@127.0.0.1:} exec /usr/bin/python3 -u /opt/cr/scripts/auto-import.py --trigger cron --max-new 0'
 StandardOutput=append:/var/log/cr-auto-import.log
 StandardError=append:/var/log/cr-auto-import.log
 # systemd tries 1 restart for transient failures (e.g. SK Torrent 502).


### PR DESCRIPTION
<!-- claude-session: 98d65447-0cc0-4c98-a612-a9b5c0699023 -->

## Summary
- Cron `auto-import` previously capped each daily run at 50 new SK Torrent videos. SK Torrent uploads ~100/day, so the checkpoint advanced past the oldest 50 and the remainder was silently dropped. Backlog grew permanently.
- Switch the systemd `ExecStart` to `--max-new 0` (unlimited). The scanner already terminates at the DB checkpoint, so the per-run volume is bounded by what's genuinely new since the previous successful run.

## Why
Users reported missing episodes of existing series (concrete trigger: Euforie S03E03, sktorrent_video_id 60144 uploaded 2026-04-28, never imported). The 50/day cap was the root cause — see the analysis in the commit body.

## Test plan
- [x] Manual run on prod with `--max-new 0` (run #43): scanned 51 new generic videos uncapped, added Euforie S03E03 as episode 34070, plus 9 other episodes and 19 films
- [x] DB confirms: `SELECT * FROM episodes WHERE series_id=757 AND season=3` returns S03E01–E03
- [x] Page `https://ceskarepublika.wiki/serialy-online/euforie/3x3/` renders correctly with multiple SK Torrent sources, 0 console errors/warnings
- [x] Live `/etc/systemd/system/cr-auto-import.service` already updated and `daemon-reload`'d on VPS
- [ ] Tomorrow's 05:00 UTC cron should now drain any new videos in full