### PR TITLE
feat(prehrajto-import): broaden cluster matching with original_title + segments

### DIFF
--- a/scripts/import-prehrajto-uploads.py
+++ b/scripts/import-prehrajto-uploads.py
@@ -200,6 +200,56 @@ def cluster_key(row: dict) -> tuple:
     return (core, year, dur_bucket)
 
 
+# Separators that uploaders use between localized and original (or
+# alternate) titles: " - Project Hail Mary", "/Project Hail Mary",
+# " | Posledná šanca", " : Spasitel". Splitting on these gives us cleaner
+# candidate cores.
+_TITLE_SEPARATOR_RE = re.compile(r"\s+[-|/:]\s+")
+
+
+def cluster_key_candidates(row: dict) -> list[tuple]:
+    """Return all plausible cluster keys for a sitemap row (#654).
+
+    Uploaders combine the localized title with the original / alternate
+    title in many forms — "Spasitel - Project Hail Mary HD CZ DABING",
+    "Spasitel sci-fi-drama USA Ryan Gosling cztit", etc. The strict
+    full-string normalization in `cluster_key` only matches when the
+    upload's title is essentially just the film's title; for everything
+    else we need to surface the underlying canonical name(s).
+
+    We try (in order):
+      1. The full normalized core (current behavior).
+      2. Each segment after splitting on `" - " | "/" | ":"` separators.
+      3. The first whitespace-separated word — catches descriptive
+         uploads like "Spasitel sci-fi-drama USA Ryan Gosling".
+
+    Year + duration anchor unchanged across all candidates, so false
+    positives stay bounded by those fields. The films-table side now
+    emits both `title` and `original_title` cores, so candidate-core
+    matching is effective in both directions.
+    """
+    title = row["title"]
+    year = extract_year(title)
+    dur_bucket = row["duration"] // (3 * 60)
+    stripped = strip_title(title)
+    candidates: list[str] = []
+    seen: set[str] = set()
+
+    def _add(s: str) -> None:
+        c = normalize(s)
+        if c and c not in seen:
+            seen.add(c)
+            candidates.append(c)
+
+    _add(stripped)
+    for seg in _TITLE_SEPARATOR_RE.split(stripped):
+        _add(seg)
+    first_word = stripped.split(" ", 1)[0] if stripped else ""
+    if first_word:
+        _add(first_word)
+    return [(c, year, dur_bucket) for c in candidates]
+
+
 def extract_upload_id(url: str) -> str | None:
     m = _UPLOAD_ID_RE.search(url or "")
     return m.group(1) if m else None
@@ -337,36 +387,51 @@ def load_matches_from_films(cur, bucket_window: int = 2) -> dict[tuple, dict]:
     id, and each collision is logged so the operator can investigate.
     """
     cur.execute(
-        "SELECT id, title, year, imdb_id, runtime_min FROM films "
+        "SELECT id, title, original_title, year, imdb_id, runtime_min "
+        "FROM films "
         "WHERE imdb_id IS NOT NULL AND year IS NOT NULL "
         "ORDER BY id"
     )
     matches: dict[tuple, dict] = {}
     collisions: list[tuple[tuple, int, int]] = []
     skipped_no_runtime = 0
-    for film_id, title, year, imdb_id, runtime_min in cur.fetchall():
+    for film_id, title, original_title, year, imdb_id, runtime_min in cur.fetchall():
         if not title or not imdb_id:
             continue
         if runtime_min is None or runtime_min <= 0:
             skipped_no_runtime += 1
             continue
-        core = normalize(strip_title(title))
-        if not core:
+        # Emit both the localized and the original title as candidate
+        # cores (#654). Spasitel (cs) ↔ Project Hail Mary (en) is the
+        # canonical example — sitemap titles like
+        # "Spasitel - Project Hail Mary HD CZ DABING" expand on the
+        # parser side into ['spasitel', 'projecthailmary'] candidates,
+        # so both forms produce a match key here.
+        cores: set[str] = set()
+        c1 = normalize(strip_title(title))
+        if c1:
+            cores.add(c1)
+        if original_title and original_title.strip():
+            c2 = normalize(strip_title(original_title))
+            if c2:
+                cores.add(c2)
+        if not cores:
             continue
         anchor = int(runtime_min) // 3
-        for dur_bucket in range(anchor - bucket_window, anchor + bucket_window + 1):
-            if dur_bucket < 0:
-                continue
-            key = (core, year, dur_bucket)
-            existing = matches.get(key)
-            if existing is None:
-                matches[key] = {
-                    "imdb_id": imdb_id,
-                    "_film_id": film_id,
-                    "_source": "films_table",
-                }
-            elif existing["_film_id"] != film_id:
-                collisions.append((key, existing["_film_id"], film_id))
+        for core in cores:
+            for dur_bucket in range(anchor - bucket_window, anchor + bucket_window + 1):
+                if dur_bucket < 0:
+                    continue
+                key = (core, year, dur_bucket)
+                existing = matches.get(key)
+                if existing is None:
+                    matches[key] = {
+                        "imdb_id": imdb_id,
+                        "_film_id": film_id,
+                        "_source": "films_table",
+                    }
+                elif existing["_film_id"] != film_id:
+                    collisions.append((key, existing["_film_id"], film_id))
     if skipped_no_runtime:
         print(f"  load_matches_from_films: skipped {skipped_no_runtime} films "
               f"without runtime_min (would match too widely)", flush=True)
@@ -453,9 +518,15 @@ def main() -> int:
             if not film_shape(r):
                 continue
             film_shape_count += 1
-            k = cluster_key(r)
-            if k in wanted_keys:
-                clusters[k].append(r)
+            # Try multiple candidate cluster cores (#654). First match
+            # wins, so the order in cluster_key_candidates() matters:
+            # full-title core first (preserves prior behaviour for
+            # exact matches), then split segments, then first-word.
+            # Using a single bucket per row keeps de-duplication trivial.
+            for k in cluster_key_candidates(r):
+                if k in wanted_keys:
+                    clusters[k].append(r)
+                    break
     print(f"  {total_entries:,} total entries scanned in {time.time()-t0:.1f}s")
     print(f"  {film_shape_count:,} film-shape entries")
     print(f"  {len(clusters):,} clusters matched wanted set")

--- a/scripts/import-prehrajto-uploads.py
+++ b/scripts/import-prehrajto-uploads.py
@@ -202,9 +202,12 @@ def cluster_key(row: dict) -> tuple:
 
 # Separators that uploaders use between localized and original (or
 # alternate) titles: " - Project Hail Mary", "/Project Hail Mary",
-# " | Posledná šanca", " : Spasitel". Splitting on these gives us cleaner
-# candidate cores.
-_TITLE_SEPARATOR_RE = re.compile(r"\s+[-|/:]\s+")
+# " | Posledná šanca", " : Spasitel", "Title:Original", "Title -Original".
+# Allow whitespace on only one side for "-", "/", "|" and optional
+# spacing around ":" — but require at least one whitespace adjacency for
+# the dash/slash/pipe forms so we don't split inside hyphenated words
+# like "Spider-Man" or path-shaped tokens.
+_TITLE_SEPARATOR_RE = re.compile(r"(?:\s+[-/|]\s*|\s*[-/|]\s+|\s*:\s*)")
 
 
 def cluster_key_candidates(row: dict) -> list[tuple]:
@@ -219,7 +222,8 @@ def cluster_key_candidates(row: dict) -> list[tuple]:
 
     We try (in order):
       1. The full normalized core (current behavior).
-      2. Each segment after splitting on `" - " | "/" | ":"` separators.
+      2. Each segment after splitting on `" - " | " / " | " : " | " | "`
+         separators (and one-sided variants — see `_TITLE_SEPARATOR_RE`).
       3. The first whitespace-separated word — catches descriptive
          uploads like "Spasitel sci-fi-drama USA Ryan Gosling".
 


### PR DESCRIPTION
<!-- claude-session: 98d65447-0cc0-4c98-a612-a9b5c0699023 -->

Closes #654

## Summary

Spasitel was the canonical regression: prehraj.to has many uploads we weren't surfacing because the matcher required the upload's normalized core to equal the film's normalized title core verbatim. Most upload titles add the original name, the genre, or the cast (`Spasitel - Project Hail Mary HD CZ DABING`, `Spasitel sci-fi-drama USA Ryan Gosling cztit 1080p`), so the strict-equality match dropped them.

This change widens the matcher in both directions, deployed and verified on production.

## Changes

**Films side (`load_matches_from_films`):** emit cluster keys for both `films.title` AND `films.original_title` cores. The TMDB import already populates `original_title` for almost every row, so this comes free.

**Parser side (new `cluster_key_candidates`):** for each sitemap row, try multiple candidate cluster cores in priority order:
1. The full normalized core (preserves prior exact-match behavior).
2. Each segment after splitting on ` - `, ` / `, ` | `, ` : ` — catches localized + original concatenations.
3. The first whitespace-separated word — catches descriptive uploads where the localized title is followed by genre/cast/codec tags.

Year and duration anchors are unchanged, so false positives still need to agree on both. Determinism preserved — first matching candidate wins, plus the films-side `ORDER BY id` collision rule from #653.

## Production verification

Re-ran `cr-prehrajto-sync.service` after deploying this change. Compared with the previous run on the same sitemap snapshot:

| Metric | Before #654 | After #654 | Delta |
|---|---|---|---|
| Match-map keys | 78,274 | 131,162 | +68% |
| Clusters matched | 9,744 | 12,090 | +24% |
| Distinct films enriched | 8,731 | 10,108 | +16% |
| Total upload rows | 20,416 | 28,116 | +38% |

**Spasitel went from 2 to 8 alive uploads:**

```
2d1c174653369227 | CZ_DUB   | primary | Spasitel -Project hail Mary HD 2026 CZ DABING.mkv  ← new primary
237c2f42856e03d0 | CZ_SUB   |         | Spasitel 2026 CZ Titulky                         ← previous primary
20127347c6682258 | UNKNOWN  |         | Spasitel 2026
3602730f0b8b0cd3 | UNKNOWN  |         | spasitel-2026-cz-titulky-mp4._mp4
82c0af10ecefe675 | UNKNOWN  |         | Spasitel.Project Hail Mary (2026).2160p.WEBrip.h265.Titulky CZ.SK.Eng
8f67640d0bd01ffc | CZ_SUB   |         | SPASITEL 2026 CZ TITULKY SUPERKVALITA
9a58f42404bb9584 | UNKNOWN  |         | Spasitel -Project hail Mary HD 2026 (cz)
bdf73ab62ec4c613 | UNKNOWN  |         | Spasitel -Project hail Mary HD 2026 (cz)
```

Tested CZ DABING + 2160p WEBrip endpoints — both `/api/movies/stream/<id>` calls return `307 → premiumcdn.net`.

## Out of scope

Slovak / foreign release titles (e.g. `Posledná šanca` for Spasitel) remain unmatched — they share neither the localized nor the original title's normalized core. Capturing them needs an alternate-titles table populated from TMDB `also_known_as`. Tracked separately if the gap matters in practice.

## Test plan

- [x] Smoke run on production sitemap → matcher metrics improved as expected
- [x] Spasitel 2026: 2 → 8 alive uploads, CZ DABING is new primary
- [x] `/api/movies/stream/<new-id>` returns 307 to allow-listed CDN host
- [x] No regression on cross-film cluster collision handling (mark-dead only flagged 770 stale rows vs 7,836 last run, consistent with mostly-fresh data)