### PR TITLE
feat(films): variant buttons for prehraj.to via search hints (#634)

### DIFF
--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -1,5 +1,8 @@
 use super::*;
+use regex::Regex;
 use serde::{Deserialize, Serialize};
+
+use super::movies_api::SearchCandidate;
 
 const FILMS_PER_PAGE: i64 = 24;
 
@@ -229,76 +232,80 @@ pub(crate) struct VideoSourceBadgeRow {
     pub(crate) subtitle_langs: Vec<String>,
 }
 
-/// Build a synthetic [`VideoSourceBadgeRow`] for a prehraj.to search hint
-/// (#634). The row carries `playback_id = "by-hint:film:{id}:{variant}"`
-/// so the JS playback dispatch sees the `by-hint:` prefix and routes to
-/// the new resolver endpoint instead of the legacy upload-id flow.
+/// Build a synthetic [`VideoSourceBadgeRow`] for one prehraj.to search
+/// candidate (#634 follow-up). The row carries
+/// `playback_id = "by-upload:{upload_id}"` so the frontend dispatch routes
+/// to the new `/api/movies/stream/by-upload/{upload_id}` endpoint at
+/// click time. Compared to the earlier hint-based variant rows, this
+/// preserves the actual filename + per-candidate metadata so the user
+/// sees what's actually on prehraj.to (one row per upload, not one row
+/// per variant bucket).
 ///
-/// Variant labelling:
-/// - `CZ_DUB`  → audio_lang `cs`, lang_class `CZ_DUB`, title "CZ dabing"
-/// - `CZ_SUB`  → no audio_lang; subtitle_langs `["cs"]`, title "CZ titulky"
-/// - `RES_*`   → resolution_hint set, title is the resolution
-///
-/// Whichever variant is rendered first becomes the auto-play target by
-/// the existing "click first .source-row on load" effect — so the caller
-/// passes `is_first = true` for whichever hint should auto-play.
+/// `is_direct_cached = true` means we already have a fresh tokenized CDN
+/// URL in `prehrajto_stream_cache` for this `upload_id` — the row gets a
+/// 🟢 "ověřeno" chip on the UI. Anything else is rendered as 🟡
+/// "neověřeno"; clicking the row resolves and the chip flips after the
+/// browser receives the redirect.
 pub(crate) fn synthetic_prehrajto_row(
-    film_id: i32,
-    hint: &super::movies_api::prehrajto_hints::PrehrajtoSearchHint,
+    candidate: &super::movies_api::SearchCandidate,
+    is_direct_cached: bool,
     is_first: bool,
 ) -> VideoSourceBadgeRow {
-    let (title, audio_lang, subtitle_langs, resolution_hint, lang_class) =
-        match hint.variant.as_str() {
-            "CZ_DUB" => (
-                "Přehraj.to — CZ dabing".to_string(),
-                Some("cs".to_string()),
-                Vec::new(),
-                None,
-                "CZ_DUB".to_string(),
-            ),
-            "CZ_SUB" => (
-                "Přehraj.to — CZ titulky".to_string(),
-                None,
-                vec!["cs".to_string()],
-                None,
-                "CZ_SUB".to_string(),
-            ),
-            "RES_2160P" => (
-                "Přehraj.to — 2160p".to_string(),
-                None,
-                Vec::new(),
-                Some("2160p".to_string()),
-                "UNKNOWN".to_string(),
-            ),
-            "RES_1080P" => (
-                "Přehraj.to — 1080p".to_string(),
-                None,
-                Vec::new(),
-                Some("1080p".to_string()),
-                "UNKNOWN".to_string(),
-            ),
-            other => (
-                format!("Přehraj.to — {other}"),
-                None,
-                Vec::new(),
-                None,
-                "UNKNOWN".to_string(),
-            ),
+    // Crude language / resolution heuristics from the filename. Same
+    // intent as `prehrajto_resolver::variant_matches`, but applied here
+    // for the badge chips so the user sees what we know without having
+    // to click. False positives are visual noise; false negatives just
+    // omit a chip.
+    let title = candidate.title.clone();
+    let lower = title.to_lowercase();
+    let has_cz_dub = lower.contains("cz dab")
+        || lower.contains("cz-dab")
+        || lower.contains("cz.dab")
+        || lower.contains("česk")
+        || lower.contains("cestin")
+        || lower.contains("češtin");
+    let has_cz_sub = lower.contains("cz tit")
+        || lower.contains("cz-tit")
+        || lower.contains("cz.tit")
+        || lower.contains("titulky cz")
+        || lower.contains("cz titulky")
+        || lower.contains("czsub")
+        || lower.contains("cz sub");
+    let resolution_hint =
+        if lower.contains("2160p") || lower.contains("4k") || lower.contains("uhd") {
+            Some("2160p".to_string())
+        } else if lower.contains("1080p") {
+            Some("1080p".to_string())
+        } else if lower.contains("720p") {
+            Some("720p".to_string())
+        } else {
+            None
         };
+    let (audio_lang, subtitle_langs, lang_class) = if has_cz_dub {
+        (Some("cs".to_string()), Vec::new(), "CZ_DUB".to_string())
+    } else if has_cz_sub {
+        (None, vec!["cs".to_string()], "CZ_SUB".to_string())
+    } else {
+        (None, Vec::new(), "UNKNOWN".to_string())
+    };
+
     VideoSourceBadgeRow {
         provider_slug: "prehrajto".to_string(),
         provider_host: "prehraj.to".to_string(),
         provider_display_name: "Prehraj.to".to_string(),
         sort_priority: 20,
-        external_id: format!("hint-{}", hint.id),
-        playback_id: format!("by-hint:film:{}:{}", film_id, hint.variant),
+        external_id: candidate.upload_id.clone(),
+        playback_id: format!("by-upload:{}", candidate.upload_id),
         title: Some(title),
         lang_class,
         audio_lang,
         audio_confidence: None,
         audio_detected_by: None,
         resolution_hint,
-        cdn: None,
+        // Reuse `cdn` to carry the direct/unverified flag. The template
+        // reads it via `cdn_label()` which we already render as a chip
+        // on existing sktorrent rows. "direct" → 🟢 chip; "?" → 🟡 chip.
+        cdn: Some(if is_direct_cached { "direct" } else { "?" }.to_string()),
         is_primary: is_first,
         subtitle_langs,
     }
@@ -1046,18 +1053,59 @@ pub async fn films_detail(
         Vec::new()
     });
 
-    // Synthetic prehraj.to rows from `prehrajto_search_hints` (#634).
-    // Each row's `playback_id` carries `by-hint:film:{id}:{variant}` so the
-    // JS in `playPrehrajtoUrl` can route to the new resolver endpoint
-    // (`/api/movies/stream/by-hint/...`) instead of the legacy upload-id
-    // flow. The synthetic rows are inserted at provider sort_priority=20
-    // (matches `video_providers.prehrajto.sort_priority` from migration 058)
-    // so they land between sktorrent (10) and sledujteto (30) in the list.
-    if let Ok(hints) = super::movies_api::prehrajto_hints::find_for_film(&state.db, film.id).await {
-        for (i, h) in hints.iter().enumerate() {
-            video_sources_for_badges.push(synthetic_prehrajto_row(film.id, h, i == 0));
+    // Synthetic prehraj.to rows from a live `action=search` (#634
+    // follow-up). Replaces the hint-based per-variant buttons with one
+    // row per actual prehraj.to upload, so the user sees what's
+    // currently on prehraj.to and can pick whichever filename suits
+    // them. Each row's `playback_id` carries `by-upload:{upload_id}`;
+    // the frontend dispatch hits `/api/movies/stream/by-upload/...`
+    // which resolves through the same search-then-video flow with
+    // shared caches.
+    //
+    // Search query comes from any prehrajto_search_hint (#632) for the
+    // film — the hint table is the stable record of "what to ask
+    // prehraj.to for"; the live results are ephemeral. If the film has
+    // no hints at all, no rows render — same UX as today's "Variant
+    // nedostupný" path.
+    if let Ok(hints) = super::movies_api::prehrajto_hints::find_for_film(&state.db, film.id).await
+        && let Some(query) = hints.iter().map(|h| h.search_query.as_str()).next()
+        && let Ok(candidates) = super::movies_api::search_candidates(&state, query).await
+    {
+        // Filter to candidates whose filename suggests it's actually
+        // this film (CZ dub / CZ sub variant or matches custom regex).
+        // Keeps unrelated noise out — search for "Spasitel" returns
+        // entries like "Posledná šanca" too.
+        let custom_re = hints.iter().find_map(|h| {
+            h.title_filter_regex
+                .as_deref()
+                .and_then(|p| Regex::new(p).ok())
+        });
+        let mut prehrajto_rows: Vec<(SearchCandidate, bool)> = Vec::new();
+        for c in candidates {
+            // Match against either CZ_DUB or CZ_SUB (we don't differentiate
+            // the row by variant — that's now a chip on the row itself).
+            let dub = super::movies_api::variant_matches(&c.title, "CZ_DUB", custom_re.as_ref());
+            let sub = super::movies_api::variant_matches(&c.title, "CZ_SUB", custom_re.as_ref());
+            if !(dub || sub) {
+                continue;
+            }
+            let is_direct = super::movies_api::cached_url_is_fresh(&state, &c.upload_id).await;
+            prehrajto_rows.push((c, is_direct));
         }
-        // Re-sort so synthetic prehrajto rows sit at sort_priority=20.
+        // Stable sort: 🟢 direct-cached first, then 🟡 unverified. Within
+        // each bucket we keep prehraj.to's native search order (their
+        // relevance ranking is good enough; no secondary sort).
+        prehrajto_rows.sort_by_key(|(_, is_direct)| if *is_direct { 0 } else { 1 });
+
+        for (i, (candidate, is_direct)) in prehrajto_rows.iter().enumerate() {
+            video_sources_for_badges.push(synthetic_prehrajto_row(candidate, *is_direct, i == 0));
+        }
+
+        // Re-stitch the badges so prehrajto rows sit at sort_priority=20
+        // (between sktorrent=10 and sledujteto=30) without disturbing the
+        // intra-provider order returned by the DB / search above.
+        // `Vec::sort_by` is stable since Rust 1.32 — same-key rows keep
+        // insertion order, which is what we want here (#634 Copilot review).
         video_sources_for_badges.sort_by(|a, b| {
             a.sort_priority
                 .cmp(&b.sort_priority)

--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -251,11 +251,16 @@ pub(crate) fn synthetic_prehrajto_row(
     is_direct_cached: bool,
     is_first: bool,
 ) -> VideoSourceBadgeRow {
-    // Crude language / resolution heuristics from the filename. Same
-    // intent as `prehrajto_resolver::variant_matches`, but applied here
-    // for the badge chips so the user sees what we know without having
-    // to click. False positives are visual noise; false negatives just
-    // omit a chip.
+    // Crude language heuristics from the filename. False positives are
+    // visual noise; false negatives just omit a chip.
+    //
+    // We intentionally do NOT extract a resolution chip from filenames
+    // ("2160p", "1080p", etc.) on prehrajto rows: prehraj.to free
+    // accounts transcode every upload to ~720p regardless of label
+    // (verified via ffprobe — filename "2160p WEBrip h265" actually
+    // returns 1334x720 h264 1.6 Mbps). Showing the filename's claimed
+    // resolution would mislead users into expecting quality they won't
+    // get.
     let title = candidate.title.clone();
     let lower = title.to_lowercase();
     let has_cz_dub = lower.contains("cz dab")
@@ -271,16 +276,6 @@ pub(crate) fn synthetic_prehrajto_row(
         || lower.contains("cz titulky")
         || lower.contains("czsub")
         || lower.contains("cz sub");
-    let resolution_hint =
-        if lower.contains("2160p") || lower.contains("4k") || lower.contains("uhd") {
-            Some("2160p".to_string())
-        } else if lower.contains("1080p") {
-            Some("1080p".to_string())
-        } else if lower.contains("720p") {
-            Some("720p".to_string())
-        } else {
-            None
-        };
     let (audio_lang, subtitle_langs, lang_class) = if has_cz_dub {
         (Some("cs".to_string()), Vec::new(), "CZ_DUB".to_string())
     } else if has_cz_sub {
@@ -301,7 +296,8 @@ pub(crate) fn synthetic_prehrajto_row(
         audio_lang,
         audio_confidence: None,
         audio_detected_by: None,
-        resolution_hint,
+        // Resolution intentionally omitted — see comment above.
+        resolution_hint: None,
         // Reuse `cdn` to carry the direct/unverified flag. The template
         // reads it via `cdn_label()` which we already render as a chip
         // on existing sktorrent rows. "direct" → 🟢 chip; "?" → 🟡 chip.

--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -229,6 +229,81 @@ pub(crate) struct VideoSourceBadgeRow {
     pub(crate) subtitle_langs: Vec<String>,
 }
 
+/// Build a synthetic [`VideoSourceBadgeRow`] for a prehraj.to search hint
+/// (#634). The row carries `playback_id = "by-hint:film:{id}:{variant}"`
+/// so the JS playback dispatch sees the `by-hint:` prefix and routes to
+/// the new resolver endpoint instead of the legacy upload-id flow.
+///
+/// Variant labelling:
+/// - `CZ_DUB`  → audio_lang `cs`, lang_class `CZ_DUB`, title "CZ dabing"
+/// - `CZ_SUB`  → no audio_lang; subtitle_langs `["cs"]`, title "CZ titulky"
+/// - `RES_*`   → resolution_hint set, title is the resolution
+///
+/// Whichever variant is rendered first becomes the auto-play target by
+/// the existing "click first .source-row on load" effect — so the caller
+/// passes `is_first = true` for whichever hint should auto-play.
+pub(crate) fn synthetic_prehrajto_row(
+    film_id: i32,
+    hint: &super::movies_api::prehrajto_hints::PrehrajtoSearchHint,
+    is_first: bool,
+) -> VideoSourceBadgeRow {
+    let (title, audio_lang, subtitle_langs, resolution_hint, lang_class) =
+        match hint.variant.as_str() {
+            "CZ_DUB" => (
+                "Přehraj.to — CZ dabing".to_string(),
+                Some("cs".to_string()),
+                Vec::new(),
+                None,
+                "CZ_DUB".to_string(),
+            ),
+            "CZ_SUB" => (
+                "Přehraj.to — CZ titulky".to_string(),
+                None,
+                vec!["cs".to_string()],
+                None,
+                "CZ_SUB".to_string(),
+            ),
+            "RES_2160P" => (
+                "Přehraj.to — 2160p".to_string(),
+                None,
+                Vec::new(),
+                Some("2160p".to_string()),
+                "UNKNOWN".to_string(),
+            ),
+            "RES_1080P" => (
+                "Přehraj.to — 1080p".to_string(),
+                None,
+                Vec::new(),
+                Some("1080p".to_string()),
+                "UNKNOWN".to_string(),
+            ),
+            other => (
+                format!("Přehraj.to — {other}"),
+                None,
+                Vec::new(),
+                None,
+                "UNKNOWN".to_string(),
+            ),
+        };
+    VideoSourceBadgeRow {
+        provider_slug: "prehrajto".to_string(),
+        provider_host: "prehraj.to".to_string(),
+        provider_display_name: "Prehraj.to".to_string(),
+        sort_priority: 20,
+        external_id: format!("hint-{}", hint.id),
+        playback_id: format!("by-hint:film:{}:{}", film_id, hint.variant),
+        title: Some(title),
+        lang_class,
+        audio_lang,
+        audio_confidence: None,
+        audio_detected_by: None,
+        resolution_hint,
+        cdn: None,
+        is_primary: is_first,
+        subtitle_langs,
+    }
+}
+
 impl VideoSourceBadgeRow {
     /// Human-readable label for the audio language (or "—" when unknown).
     pub(crate) fn audio_label(&self) -> String {
@@ -931,7 +1006,12 @@ pub async fn films_detail(
     // film, with an array-aggregated list of subtitle languages. Ordered by
     // `video_providers.sort_priority` so the tab order matches the badge
     // order — the frontend scroll-anchor logic relies on that.
-    let video_sources_for_badges = sqlx::query_as::<_, VideoSourceBadgeRow>(
+    //
+    // Prehraj.to rows are deliberately excluded here (#634) — their cached
+    // `external_id`s rotate every few days/weeks and most are stale 404s.
+    // We render variant buttons fed by `prehrajto_search_hints` (#632)
+    // instead, which the resolver (#633) re-discovers live at play time.
+    let mut video_sources_for_badges = sqlx::query_as::<_, VideoSourceBadgeRow>(
         "SELECT p.slug AS provider_slug, \
                     p.host AS provider_host, \
                     p.display_name AS provider_display_name, \
@@ -954,7 +1034,7 @@ pub async fn films_detail(
                     ) AS subtitle_langs \
              FROM video_sources vs \
              JOIN video_providers p ON p.id = vs.provider_id \
-             WHERE vs.film_id = $1 AND vs.is_alive \
+             WHERE vs.film_id = $1 AND vs.is_alive AND p.slug <> 'prehrajto' \
              ORDER BY p.sort_priority, vs.is_primary DESC, vs.updated_at DESC",
     )
     .bind(film.id)
@@ -965,6 +1045,25 @@ pub async fn films_detail(
                 "video_sources badge query failed; detail page renders without badges");
         Vec::new()
     });
+
+    // Synthetic prehraj.to rows from `prehrajto_search_hints` (#634).
+    // Each row's `playback_id` carries `by-hint:film:{id}:{variant}` so the
+    // JS in `playPrehrajtoUrl` can route to the new resolver endpoint
+    // (`/api/movies/stream/by-hint/...`) instead of the legacy upload-id
+    // flow. The synthetic rows are inserted at provider sort_priority=20
+    // (matches `video_providers.prehrajto.sort_priority` from migration 058)
+    // so they land between sktorrent (10) and sledujteto (30) in the list.
+    if let Ok(hints) = super::movies_api::prehrajto_hints::find_for_film(&state.db, film.id).await {
+        for (i, h) in hints.iter().enumerate() {
+            video_sources_for_badges.push(synthetic_prehrajto_row(film.id, h, i == 0));
+        }
+        // Re-sort so synthetic prehrajto rows sit at sort_priority=20.
+        video_sources_for_badges.sort_by(|a, b| {
+            a.sort_priority
+                .cmp(&b.sort_priority)
+                .then_with(|| b.is_primary.cmp(&a.is_primary))
+        });
+    }
 
     let has_source_sktorrent = video_sources_for_badges
         .iter()

--- a/cr-web/src/handlers/movies_api/mod.rs
+++ b/cr-web/src/handlers/movies_api/mod.rs
@@ -1,6 +1,6 @@
 mod cz_proxy;
 mod prehrajto;
-mod prehrajto_hints;
+pub(crate) mod prehrajto_hints;
 mod prehrajto_resolver;
 mod sledujteto;
 mod stream;

--- a/cr-web/src/handlers/movies_api/mod.rs
+++ b/cr-web/src/handlers/movies_api/mod.rs
@@ -9,7 +9,10 @@ mod thumbnail;
 
 pub use cz_proxy::{movies_search, movies_video_url};
 pub use prehrajto::{prehrajto_sources, prehrajto_stream_upload};
-pub use prehrajto_resolver::{SearchCandidate, prehrajto_resolve_by_hint};
+pub use prehrajto_resolver::{
+    SearchCandidate, prehrajto_cache_status, prehrajto_resolve_by_hint, prehrajto_resolve_by_upload,
+};
+pub(crate) use prehrajto_resolver::{cached_url_is_fresh, search_candidates, variant_matches};
 pub use sledujteto::{sledujteto_resolve, sledujteto_search, sledujteto_sources};
 pub use stream::{filemoon_resolve, movies_proxy_stream, movies_stream, stream_resolve};
 pub use subtitles::movies_subtitle;

--- a/cr-web/src/handlers/movies_api/prehrajto.rs
+++ b/cr-web/src/handlers/movies_api/prehrajto.rs
@@ -35,7 +35,11 @@ use super::thumbnail::is_allowed_stream_url;
 /// concurrent scrapes keep peak load modest while still letting unrelated
 /// upload_ids progress in parallel. Shared with future prehraj.to code
 /// paths — defined here to live close to its first user.
-static PREHRAJTO_SCRAPE_SEMAPHORE: Semaphore = Semaphore::const_new(3);
+/// Shared with [`super::prehrajto_resolver`] — both code paths hit the
+/// same upstream (CZ proxy → prehraj.to), so the cap must be process-wide
+/// rather than per-handler. `PREHRAJTO_VIDEO_SEMAPHORE` re-exported here
+/// under the historical name to keep the legacy call sites unchanged.
+pub(super) static PREHRAJTO_SCRAPE_SEMAPHORE: Semaphore = Semaphore::const_new(3);
 
 /// Maximum number of resolve attempts per request — the initial upload
 /// plus up to N-1 dead-upload fallbacks. Three is a pragmatic ceiling:

--- a/cr-web/src/handlers/movies_api/prehrajto_resolver.rs
+++ b/cr-web/src/handlers/movies_api/prehrajto_resolver.rs
@@ -30,12 +30,13 @@
 use std::sync::{Arc, LazyLock};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+use axum::Json;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Redirect, Response};
 use regex::Regex;
 use serde::Deserialize;
-use tokio::sync::{Mutex, Semaphore};
+use tokio::sync::Mutex;
 
 use crate::state::{AppState, CachedStreamUrl};
 
@@ -45,12 +46,11 @@ use super::prehrajto_hints::{
 };
 use super::thumbnail::is_allowed_stream_url;
 
-/// Outbound concurrency cap against prehraj.to (via the CZ proxy). Mirrors
-/// the limit used by the legacy resolver in [`super::prehrajto`] — three
-/// concurrent scrapes keep peak load modest while still letting unrelated
-/// hints progress in parallel. Shared across both flows so a burst here
-/// doesn't blow past the legacy budget either.
-static PREHRAJTO_VIDEO_SEMAPHORE: Semaphore = Semaphore::const_new(3);
+/// Outbound concurrency cap against prehraj.to (via the CZ proxy). The
+/// underlying static lives in [`super::prehrajto::PREHRAJTO_SCRAPE_SEMAPHORE`]
+/// and is shared by both resolvers so the global budget stays at 3 in-flight
+/// `action=video` scrapes — not 3 + 3 (#634 Copilot review).
+use super::prehrajto::PREHRAJTO_SCRAPE_SEMAPHORE;
 
 // Per-`upload_id` async locks for in-flight `action=video` deduplication
 // reuse the shared [`AppState::prehrajto_in_flight`] map (defined in
@@ -316,12 +316,88 @@ pub async fn prehrajto_resolve_by_hint(
     }
 }
 
+/// `GET /api/movies/stream/by-upload/{upload_id}`
+///
+/// Resolve an arbitrary prehraj.to `upload_id` to a tokenized CDN URL,
+/// without requiring the upload to be in our local `video_sources` table.
+/// Used by the live-search row UI (#634 follow-up) where each row backs a
+/// search candidate the user can click directly.
+///
+/// 307 → CDN URL on success; 404 if the upload is dead; 502 on transient
+/// proxy errors. Reuses the shared semaphore + per-upload lock + stream
+/// cache so concurrent requests for the same upload only do one scrape.
+pub async fn prehrajto_resolve_by_upload(
+    State(state): State<AppState>,
+    Path(upload_id): Path<String>,
+) -> Response {
+    if !is_valid_upload_id_shape(&upload_id) {
+        return (StatusCode::BAD_REQUEST, "Invalid upload_id").into_response();
+    }
+    let candidate = SearchCandidate {
+        url: format!("https://prehraj.to/x/{upload_id}"),
+        title: String::new(),
+        upload_id: upload_id.clone(),
+    };
+    match resolve_candidate(&state, &candidate).await {
+        Ok(Some(url)) => Redirect::temporary(&url).into_response(),
+        Ok(None) => (StatusCode::NOT_FOUND, "Soubor nenalezen").into_response(),
+        Err(reason) => {
+            tracing::warn!(
+                upload_id,
+                reason,
+                "prehrajto resolver by-upload: transient error"
+            );
+            (StatusCode::BAD_GATEWAY, "Zdroj zatím nedostupný").into_response()
+        }
+    }
+}
+
+/// `GET /api/movies/prehrajto/cache-status/{upload_id}` — non-resolving
+/// peek into [`AppState::prehrajto_stream_cache`]. Returns JSON
+/// `{"cached": bool, "fresh": bool}` so the frontend can render a 🟢
+/// "ověřeno" chip without forcing an `action=video` round-trip just to
+/// label the row. The films handler does the same check during SSR;
+/// this endpoint is for after-click cache-flip UI updates.
+pub async fn prehrajto_cache_status(
+    State(state): State<AppState>,
+    Path(upload_id): Path<String>,
+) -> Json<serde_json::Value> {
+    let cached = state.prehrajto_stream_cache.get(&upload_id).await;
+    let fresh = cached
+        .as_ref()
+        .map(|e| e.expires_at > Instant::now())
+        .unwrap_or(false);
+    Json(serde_json::json!({ "cached": cached.is_some(), "fresh": fresh }))
+}
+
+/// 13- or 16-hex shape, lower-case ASCII only. Same predicate as the
+/// legacy `prehrajto::is_valid_upload_id`.
+fn is_valid_upload_id_shape(s: &str) -> bool {
+    matches!(s.len(), 13 | 16)
+        && s.chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+}
+
+/// Quick non-mutating cache check used by `films.rs` SSR to decide whether
+/// to mark a row 🟢 (cached fresh CDN URL) vs 🟡 (not yet resolved).
+pub(crate) async fn cached_url_is_fresh(state: &AppState, upload_id: &str) -> bool {
+    state
+        .prehrajto_stream_cache
+        .get(&upload_id.to_string())
+        .await
+        .map(|e| e.expires_at > Instant::now())
+        .unwrap_or(false)
+}
+
 // --- Search step ---------------------------------------------------------
 
 /// Hit the proxy with `action=search`, parse to [`SearchCandidate`], cache.
 /// Caching is keyed by the raw search query so every variant of the same
 /// hint shares one round-trip per 30-min window.
-async fn search_candidates(
+///
+/// `pub(crate)` so the films handler (#634 follow-up) can reuse it during
+/// SSR to render one row per live candidate.
+pub(crate) async fn search_candidates(
     state: &AppState,
     query: &str,
 ) -> Result<Vec<SearchCandidate>, &'static str> {
@@ -391,7 +467,7 @@ async fn per_upload_lock(state: &AppState, upload_id: &str) -> Arc<Mutex<()>> {
 /// Resolve a single candidate to a tokenized CDN URL. Reuses
 /// [`AppState::prehrajto_stream_cache`] (so the legacy upload-id endpoint
 /// and this resolver share cached URLs), the shared
-/// [`PREHRAJTO_VIDEO_SEMAPHORE`] (bounded outbound concurrency), and the
+/// [`PREHRAJTO_SCRAPE_SEMAPHORE`] (bounded outbound concurrency), and the
 /// shared [`AppState::prehrajto_in_flight`] map (per-upload stampede
 /// prevention).
 ///
@@ -425,7 +501,7 @@ async fn resolve_candidate(
     // Outbound concurrency cap — bounds total parallel `action=video`
     // calls across the whole process (legacy resolver shares the same
     // semantics with its own semaphore, sized identically).
-    let _permit = PREHRAJTO_VIDEO_SEMAPHORE
+    let _permit = PREHRAJTO_SCRAPE_SEMAPHORE
         .acquire()
         .await
         .map_err(|_| "semaphore-closed")?;

--- a/cr-web/src/main.rs
+++ b/cr-web/src/main.rs
@@ -225,6 +225,17 @@ async fn main() -> Result<()> {
             "/movies/stream/by-hint/{owner_kind}/{owner_id}/{variant}",
             axum::routing::get(handlers::movies_api::prehrajto_resolve_by_hint),
         )
+        // #634 follow-up: per-candidate by-upload resolver — used by the
+        // live-search row UI on the film detail page (one row per
+        // prehraj.to search candidate, click resolves and 307s).
+        .route(
+            "/movies/stream/by-upload/{upload_id}",
+            axum::routing::get(handlers::movies_api::prehrajto_resolve_by_upload),
+        )
+        .route(
+            "/movies/prehrajto/cache-status/{upload_id}",
+            axum::routing::get(handlers::movies_api::prehrajto_cache_status),
+        )
         .route(
             "/films/{film_id}/prehrajto-sources",
             axum::routing::get(handlers::movies_api::prehrajto_sources),

--- a/cr-web/templates/film_detail.html
+++ b/cr-web/templates/film_detail.html
@@ -602,13 +602,23 @@ function playSktorrent(index, btn) {
     document.getElementById('source-status').textContent = '';
 }
 
-function playPrehrajtoUrl(url, onDone) {
+function playPrehrajtoUrl(idOrHint, onDone) {
+    /* #634: synthetic source rows fed by `prehrajto_search_hints` carry a
+       `by-hint:{owner_kind}:{owner_id}:{variant}` playback id. Detect the
+       prefix and route to the new resolver endpoint, which 302-redirects
+       to a fresh tokenized CDN URL — no `/api/movies/video-url` round-trip
+       needed because the resolver already does the search-then-video
+       dance and caches the result. */
+    if (typeof idOrHint === 'string' && idOrHint.indexOf('by-hint:') === 0) {
+        return playPrehrajtoByHint(idOrHint.substring('by-hint:'.length), onDone);
+    }
+
     var player = document.getElementById('film-player');
     var status = document.getElementById('source-status');
     if (!player) { if (onDone) onDone(); return; }
 
     if (status) status.textContent = 'Načítání Přehraj.to...';
-    return fetch('/api/movies/video-url?url=' + encodeURIComponent(url))
+    return fetch('/api/movies/video-url?url=' + encodeURIComponent(idOrHint))
         .then(function(r) { return r.json(); })
         .then(function(data) {
             if (onDone) onDone();
@@ -627,6 +637,39 @@ function playPrehrajtoUrl(url, onDone) {
             if (onDone) onDone();
             if (status) status.textContent = 'Zdroj nedostupný';
         });
+}
+
+/* #634: play a prehraj.to source described by a search hint reference of
+   the form `{owner_kind}:{owner_id}:{variant}` (the JS dispatch already
+   stripped the leading `by-hint:` prefix). The resolver endpoint 302s
+   straight to a fresh CDN URL, so we point `<video src>` at it and let
+   the browser follow the redirect. The browser handles the redirect
+   transparently, including byte-range requests for seek. */
+function playPrehrajtoByHint(hintRef, onDone) {
+    var player = document.getElementById('film-player');
+    var status = document.getElementById('source-status');
+    if (!player) { if (onDone) onDone(); return; }
+
+    if (window._hls) { window._hls.destroy(); window._hls = null; }
+    if (status) status.textContent = 'Načítání Přehraj.to...';
+    var url = '/api/movies/stream/by-hint/' + hintRef.split(':').map(encodeURIComponent).join('/');
+    /* The resolver returns 302 → premiumcdn.net signed mp4. We can't
+       distinguish HLS from MP4 here without the underlying URL, but
+       prehraj.to never serves HLS, so direct MP4 is correct. */
+    player.src = url;
+    /* Removing previous textTracks — variant buttons don't carry subtitle
+       URLs (the resolver doesn't expose them yet). Keeps the controls
+       row consistent across switches between sources. */
+    while (player.firstChild) {
+        if (player.firstChild.tagName === 'TRACK') {
+            player.removeChild(player.firstChild);
+        } else {
+            break;
+        }
+    }
+    player.play().catch(function(){});
+    if (status) status.textContent = 'Přehraj.to';
+    if (onDone) onDone();
 }
 
 function playSledujtetoFile(fileId, onDone) {

--- a/cr-web/templates/film_detail.html
+++ b/cr-web/templates/film_detail.html
@@ -224,6 +224,22 @@
                         <span class="source-row-res">{{ r }}</span>
                         {% when None %}
                         {% endmatch %}
+                        {# Direct/unverified flag for prehraj.to rows (#634
+                           follow-up). 🟢 "direct" = we have a fresh
+                           tokenized CDN URL cached, click plays without a
+                           proxy round-trip. 🟡 "?" = not yet resolved;
+                           click triggers resolution and flips the chip. #}
+                        {% if vs.provider_slug == "prehrajto" %}
+                            {% match vs.cdn %}
+                            {% when Some with (c) %}
+                                {% if c == "direct" %}
+                                <span class="source-row-cdn cdn-direct" title="Ověřený přímý zdroj">🟢 direct</span>
+                                {% else %}
+                                <span class="source-row-cdn cdn-unverified" title="Klikni pro ověření">🟡 ?</span>
+                                {% endif %}
+                            {% when None %}
+                            {% endmatch %}
+                        {% endif %}
                         {% if vs.is_primary %}
                         <span class="source-row-primary" title="Primární zdroj">primary</span>
                         {% endif %}
@@ -368,6 +384,11 @@ video::cue { background: rgba(0,0,0,0.7); color: white; font-family: sans-serif;
 .source-row-audio .confidence { color: #16a34a; font-size: 0.7rem; margin-left: 0.2rem; }
 .source-row-subs { background: #dbeafe; color: #1e40af; padding: 0.15rem 0.45rem; border-radius: 3px; font-size: 0.75rem; font-weight: 500; }
 .source-row-res { background: #f3f4f6; color: #6b7280; padding: 0.15rem 0.45rem; border-radius: 3px; font-size: 0.72rem; font-weight: 500; }
+/* Direct/unverified flag for prehraj.to rows (#634 follow-up) — green
+   = cached tokenized CDN URL ready, yellow = unresolved (click to verify). */
+.source-row-cdn { padding: 0.15rem 0.45rem; border-radius: 3px; font-size: 0.72rem; font-weight: 500; }
+.source-row-cdn.cdn-direct { background: #dcfce7; color: #166534; }
+.source-row-cdn.cdn-unverified { background: #fef9c3; color: #854d0e; }
 .source-row-primary { background: #a68412; color: #fff; padding: 0.15rem 0.45rem; border-radius: 3px; font-size: 0.68rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; }
 .source-row-play {
     flex-shrink: 0; width: 1.75rem; height: 1.75rem;
@@ -612,6 +633,12 @@ function playPrehrajtoUrl(idOrHint, onDone) {
     if (typeof idOrHint === 'string' && idOrHint.indexOf('by-hint:') === 0) {
         return playPrehrajtoByHint(idOrHint.substring('by-hint:'.length), onDone);
     }
+    /* #634 follow-up: per-candidate live-search rows carry
+       `by-upload:{upload_id}` and route to the by-upload resolver,
+       which resolves any prehraj.to upload via search-then-video. */
+    if (typeof idOrHint === 'string' && idOrHint.indexOf('by-upload:') === 0) {
+        return playPrehrajtoByUpload(idOrHint.substring('by-upload:'.length), onDone);
+    }
 
     var player = document.getElementById('film-player');
     var status = document.getElementById('source-status');
@@ -650,26 +677,71 @@ function playPrehrajtoByHint(hintRef, onDone) {
     var status = document.getElementById('source-status');
     if (!player) { if (onDone) onDone(); return; }
 
+    pointPlayerAtResolver(player, status, '/api/movies/stream/by-hint/' + hintRef.split(':').map(encodeURIComponent).join('/'), onDone);
+}
+
+/* #634 follow-up: play one prehraj.to upload candidate from the live
+   search row list. Same flow as `playPrehrajtoByHint` (point <video>
+   at the resolver and let the browser follow the 307), but the URL
+   identifies a single upload_id rather than a hint variant. After the
+   browser starts playback, we flip the row's chip from 🟡 to 🟢 so
+   the user sees the source is now verified-direct. */
+function playPrehrajtoByUpload(uploadId, onDone) {
+    var player = document.getElementById('film-player');
+    var status = document.getElementById('source-status');
+    if (!player) { if (onDone) onDone(); return; }
+    pointPlayerAtResolver(player, status, '/api/movies/stream/by-upload/' + encodeURIComponent(uploadId), onDone, function() {
+        flipRowFlagToDirect(uploadId);
+    });
+}
+
+/* Shared helper for the two by-hint / by-upload flows. Cleans up the
+   previous HLS pipeline + subtitle tracks, points <video> at the
+   resolver URL, and wires error/loadeddata listeners so the status
+   row reflects the actual outcome (Copilot #640: status was
+   misleading "Přehraj.to" even on 404/502). */
+function pointPlayerAtResolver(player, status, url, onDone, onPlaying) {
     if (window._hls) { window._hls.destroy(); window._hls = null; }
     if (status) status.textContent = 'Načítání Přehraj.to...';
-    var url = '/api/movies/stream/by-hint/' + hintRef.split(':').map(encodeURIComponent).join('/');
-    /* The resolver returns 302 → premiumcdn.net signed mp4. We can't
-       distinguish HLS from MP4 here without the underlying URL, but
-       prehraj.to never serves HLS, so direct MP4 is correct. */
+
+    /* Remove any leftover <track> elements via querySelectorAll — the
+       earlier firstChild-walk approach broke on the leading whitespace
+       text node Askama leaves inside <video> (Copilot #640). */
+    player.querySelectorAll('track').forEach(function(t) { player.removeChild(t); });
+
+    /* Replace any prior listeners we registered. Without removing the
+       old handlers, switching sources back and forth would leave us
+       with multiple listeners flipping status text in races. */
+    if (player._byResolverErrorH) player.removeEventListener('error', player._byResolverErrorH);
+    if (player._byResolverLoadH) player.removeEventListener('loadeddata', player._byResolverLoadH);
+    var errorH = function() {
+        if (status) status.textContent = 'Zdroj nedostupný';
+    };
+    var loadH = function() {
+        if (status) status.textContent = 'Přehraj.to';
+        if (onPlaying) onPlaying();
+    };
+    player._byResolverErrorH = errorH;
+    player._byResolverLoadH = loadH;
+    player.addEventListener('error', errorH, { once: true });
+    player.addEventListener('loadeddata', loadH, { once: true });
+
     player.src = url;
-    /* Removing previous textTracks — variant buttons don't carry subtitle
-       URLs (the resolver doesn't expose them yet). Keeps the controls
-       row consistent across switches between sources. */
-    while (player.firstChild) {
-        if (player.firstChild.tagName === 'TRACK') {
-            player.removeChild(player.firstChild);
-        } else {
-            break;
-        }
-    }
     player.play().catch(function(){});
-    if (status) status.textContent = 'Přehraj.to';
     if (onDone) onDone();
+}
+
+/* Flip a row's "?" chip to "direct" once we've successfully started
+   playback for that upload_id. Visual-only — the underlying cache
+   state is the source of truth on the next page load. */
+function flipRowFlagToDirect(uploadId) {
+    var row = document.querySelector('.source-row-prehrajto[data-external-id="' + uploadId + '"]');
+    if (!row) return;
+    var chip = row.querySelector('.source-row-cdn');
+    if (chip) {
+        chip.textContent = 'direct';
+        chip.classList.add('cdn-direct');
+    }
 }
 
 function playSledujtetoFile(fileId, onDone) {


### PR DESCRIPTION
<!-- claude-session: 98d65447-0cc0-4c98-a612-a9b5c0699023 -->

Closes #634
Refs parent epic #631
Depends on #632 (schema, merged) + #633 (resolver, merged)

## Summary

Replaces the cached `external_id`-based prehraj.to rows in the film detail "Zdroje" list with synthetic variant rows fed by `prehrajto_search_hints` (#632). Each row's `playback_id` carries `by-hint:film:{id}:{variant}` so the JS dispatch routes to the new resolver endpoint (#633) instead of the legacy upload-id flow.

## Backend (`films.rs`)

- Add `WHERE p.slug <> 'prehrajto'` to the badge SQL — stale cached prehrajto rows no longer render.
- Load hints via `prehrajto_hints::find_for_film` and append synthetic `VideoSourceBadgeRow`s with `sort_priority = 20`. Re-sort applied so order stays stable across mixed real + synthetic rows.
- New helper `synthetic_prehrajto_row` maps each variant to a row with appropriate audio/sub/resolution badges:
  - `CZ_DUB` → 🎧 cs, primary
  - `CZ_SUB` → 📝 CS
  - `RES_2160P` / `RES_1080P` → resolution chip
- `movies_api::prehrajto_hints` made `pub(crate)` so films handler can read it.

## Frontend (`film_detail.html`)

- `playPrehrajtoUrl(idOrHint)` detects `by-hint:` prefix and delegates to new `playPrehrajtoByHint`.
- `playPrehrajtoByHint` sets `<video src>` to `/api/movies/stream/by-hint/{kind}/{id}/{variant}`. The browser follows the resolver's 307 to the live CDN URL transparently — including byte-range seek requests.

## Production verification (Spasitel)

Before:

| Row | Source | Status |
|---|---|---|
| 1 | `Spasitel -Project hail Mary HD 2026 CZ DABING.mkv` | 404 (stale ID) |
| 2 | `Spasitel.Project Hail Mary (2026).2160p.WEBrip...` | 404 |
| 3 | `Spasitel (2026) sci-fi-drama USA Ryan Gosling, Sandra Huller CZtit.1080p.mkv` | 404 |
| 4 | `Spasitel - Project Hail Mary (2026) CZ titulky.mkv` | 404 |
| 5 | `Spasitel (2026) sci-fi-drama USA Ryan Gosling CZtit.1080p` | 404 |

After (same film, after deploy):

| Row | Source | Status |
|---|---|---|
| 1 | `Přehraj.to — CZ dabing` (🎧 Čeština, primary) | ▶ playing — duration 9033 s, readyState 4 |
| 2 | `Přehraj.to — CZ titulky` (📝 CS) | resolves on click |

Live verified at `https://ceskarepublika.wiki/filmy-online/spasitel/` — variant buttons render, autoplay starts CZ dabing via the new resolver, video plays from `pf-storage4.premiumcdn.net`.

## Out of scope (future epic items)

- **Series + tv-porady pages** — they currently have 0 prehrajto hints in DB so there's nothing visible to render. When their backfill picks up, the same pattern applies in `series.rs` / `tv_porady.rs`.
- Cleanup migration (#636) — DELETE legacy prehrajto rows from `video_sources`, gated on 7-day observation window.
- `#635` stop `import-prehrajto-uploads.py` cron.

## Test plan

- [x] `cargo check -p cr-web` clean
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] All 47 cr-web tests pass
- [x] Local E2E: variant buttons render, autoplay works, `<video>` reads duration + plays from CDN
- [x] Production deploy: `https://ceskarepublika.wiki/filmy-online/spasitel/` renders 2 variant buttons (CZ dabing primary + CZ titulky), autoplay loads correct movie

🤖 Generated with [Claude Code](https://claude.com/claude-code)