### PR TITLE
feat(prehrajto): cron wrapper + ops README for periodic sitemap sync (#645)

### DIFF
--- a/scripts/PREHRAJTO_SYNC_README.md
+++ b/scripts/PREHRAJTO_SYNC_README.md
@@ -1,0 +1,114 @@
+# Prehraj.to sitemap sync — operations guide
+
+Runs the prehraj.to sitemap importer on a periodic schedule so DB stays
+close to live. Replaces the search-then-video flow that today's epic #631
+attempted (see #642 for the pivot reversal).
+
+## Components
+
+- `scripts/cron-prehrajto-sync.sh` — wrapper that downloads sitemap files
+  and invokes the importer.
+- `scripts/import-prehrajto-uploads.py` — actual import logic (#644 added
+  the mark-dead pass that flips rotated upload_ids to `is_alive=FALSE`).
+
+## Modes
+
+| Mode | When | What it does |
+|---|---|---|
+| `full` | daily 03:00 UTC | Downloads all 487 sub-sitemaps, runs importer with mark-dead. Authoritative is_alive snapshot. |
+| `incremental` | every 4h (00, 04, 08, 12, 16, 20 UTC) | HEADs each sub-sitemap, downloads only the ones whose ETag changed, runs importer with `--no-mark-dead` (partial coverage would mis-flag rows). |
+
+## Required environment
+
+```bash
+DATABASE_URL=postgres://cr:cr_secret@localhost:5432/cr
+MATCHES_CSV=/opt/cr/data/prehrajto-matches.csv
+```
+
+## Optional environment (with defaults)
+
+```bash
+SITEMAP_DIR=/var/cache/cr/prehrajto-sitemap
+ETAG_DIR=/var/cache/cr/prehrajto-sitemap/etags
+LOG_FILE=/var/log/cr/prehrajto-sync.log
+IMPORTER=/opt/cr/scripts/import-prehrajto-uploads.py
+```
+
+## Crontab template
+
+Install with `sudo crontab -u root -e`:
+
+```cron
+# Prehraj.to sitemap sync (#642 / #645)
+DATABASE_URL=postgres://cr:cr_secret@127.0.0.1:5432/cr
+MATCHES_CSV=/opt/cr/data/prehrajto-matches.csv
+LOG_FILE=/var/log/cr/prehrajto-sync.log
+
+# Daily full sync at 03:00 UTC — authoritative mark-dead snapshot
+0 3 * * * /opt/cr/scripts/cron-prehrajto-sync.sh full
+
+# Incremental check every 4h (only ETag-changed sub-sitemaps)
+0 0,4,8,12,16,20 * * * /opt/cr/scripts/cron-prehrajto-sync.sh incremental
+```
+
+## Setup checklist for prod VPS
+
+```bash
+# 1. Copy scripts
+sudo mkdir -p /opt/cr/scripts /opt/cr/data /var/cache/cr/prehrajto-sitemap /var/log/cr
+sudo cp scripts/cron-prehrajto-sync.sh \
+       scripts/import-prehrajto-uploads.py \
+       scripts/video_sources_helper.py \
+       /opt/cr/scripts/
+sudo chmod +x /opt/cr/scripts/cron-prehrajto-sync.sh
+
+# 2. Place the matches CSV (built once via the pilot pipeline)
+sudo cp /tmp/prehrajto-pilot/matches-full.csv /opt/cr/data/prehrajto-matches.csv
+
+# 3. Install crontab (see above)
+sudo crontab -e
+
+# 4. Smoke-test full mode manually, watch the log tail
+sudo /opt/cr/scripts/cron-prehrajto-sync.sh full
+sudo tail -f /var/log/cr/prehrajto-sync.log
+
+# 5. Logrotate config (optional)
+cat <<'EOF' | sudo tee /etc/logrotate.d/cr-prehrajto-sync
+/var/log/cr/prehrajto-sync.log {
+    weekly
+    rotate 4
+    compress
+    missingok
+    notifempty
+    create 0640 root adm
+}
+EOF
+```
+
+## Expected first-run timing
+
+| Mode | Cold | Warm |
+|---|---|---|
+| `full` | 15-30 min (downloads ~15 GB, parses ~9.6M URLs, batched UPSERTs) | 8-15 min if sitemap dir already populated |
+| `incremental` | 1-5 min (only ETag-changed sub-sitemaps + per-film mark-dead skipped) | 30 s if no sitemaps changed |
+
+## Monitoring
+
+- `tail -f /var/log/cr/prehrajto-sync.log` — live progress.
+- After 24h: `SELECT COUNT(*) FILTER (WHERE is_alive) FROM video_sources WHERE provider_id = (SELECT id FROM video_providers WHERE slug='prehrajto');`
+  should be in the millions and within ~1% of the sitemap URL count.
+- After 24h: `SELECT MAX(updated_at) FROM video_sources WHERE provider_id = ...`
+  should be no older than 4h.
+
+## Refreshing matches CSV
+
+The matches CSV (`MATCHES_CSV`) is built once by joining sitemap clusters
+to TMDB IMDB IDs (see `/tmp/prehrajto-pilot/match_tmdb.py` from the
+original pilot). It only needs refreshing when:
+
+- Many new films have been added to our DB without matching prehrajto
+  uploads (so the importer's existing CSV doesn't know about them).
+- prehraj.to title clustering drifts significantly (rare).
+
+Refresh procedure is out of scope for this README — see the matches
+generation script in the pilot directory.

--- a/scripts/cron-prehrajto-sync.sh
+++ b/scripts/cron-prehrajto-sync.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+# Periodic prehraj.to sitemap sync (#645, parent epic #642).
+#
+# Two modes:
+#   full          — download all 487 sub-sitemaps, run importer with mark-dead.
+#                   Used by the daily cron at 03:00 UTC.
+#   incremental   — HEAD index.xml, only fetch sub-sitemaps whose ETag changed
+#                   since last run. Used by the 6×daily cron.
+#                   Skips mark-dead (partial coverage would mis-flag rows).
+#
+# Side effects:
+#   - Writes downloaded sitemap files into $SITEMAP_DIR (default /var/cache/cr/prehrajto-sitemap/)
+#   - Persists per-file ETags in $ETAG_DIR/etags.json for incremental runs
+#   - Appends progress to $LOG_FILE (default /var/log/cr/prehrajto-sync.log)
+#   - Calls scripts/import-prehrajto-uploads.py with $DATABASE_URL from env
+#
+# Required env:
+#   DATABASE_URL  — postgres URL the importer connects to
+#   MATCHES_CSV   — path to the IMDB-matches CSV the importer joins against
+#                   (built once via the pilot pipeline; refresh policy is a
+#                   separate concern outside this cron)
+#
+# Optional env:
+#   SITEMAP_DIR   — default /var/cache/cr/prehrajto-sitemap/
+#   ETAG_DIR      — default /var/cache/cr/prehrajto-sitemap/etags/
+#   LOG_FILE      — default /var/log/cr/prehrajto-sync.log
+#   IMPORTER      — default $(dirname "$0")/import-prehrajto-uploads.py
+
+set -euo pipefail
+
+MODE="${1:-}"
+if [[ "$MODE" != "full" && "$MODE" != "incremental" ]]; then
+    echo "Usage: $0 {full|incremental}" >&2
+    exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SITEMAP_DIR="${SITEMAP_DIR:-/var/cache/cr/prehrajto-sitemap}"
+ETAG_DIR="${ETAG_DIR:-$SITEMAP_DIR/etags}"
+ETAG_FILE="$ETAG_DIR/etags.json"
+LOG_FILE="${LOG_FILE:-/var/log/cr/prehrajto-sync.log}"
+IMPORTER="${IMPORTER:-$SCRIPT_DIR/import-prehrajto-uploads.py}"
+INDEX_URL="https://prehraj.to/sitemap/index.xml"
+
+if [[ -z "${DATABASE_URL:-}" ]]; then
+    echo "ERROR: DATABASE_URL is required" >&2
+    exit 2
+fi
+if [[ -z "${MATCHES_CSV:-}" ]]; then
+    echo "ERROR: MATCHES_CSV path is required" >&2
+    exit 2
+fi
+if [[ ! -f "$MATCHES_CSV" ]]; then
+    echo "ERROR: MATCHES_CSV not found: $MATCHES_CSV" >&2
+    exit 2
+fi
+
+mkdir -p "$SITEMAP_DIR" "$ETAG_DIR" "$(dirname "$LOG_FILE")"
+
+log() {
+    printf "[%s] [%s] %s\n" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$MODE" "$*" | tee -a "$LOG_FILE"
+}
+
+log "starting (importer=$IMPORTER)"
+
+# --- 1. Index.xml — list all sub-sitemap URLs --------------------------------
+INDEX_FILE="$SITEMAP_DIR/index.xml"
+log "fetching index.xml..."
+if ! curl -fsS -o "$INDEX_FILE.tmp" -m 60 "$INDEX_URL"; then
+    log "ERROR: failed to fetch $INDEX_URL"
+    exit 1
+fi
+mv "$INDEX_FILE.tmp" "$INDEX_FILE"
+SUB_URLS=$(grep -oE "https://prehrajto\.cz/sitemap/video-sitemap-[0-9]+\.xml" "$INDEX_FILE" | sort -u)
+SUB_COUNT=$(echo "$SUB_URLS" | wc -l)
+log "$SUB_COUNT sub-sitemaps listed in index"
+
+# --- 2. Decide which sub-sitemaps to download -------------------------------
+# Incremental: HEAD each sub-sitemap, compare ETag against $ETAG_FILE, fetch
+# only changes. Full: download everything unconditionally so a stale or
+# corrupt cache can't poison the importer's view.
+declare -A OLD_ETAGS=()
+if [[ -f "$ETAG_FILE" ]]; then
+    while IFS=$'\t' read -r url etag; do
+        OLD_ETAGS[$url]=$etag
+    done < <(python3 -c "
+import json,sys
+try:
+    d = json.load(open('$ETAG_FILE'))
+    for k,v in d.items(): print(f'{k}\\t{v}')
+except Exception:
+    pass
+")
+fi
+
+CHANGED_COUNT=0
+TO_DOWNLOAD=()
+declare -A NEW_ETAGS=()
+while IFS= read -r url; do
+    [[ -z "$url" ]] && continue
+    if [[ "$MODE" == "full" ]]; then
+        TO_DOWNLOAD+=("$url")
+        continue
+    fi
+    # Incremental: HEAD to get ETag, skip if unchanged
+    etag=$(curl -sIfm 30 "$url" | grep -i "^etag:" | tr -d '\r' | awk '{print $2}' || true)
+    if [[ -z "$etag" ]]; then
+        # No ETag — treat as changed to be safe
+        TO_DOWNLOAD+=("$url")
+        continue
+    fi
+    NEW_ETAGS[$url]=$etag
+    if [[ "${OLD_ETAGS[$url]:-}" != "$etag" ]]; then
+        TO_DOWNLOAD+=("$url")
+        ((CHANGED_COUNT++))
+    fi
+done <<< "$SUB_URLS"
+
+log "$( [[ "$MODE" == full ]] && echo "${#TO_DOWNLOAD[@]} files to download (full)" \
+                              || echo "$CHANGED_COUNT of $SUB_COUNT changed (incremental)" )"
+
+# --- 3. Download (parallel curls, capped at 8 concurrent) -------------------
+if (( ${#TO_DOWNLOAD[@]} > 0 )); then
+    printf "%s\n" "${TO_DOWNLOAD[@]}" | xargs -P 8 -I {} sh -c '
+        url="$1"
+        out_dir="$2"
+        fname=$(basename "$url")
+        if curl -fsSL -o "$out_dir/$fname.tmp" -m 300 "$url"; then
+            mv "$out_dir/$fname.tmp" "$out_dir/$fname"
+        else
+            echo "WARN: failed $url" >&2
+            rm -f "$out_dir/$fname.tmp"
+        fi
+    ' _ {} "$SITEMAP_DIR"
+fi
+log "downloads complete"
+
+# Persist ETags for next incremental run (full runs also update so subsequent
+# incrementals start from a correct baseline).
+if (( ${#NEW_ETAGS[@]} > 0 )); then
+    python3 -c "
+import json
+existing = {}
+try:
+    existing = json.load(open('$ETAG_FILE'))
+except Exception:
+    pass
+$(for u in "${!NEW_ETAGS[@]}"; do
+    printf "existing[%q] = %q\n" "$u" "${NEW_ETAGS[$u]}"
+done)
+json.dump(existing, open('$ETAG_FILE','w'), indent=2, sort_keys=True)
+"
+fi
+
+# --- 4. Run the importer ----------------------------------------------------
+IMPORTER_ARGS=(--sitemap-dir "$SITEMAP_DIR" --matches "$MATCHES_CSV")
+if [[ "$MODE" == "incremental" ]]; then
+    # Partial sitemap coverage — disable mark-dead; the daily full run is
+    # the authoritative source for is_alive transitions.
+    IMPORTER_ARGS+=(--no-mark-dead)
+fi
+log "running importer: ${IMPORTER_ARGS[*]}"
+if python3 "$IMPORTER" "${IMPORTER_ARGS[@]}" >> "$LOG_FILE" 2>&1; then
+    log "importer OK"
+else
+    rc=$?
+    log "ERROR: importer exited $rc"
+    exit "$rc"
+fi
+
+log "done"

--- a/scripts/cron-prehrajto-sync.sh
+++ b/scripts/cron-prehrajto-sync.sh
@@ -25,6 +25,7 @@
 #   ETAG_DIR      — default /var/cache/cr/prehrajto-sitemap/etags/
 #   LOG_FILE      — default /var/log/cr/prehrajto-sync.log
 #   IMPORTER      — default $(dirname "$0")/import-prehrajto-uploads.py
+#   LOCK_FILE     — default $SITEMAP_DIR/sync.lock (flock to prevent overlap)
 
 set -euo pipefail
 
@@ -40,6 +41,7 @@ ETAG_DIR="${ETAG_DIR:-$SITEMAP_DIR/etags}"
 ETAG_FILE="$ETAG_DIR/etags.json"
 LOG_FILE="${LOG_FILE:-/var/log/cr/prehrajto-sync.log}"
 IMPORTER="${IMPORTER:-$SCRIPT_DIR/import-prehrajto-uploads.py}"
+LOCK_FILE="${LOCK_FILE:-$SITEMAP_DIR/sync.lock}"
 INDEX_URL="https://prehraj.to/sitemap/index.xml"
 
 if [[ -z "${DATABASE_URL:-}" ]]; then
@@ -57,6 +59,17 @@ fi
 
 mkdir -p "$SITEMAP_DIR" "$ETAG_DIR" "$(dirname "$LOG_FILE")"
 
+# --- Lock to prevent overlapping runs (#650 Copilot review) ----------------
+# A `full` run can take 15-30 min; if a 4-hourly `incremental` fires while
+# a `full` is still running (or two `full`s overlap on a slow VPS), they'd
+# race on the same sitemap dir + etags.json + DB transaction. flock makes
+# the second invocation exit immediately so cron just skips it.
+exec 9>"$LOCK_FILE"
+if ! flock -n 9; then
+    echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [$MODE] another sync already running, skipping" >> "$LOG_FILE"
+    exit 0
+fi
+
 log() {
     printf "[%s] [%s] %s\n" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$MODE" "$*" | tee -a "$LOG_FILE"
 }
@@ -71,20 +84,30 @@ if ! curl -fsS -o "$INDEX_FILE.tmp" -m 60 "$INDEX_URL"; then
     exit 1
 fi
 mv "$INDEX_FILE.tmp" "$INDEX_FILE"
-SUB_URLS=$(grep -oE "https://prehrajto\.cz/sitemap/video-sitemap-[0-9]+\.xml" "$INDEX_FILE" | sort -u)
+# Host-agnostic <loc> extraction (#650 Copilot review): the index.xml hostname
+# (`prehraj.to`) and the sub-sitemap hostnames inside it (`prehrajto.cz` today)
+# don't have to match, and prehraj.to has switched between them before.
+# Match any host serving the canonical /sitemap/video-sitemap-N.xml path.
+SUB_URLS=$(grep -oE "https?://[^<]*/sitemap/video-sitemap-[0-9]+\.xml" "$INDEX_FILE" | sort -u || true)
+if [[ -z "$SUB_URLS" ]]; then
+    log "ERROR: index.xml contained zero sub-sitemap URLs (host change?)"
+    exit 1
+fi
 SUB_COUNT=$(echo "$SUB_URLS" | wc -l)
 log "$SUB_COUNT sub-sitemaps listed in index"
 
 # --- 2. Decide which sub-sitemaps to download -------------------------------
 # Incremental: HEAD each sub-sitemap, compare ETag against $ETAG_FILE, fetch
 # only changes. Full: download everything unconditionally so a stale or
-# corrupt cache can't poison the importer's view.
+# corrupt cache can't poison the importer's view, but ALSO HEAD them to
+# capture fresh ETags so the next incremental has a correct baseline (#650
+# Copilot review).
 declare -A OLD_ETAGS=()
 if [[ -f "$ETAG_FILE" ]]; then
     while IFS=$'\t' read -r url etag; do
         OLD_ETAGS[$url]=$etag
     done < <(python3 -c "
-import json,sys
+import json
 try:
     d = json.load(open('$ETAG_FILE'))
     for k,v in d.items(): print(f'{k}\\t{v}')
@@ -98,18 +121,21 @@ TO_DOWNLOAD=()
 declare -A NEW_ETAGS=()
 while IFS= read -r url; do
     [[ -z "$url" ]] && continue
+    # HEAD in both modes: incremental uses it to skip unchanged shards;
+    # full uses it just to capture ETags for the baseline.
+    etag=$(curl -sIfm 30 "$url" | grep -i "^etag:" | tr -d '\r' | awk '{print $2}' || true)
+    if [[ -n "$etag" ]]; then
+        NEW_ETAGS[$url]=$etag
+    fi
     if [[ "$MODE" == "full" ]]; then
         TO_DOWNLOAD+=("$url")
         continue
     fi
-    # Incremental: HEAD to get ETag, skip if unchanged
-    etag=$(curl -sIfm 30 "$url" | grep -i "^etag:" | tr -d '\r' | awk '{print $2}' || true)
     if [[ -z "$etag" ]]; then
         # No ETag — treat as changed to be safe
         TO_DOWNLOAD+=("$url")
         continue
     fi
-    NEW_ETAGS[$url]=$etag
     if [[ "${OLD_ETAGS[$url]:-}" != "$etag" ]]; then
         TO_DOWNLOAD+=("$url")
         ((CHANGED_COUNT++))
@@ -120,20 +146,36 @@ log "$( [[ "$MODE" == full ]] && echo "${#TO_DOWNLOAD[@]} files to download (ful
                               || echo "$CHANGED_COUNT of $SUB_COUNT changed (incremental)" )"
 
 # --- 3. Download (parallel curls, capped at 8 concurrent) -------------------
+# Track failures explicitly: in `full` mode we ABORT before running the
+# importer, because a partial snapshot + mark-dead would incorrectly flip
+# uploads to dead just because their sub-sitemap was missing from this
+# run (#650 Copilot review). In `incremental` mode partial download is
+# fine — `--no-mark-dead` is set, so missing sub-sitemaps just defer
+# their freshening to the next run.
+FAILED_DIR=$(mktemp -d)
+# shellcheck disable=SC2064
+trap "rm -rf '$FAILED_DIR'" EXIT
 if (( ${#TO_DOWNLOAD[@]} > 0 )); then
     printf "%s\n" "${TO_DOWNLOAD[@]}" | xargs -P 8 -I {} sh -c '
         url="$1"
         out_dir="$2"
+        failed_dir="$3"
         fname=$(basename "$url")
         if curl -fsSL -o "$out_dir/$fname.tmp" -m 300 "$url"; then
             mv "$out_dir/$fname.tmp" "$out_dir/$fname"
         else
             echo "WARN: failed $url" >&2
             rm -f "$out_dir/$fname.tmp"
+            : > "$failed_dir/$fname"
         fi
-    ' _ {} "$SITEMAP_DIR"
+    ' _ {} "$SITEMAP_DIR" "$FAILED_DIR"
 fi
-log "downloads complete"
+FAILED_COUNT=$(find "$FAILED_DIR" -type f | wc -l)
+log "downloads complete (${FAILED_COUNT} failures)"
+if (( FAILED_COUNT > 0 )) && [[ "$MODE" == "full" ]]; then
+    log "ABORT: full mode requires complete sitemap snapshot before mark-dead"
+    exit 1
+fi
 
 # Persist ETags for next incremental run (full runs also update so subsequent
 # incrementals start from a correct baseline).


### PR DESCRIPTION
<!-- claude-session: 98d65447-0cc0-4c98-a612-a9b5c0699023 -->

Closes #645
Refs parent epic #642
Pairs with: #649 (importer mark-dead, #644)

## Summary

Adds the operational layer that makes the importer (#644) run on a schedule:

- `scripts/cron-prehrajto-sync.sh` — bash wrapper that downloads sitemap files (full or ETag-incremental) and invokes `import-prehrajto-uploads.py`.
- `scripts/PREHRAJTO_SYNC_README.md` — operations guide with crontab template, VPS setup checklist, and monitoring queries.

## Modes

| Mode | When | What it does |
|---|---|---|
| `full` | daily 03:00 UTC | All 487 sub-sitemaps in parallel (xargs -P 8); importer with mark-dead. Authoritative is_alive snapshot. |
| `incremental` | every 4h (00, 04, 08, 12, 16, 20 UTC) | HEADs each sub-sitemap, downloads only ETag-changed; importer with `--no-mark-dead` (partial coverage would mis-flag rows). |

## Crontab template (in README)

```cron
DATABASE_URL=postgres://cr:cr_secret@127.0.0.1:5432/cr
MATCHES_CSV=/opt/cr/data/prehrajto-matches.csv
LOG_FILE=/var/log/cr/prehrajto-sync.log

0 3 * * *               /opt/cr/scripts/cron-prehrajto-sync.sh full
0 0,4,8,12,16,20 * * *  /opt/cr/scripts/cron-prehrajto-sync.sh incremental
```

## Verification

- [x] `bash -n` syntax check clean
- [x] `shellcheck` no fatal findings (only one SC2016 in an intentional single-quoted xargs sub-shell)
- [x] `--help` style invocation prints usage
- [ ] Production VPS install — covered by #646 (initial post-revert sitemap import + Spasitel verification)

## Test plan

- [x] Local: shell syntax check
- [x] Local: README rendered correctly
- [ ] CI green
- [ ] Production deploy: this PR is just files in repo — no runtime change until the cron lines are pasted into `crontab -e` on the VPS (covered by #646)

## Out of scope

- Actual production cron install (#646)
- Initial sitemap import + Spasitel verification (#646)
- Refresh policy for the matches CSV (separate concern, noted in README)

🤖 Generated with [Claude Code](https://claude.com/claude-code)