### PR TITLE
feat(prehrajto): registry of TMDB-unmatched sitemap clusters (#657)

### DIFF
--- a/cr-infra/migrations/20260604_064_prehrajto_unmatched_clusters.sql
+++ b/cr-infra/migrations/20260604_064_prehrajto_unmatched_clusters.sql
@@ -1,0 +1,78 @@
+-- Registry of sitemap clusters that the prehraj.to importer could not
+-- match to any row in `films` (#657, parent epic #656).
+--
+-- Today the importer (`scripts/import-prehrajto-uploads.py`) joins
+-- sitemap clusters against the films table by (normalized title core,
+-- year, 3-min duration bucket) and silently drops everything that does
+-- not match. We do not know how large that pile is, which titles keep
+-- showing up, or whether previously unmatched clusters later got
+-- resolved (e.g. operator added the film manually, or it landed via SK
+-- Torrent auto-import). This table is the persistent log so:
+--
+--   - The follow-up auto-import flow (#652) can consult `last_attempt_at`
+--     and skip TMDB lookups for clusters that recently failed, instead
+--     of mlátit do TMDB rate-limitu se stejným nematchem každý den.
+--   - The /admin/prehrajto/unmatched dashboard surfaces "loudest" rows
+--     (high `upload_count`) so the operator can decide what to backfill
+--     manually or where the matching heuristic is too strict.
+--   - When a cluster eventually does match (films table catches up),
+--     the importer marks it `resolved_at` + `resolved_film_id` so we
+--     have a feedback loop on what gets fixed how.
+--
+-- Bucket size matches `cluster_key`: row.duration / (3 * 60). Year is
+-- nullable in principle (the importer skips rows without an extractable
+-- year, but we keep the column nullable for forward compatibility).
+
+CREATE TABLE IF NOT EXISTS prehrajto_unmatched_clusters (
+    id                    SERIAL PRIMARY KEY,
+    -- Normalized title core after strip_title()+normalize() — the same
+    -- form `cluster_key()` uses on the films-side. Stored as TEXT
+    -- because there is no length cap on the input title.
+    cluster_key           TEXT        NOT NULL,
+    year                  INTEGER,
+    duration_bucket       INTEGER,
+    -- One representative <video:title> for humans; updated whenever a
+    -- new sitemap snapshot bumps `last_seen_at`. Helps the operator
+    -- recognize "ah, this is the Czech localized title vs. original".
+    sample_title          TEXT        NOT NULL,
+    -- One representative prehraj.to URL — clickable link in the admin
+    -- table so the operator can verify the upload is real.
+    sample_url            TEXT        NOT NULL,
+    -- Number of distinct sitemap entries (uploads) that fell into this
+    -- cluster across all runs. Sortable signal for the admin view.
+    upload_count          INTEGER     NOT NULL DEFAULT 1,
+    first_seen_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_seen_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    -- Last time we ATTEMPTED to resolve this cluster. Today the importer
+    -- doesn't call TMDB, so this equals `last_seen_at`. Once #652 lands,
+    -- the auto-import will set this independently from `last_seen_at`
+    -- (e.g. seen today but skipped TMDB because attempted < 7 days ago).
+    last_attempt_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    attempt_count         INTEGER     NOT NULL DEFAULT 1,
+    last_failure_reason   TEXT,
+    -- Set when a later run successfully matched this cluster — either
+    -- because someone added the film manually, or because #652 resolved
+    -- it via TMDB. Once set we leave the row in place (keeps the
+    -- per-cluster history) but stop counting it on the dashboard.
+    resolved_at           TIMESTAMPTZ,
+    resolved_film_id      INTEGER     REFERENCES films(id) ON DELETE SET NULL,
+
+    -- One row per (key, year, duration_bucket). Same triplet as
+    -- `cluster_key()` returns on the films side, so resolving = exact
+    -- key lookup.
+    CONSTRAINT uq_pu_clusters_key UNIQUE (cluster_key, year, duration_bucket)
+);
+
+-- Admin dashboard sorts unresolved rows by upload_count DESC. Partial
+-- index keeps the dashboard query cheap as resolved rows accumulate.
+CREATE INDEX IF NOT EXISTS idx_pu_clusters_unresolved
+    ON prehrajto_unmatched_clusters (upload_count DESC)
+    WHERE resolved_at IS NULL;
+
+-- #652 will look up rows by (key, year, bucket) plus `last_attempt_at`
+-- to decide skip vs. retry. The unique constraint above already covers
+-- the lookup; this index speeds up the time-window scan when the
+-- importer iterates "all unresolved clusters older than X days".
+CREATE INDEX IF NOT EXISTS idx_pu_clusters_attempt
+    ON prehrajto_unmatched_clusters (last_attempt_at)
+    WHERE resolved_at IS NULL;

--- a/cr-infra/migrations/20260604_064_prehrajto_unmatched_clusters.sql
+++ b/cr-infra/migrations/20260604_064_prehrajto_unmatched_clusters.sql
@@ -38,17 +38,27 @@ CREATE TABLE IF NOT EXISTS prehrajto_unmatched_clusters (
     -- One representative prehraj.to URL — clickable link in the admin
     -- table so the operator can verify the upload is real.
     sample_url            TEXT        NOT NULL,
-    -- Number of distinct sitemap entries (uploads) that fell into this
-    -- cluster across all runs. Sortable signal for the admin view.
+    -- Number of distinct upload_ids in the cluster *as observed by the
+    -- most recent importer run* — a per-run snapshot, NOT cumulative. We
+    -- replace the value on each UPSERT instead of summing because the
+    -- same uploads stay in sitemap day after day; summing would inflate
+    -- the count without adding signal. Sortable signal for the admin view.
     upload_count          INTEGER     NOT NULL DEFAULT 1,
     first_seen_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     last_seen_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    -- Last time we ATTEMPTED to resolve this cluster. Today the importer
-    -- doesn't call TMDB, so this equals `last_seen_at`. Once #652 lands,
-    -- the auto-import will set this independently from `last_seen_at`
-    -- (e.g. seen today but skipped TMDB because attempted < 7 days ago).
+    -- Last time we attempted to *resolve* this cluster — i.e. tried to
+    -- match it to something concrete. Today the importer doesn't call
+    -- TMDB, so this is set only on INSERT and stays put on subsequent
+    -- sightings. #652 (auto-import via TMDB) will UPDATE it whenever
+    -- it actually tries a lookup, so its 7-day skip-window arithmetic
+    -- works without being reset by every nightly sitemap parse.
     last_attempt_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     attempt_count         INTEGER     NOT NULL DEFAULT 1,
+    -- Set on INSERT to a generic "no match" string; #652 will overwrite
+    -- with TMDB-specific failure reasons when it tries lookups. The
+    -- importer never overwrites an existing value (COALESCE protects it),
+    -- so #652's diagnostic text isn't clobbered by a nightly sitemap
+    -- parse that didn't actually retry the lookup.
     last_failure_reason   TEXT,
     -- Set when a later run successfully matched this cluster — either
     -- because someone added the film manually, or because #652 resolved

--- a/cr-web/src/handlers/admin_prehrajto.rs
+++ b/cr-web/src/handlers/admin_prehrajto.rs
@@ -1,0 +1,161 @@
+//! Admin dashboard for prehraj.to importer observability (#657, parent #656).
+//!
+//! Routes:
+//!   GET /admin/prehrajto/unmatched      — list unresolved unmatched clusters
+//!   GET /admin/prehrajto/unmatched.csv  — CSV export of the same dataset
+//!
+//! Source data: `prehrajto_unmatched_clusters` table (see migration
+//! 20260604_064). Rows land there during the daily sitemap import for
+//! every film-shape cluster the importer could not match against the
+//! `films` table. Operator uses this view to decide which titles are
+//! worth backfilling manually or where the matching heuristic is too
+//! strict.
+
+use askama::Template;
+use axum::extract::State;
+use axum::http::HeaderValue;
+use axum::http::header::CONTENT_TYPE;
+use axum::response::{Html, IntoResponse, Response};
+
+use crate::error::WebResult;
+use crate::state::AppState;
+
+#[derive(sqlx::FromRow)]
+struct UnmatchedRow {
+    id: i32,
+    cluster_key: String,
+    year: Option<i32>,
+    duration_bucket: Option<i32>,
+    sample_title: String,
+    sample_url: String,
+    upload_count: i32,
+    first_seen_at: chrono::DateTime<chrono::Utc>,
+    last_seen_at: chrono::DateTime<chrono::Utc>,
+    attempt_count: i32,
+}
+
+impl UnmatchedRow {
+    fn first_seen_at_str(&self) -> String {
+        self.first_seen_at.format("%Y-%m-%d %H:%M").to_string()
+    }
+    fn last_seen_at_str(&self) -> String {
+        self.last_seen_at.format("%Y-%m-%d %H:%M").to_string()
+    }
+    fn duration_min(&self) -> Option<i32> {
+        // Bucket size is 3 minutes (see scripts/import-prehrajto-uploads.py
+        // ::cluster_key — duration_sec / (3 * 60)). Multiplying back gives the
+        // lower bound of the bucket in minutes — close enough for human eyes.
+        self.duration_bucket.map(|b| b * 3)
+    }
+    fn year_str(&self) -> String {
+        self.year.map(|y| y.to_string()).unwrap_or_default()
+    }
+}
+
+#[derive(Template)]
+#[template(path = "admin_prehrajto_unmatched.html")]
+struct AdminPrehrajtoUnmatchedTemplate {
+    img: String,
+    rows: Vec<UnmatchedRow>,
+    total_rows: i64,
+    total_uploads: i64,
+}
+
+const QUERY_LIST_UNRESOLVED: &str = "SELECT id, cluster_key, year, duration_bucket, \
+     sample_title, sample_url, upload_count, first_seen_at, last_seen_at, \
+     attempt_count \
+     FROM prehrajto_unmatched_clusters \
+     WHERE resolved_at IS NULL \
+     ORDER BY upload_count DESC, last_seen_at DESC \
+     LIMIT 500";
+
+fn noindex(html: String) -> Response {
+    let mut resp = Html(html).into_response();
+    resp.headers_mut().insert(
+        "X-Robots-Tag",
+        HeaderValue::from_static("noindex, nofollow"),
+    );
+    resp
+}
+
+/// GET /admin/prehrajto/unmatched — paginated table of unresolved clusters.
+pub async fn admin_prehrajto_unmatched(State(state): State<AppState>) -> WebResult<Response> {
+    let rows = sqlx::query_as::<_, UnmatchedRow>(QUERY_LIST_UNRESOLVED)
+        .fetch_all(&state.db)
+        .await?;
+
+    // Aggregate stats over the full unresolved set (not just the displayed
+    // 500), so the operator sees the true scope even when the table is
+    // truncated. Two cheap COUNTs in one round-trip via UNION ALL would also
+    // work; the two queries here are clearer and still sub-millisecond on
+    // an indexed table this small.
+    let (total_rows, total_uploads): (i64, i64) = sqlx::query_as(
+        "SELECT COUNT(*)::BIGINT, COALESCE(SUM(upload_count), 0)::BIGINT \
+         FROM prehrajto_unmatched_clusters WHERE resolved_at IS NULL",
+    )
+    .fetch_one(&state.db)
+    .await?;
+
+    let tmpl = AdminPrehrajtoUnmatchedTemplate {
+        img: state.image_base_url.clone(),
+        rows,
+        total_rows,
+        total_uploads,
+    };
+    Ok(noindex(tmpl.render()?))
+}
+
+/// GET /admin/prehrajto/unmatched.csv — CSV export for offline review.
+pub async fn admin_prehrajto_unmatched_csv(State(state): State<AppState>) -> WebResult<Response> {
+    let rows = sqlx::query_as::<_, UnmatchedRow>(QUERY_LIST_UNRESOLVED)
+        .fetch_all(&state.db)
+        .await?;
+
+    let mut out = String::with_capacity(64 + rows.len() * 200);
+    out.push_str(
+        "id,cluster_key,year,duration_min,upload_count,attempt_count,\
+         first_seen_at,last_seen_at,sample_title,sample_url\n",
+    );
+    for r in &rows {
+        out.push_str(&format!(
+            "{},{},{},{},{},{},{},{},{},{}\n",
+            r.id,
+            csv_escape(&r.cluster_key),
+            r.year_str(),
+            r.duration_min().map(|m| m.to_string()).unwrap_or_default(),
+            r.upload_count,
+            r.attempt_count,
+            r.first_seen_at_str(),
+            r.last_seen_at_str(),
+            csv_escape(&r.sample_title),
+            csv_escape(&r.sample_url),
+        ));
+    }
+
+    let mut resp = out.into_response();
+    resp.headers_mut().insert(
+        CONTENT_TYPE,
+        HeaderValue::from_static("text/csv; charset=utf-8"),
+    );
+    resp.headers_mut().insert(
+        "X-Robots-Tag",
+        HeaderValue::from_static("noindex, nofollow"),
+    );
+    resp.headers_mut().insert(
+        axum::http::header::CONTENT_DISPOSITION,
+        HeaderValue::from_static("attachment; filename=\"prehrajto-unmatched.csv\""),
+    );
+    Ok(resp)
+}
+
+/// RFC 4180-ish CSV cell quoting — wrap in double quotes and escape any
+/// embedded double quotes by doubling them. Only emit quotes when the
+/// value contains a comma, quote, or newline.
+fn csv_escape(s: &str) -> String {
+    if s.contains(',') || s.contains('"') || s.contains('\n') || s.contains('\r') {
+        let escaped = s.replace('"', "\"\"");
+        format!("\"{escaped}\"")
+    } else {
+        s.to_string()
+    }
+}

--- a/cr-web/src/handlers/admin_prehrajto.rs
+++ b/cr-web/src/handlers/admin_prehrajto.rs
@@ -61,6 +61,7 @@ struct AdminPrehrajtoUnmatchedTemplate {
     total_uploads: i64,
 }
 
+/// HTML table is capped — operator only ever needs the loudest entries.
 const QUERY_LIST_UNRESOLVED: &str = "SELECT id, cluster_key, year, duration_bucket, \
      sample_title, sample_url, upload_count, first_seen_at, last_seen_at, \
      attempt_count \
@@ -68,6 +69,16 @@ const QUERY_LIST_UNRESOLVED: &str = "SELECT id, cluster_key, year, duration_buck
      WHERE resolved_at IS NULL \
      ORDER BY upload_count DESC, last_seen_at DESC \
      LIMIT 500";
+
+/// CSV export streams every unresolved row — no LIMIT — because the
+/// whole point of CSV is offline analysis where the top-500 slice would
+/// hide long-tail entries the operator might want to grep through.
+const QUERY_FULL_UNRESOLVED: &str = "SELECT id, cluster_key, year, duration_bucket, \
+     sample_title, sample_url, upload_count, first_seen_at, last_seen_at, \
+     attempt_count \
+     FROM prehrajto_unmatched_clusters \
+     WHERE resolved_at IS NULL \
+     ORDER BY upload_count DESC, last_seen_at DESC";
 
 fn noindex(html: String) -> Response {
     let mut resp = Html(html).into_response();
@@ -78,7 +89,9 @@ fn noindex(html: String) -> Response {
     resp
 }
 
-/// GET /admin/prehrajto/unmatched — paginated table of unresolved clusters.
+/// GET /admin/prehrajto/unmatched — table of unresolved clusters, capped at
+/// the top 500 rows by `upload_count` / `last_seen_at`. No pagination
+/// controls — the long tail belongs in the CSV export, not in the UI.
 pub async fn admin_prehrajto_unmatched(State(state): State<AppState>) -> WebResult<Response> {
     let rows = sqlx::query_as::<_, UnmatchedRow>(QUERY_LIST_UNRESOLVED)
         .fetch_all(&state.db)
@@ -105,9 +118,9 @@ pub async fn admin_prehrajto_unmatched(State(state): State<AppState>) -> WebResu
     Ok(noindex(tmpl.render()?))
 }
 
-/// GET /admin/prehrajto/unmatched.csv — CSV export for offline review.
+/// GET /admin/prehrajto/unmatched.csv — CSV export of EVERY unresolved row.
 pub async fn admin_prehrajto_unmatched_csv(State(state): State<AppState>) -> WebResult<Response> {
-    let rows = sqlx::query_as::<_, UnmatchedRow>(QUERY_LIST_UNRESOLVED)
+    let rows = sqlx::query_as::<_, UnmatchedRow>(QUERY_FULL_UNRESOLVED)
         .fetch_all(&state.db)
         .await?;
 

--- a/cr-web/src/handlers/mod.rs
+++ b/cr-web/src/handlers/mod.rs
@@ -13,6 +13,7 @@ pub mod admin_backups;
 pub mod admin_cache;
 pub mod admin_dashboard;
 pub mod admin_import;
+pub mod admin_prehrajto;
 mod admin_test_sledujteto;
 mod audiobooks;
 pub mod cover_proxy;

--- a/cr-web/src/main.rs
+++ b/cr-web/src/main.rs
@@ -337,6 +337,18 @@ async fn main() -> Result<()> {
             "/admin/import/{run_id}",
             axum::routing::get(handlers::admin_import::admin_import_detail),
         )
+        .route(
+            "/admin/prehrajto/unmatched",
+            axum::routing::get(handlers::admin_prehrajto::admin_prehrajto_unmatched),
+        )
+        .route(
+            "/admin/prehrajto/unmatched/",
+            axum::routing::get(handlers::admin_prehrajto::admin_prehrajto_unmatched),
+        )
+        .route(
+            "/admin/prehrajto/unmatched.csv",
+            axum::routing::get(handlers::admin_prehrajto::admin_prehrajto_unmatched_csv),
+        )
         .route("/pamatky", axum::routing::get(handlers::landmarks_index))
         .route("/pamatky/", axum::routing::get(handlers::landmarks_index))
         .route("/audioknihy", axum::routing::get(handlers::audiobooks))

--- a/cr-web/templates/admin_dashboard.html
+++ b/cr-web/templates/admin_dashboard.html
@@ -52,6 +52,13 @@
             <p class="tile-sub">Hash-gen + www CDN playback z produkční IP</p>
             <p class="tile-status">Diagnostika — když něco přestane chodit.</p>
         </a>
+
+        <a href="/admin/prehrajto/unmatched" class="tile" title="Prehraj.to importer — clustery bez shody v films">
+            <div class="tile-icon">🔍</div>
+            <h3>Prehraj.to nesparované</h3>
+            <p class="tile-sub">Filmy v sitemap, ke kterým nemáme řádek ve films</p>
+            <p class="tile-status">Kandidáti pro #652 / kontrola heuristiky.</p>
+        </a>
     </div>
 </main>
 

--- a/cr-web/templates/admin_prehrajto_unmatched.html
+++ b/cr-web/templates/admin_prehrajto_unmatched.html
@@ -1,0 +1,110 @@
+{% extends "base.html" %}
+
+{% block title %}Prehraj.to — nesparované clustery{% endblock %}
+{% block meta_description %}Filmy v prehraj.to sitemap, které importer neuměl spárovat s naší films tabulkou.{% endblock %}
+
+{% block og_title %}Prehraj.to — nesparované clustery{% endblock %}
+{% block og_description %}Filmy v prehraj.to sitemap, které importer neuměl spárovat.{% endblock %}
+
+{% block header_left %}
+<div class="logo-group">
+    <h1>Prehraj.to — nesparované clustery</h1>
+</div>
+{% endblock %}
+
+{% block content %}
+<main class="admin-prehrajto-page">
+    <nav class="breadcrumb">
+        <a href="/" title="Domů">Česká republika</a>
+        <span>›</span> <a href="/admin/" title="Admin">Admin</a>
+        <span>›</span> <span>Prehraj.to — nesparované</span>
+    </nav>
+
+    <p class="lead">
+        Filmy ze sitemap <code>prehraj.to</code>, které denní importer
+        neuměl spárovat s žádným řádkem v tabulce <code>films</code>.
+        Bývá to buď tím, že film u nás zatím nemáme (kandidát pro
+        <a href="https://github.com/Olbrasoft/cr/issues/652">#652</a>),
+        nebo tím, že matching heuristika je moc přísná
+        (<a href="https://github.com/Olbrasoft/cr/issues/657">#657</a> kontext).
+    </p>
+
+    <div class="stats">
+        <div class="stat">
+            <span class="stat-num">{{ total_rows }}</span>
+            <span class="stat-label">nesparovaných clusterů</span>
+        </div>
+        <div class="stat">
+            <span class="stat-num">{{ total_uploads }}</span>
+            <span class="stat-label">celkem uploadů na prehraj.to</span>
+        </div>
+        <div class="stat">
+            <a class="csv-link" href="/admin/prehrajto/unmatched.csv">⬇ CSV export</a>
+        </div>
+    </div>
+
+    {% if rows.is_empty() %}
+    <p class="empty-state">Žádné nesparované clustery. 🎉</p>
+    {% else %}
+    <p class="hint">
+        Zobrazeno top {{ rows.len() }} podle <strong>upload_count DESC</strong>
+        (kolik různých uploadů na prehraj.to do clusteru spadlo). Klikni na
+        sample URL, ověř, že jde o film, a buď přidej do <code>films</code>
+        ručně, nebo otevři issue na úpravu matching heuristiky.
+    </p>
+    <table class="unmatched-table">
+        <thead>
+            <tr>
+                <th class="num">#</th>
+                <th>Cluster key</th>
+                <th class="num">Rok</th>
+                <th class="num">Délka (min)</th>
+                <th class="num" title="Počet různých uploadů na prehraj.to s tímto klíčem">Uploady</th>
+                <th class="num" title="Kolikrát tento cluster prošel importerem">Pokusy</th>
+                <th>Sample title</th>
+                <th>Naposledy</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for r in rows %}
+            <tr>
+                <td class="num"><code>{{ r.id }}</code></td>
+                <td><code>{{ r.cluster_key }}</code></td>
+                <td class="num">{{ r.year_str() }}</td>
+                <td class="num">{% match r.duration_min() %}{% when Some with (m) %}≥ {{ m }}{% when None %}—{% endmatch %}</td>
+                <td class="num"><strong>{{ r.upload_count }}</strong></td>
+                <td class="num">{{ r.attempt_count }}</td>
+                <td><a href="{{ r.sample_url }}" target="_blank" rel="noopener noreferrer">{{ r.sample_title }}</a></td>
+                <td title="První viděno: {{ r.first_seen_at_str() }}">{{ r.last_seen_at_str() }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% endif %}
+</main>
+
+<style>
+.admin-prehrajto-page { max-width: 1280px; margin: 0 auto; padding: 1rem; }
+.admin-prehrajto-page .lead { color: #555; margin: 1rem 0; }
+.admin-prehrajto-page .lead code { background: #f1f5f9; padding: 0.1rem 0.3rem; border-radius: 3px; font-size: 0.85em; }
+.admin-prehrajto-page .lead a { color: #11457E; text-decoration: none; }
+.admin-prehrajto-page .lead a:hover { text-decoration: underline; }
+.stats { display: flex; gap: 1.5rem; margin: 1.2rem 0; align-items: center; }
+.stat { display: flex; flex-direction: column; padding: 0.6rem 1rem; background: #f8fafc; border-radius: 6px; min-width: 140px; }
+.stat-num { font-size: 1.4rem; font-weight: 700; color: #11457E; }
+.stat-label { font-size: 0.75rem; color: #666; text-transform: uppercase; letter-spacing: 0.03em; }
+.csv-link { color: #11457E; text-decoration: none; font-weight: 600; padding: 0.6rem 1rem; background: #f8fafc; border-radius: 6px; }
+.csv-link:hover { background: #e2e8f0; }
+.hint { color: #666; font-size: 0.85rem; margin: 0.8rem 0; }
+.unmatched-table { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
+.unmatched-table th, .unmatched-table td { padding: 0.45rem 0.6rem; border-bottom: 1px solid #eee; text-align: left; vertical-align: top; }
+.unmatched-table th.num, .unmatched-table td.num { text-align: right; }
+.unmatched-table th { background: #f8fafc; font-weight: 600; color: #555; position: sticky; top: 0; }
+.unmatched-table a { color: #11457E; text-decoration: none; }
+.unmatched-table a:hover { text-decoration: underline; }
+.unmatched-table code { font-size: 0.78rem; color: #555; }
+.empty-state { color: #888; padding: 2rem; text-align: center; background: #fafafa; border-radius: 8px; }
+.breadcrumb { font-size: 0.85rem; color: #888; margin-bottom: 1.2rem; }
+.breadcrumb a { color: #11457E; text-decoration: none; }
+</style>
+{% endblock %}

--- a/cr-web/templates/admin_prehrajto_unmatched.html
+++ b/cr-web/templates/admin_prehrajto_unmatched.html
@@ -36,7 +36,7 @@
         </div>
         <div class="stat">
             <span class="stat-num">{{ total_uploads }}</span>
-            <span class="stat-label">celkem uploadů na prehraj.to</span>
+            <span class="stat-label">celkem uploadů v nesparovaných clusterech</span>
         </div>
         <div class="stat">
             <a class="csv-link" href="/admin/prehrajto/unmatched.csv">⬇ CSV export</a>

--- a/scripts/import-prehrajto-uploads.py
+++ b/scripts/import-prehrajto-uploads.py
@@ -514,6 +514,12 @@ def main() -> int:
     print(f"Parsing {len(files)} sitemaps from {sitemap_dir}...")
     t0 = time.time()
     clusters: dict[tuple, list[dict]] = defaultdict(list)
+    # #657: registry of film-shape clusters that did NOT match any wanted
+    # key. Bucketed by their first cluster_key_candidate (the most
+    # specific normalized form). Each entry tracks the distinct set of
+    # upload_ids seen this run so `upload_count` is a true snapshot, not
+    # a cumulative counter inflated by re-seeing the same uploads.
+    unmatched_clusters: dict[tuple, dict] = {}
     total_entries = 0
     film_shape_count = 0
     for p in files:
@@ -527,13 +533,33 @@ def main() -> int:
             # full-title core first (preserves prior behaviour for
             # exact matches), then split segments, then first-word.
             # Using a single bucket per row keeps de-duplication trivial.
-            for k in cluster_key_candidates(r):
+            candidates = cluster_key_candidates(r)
+            matched = False
+            for k in candidates:
                 if k in wanted_keys:
                     clusters[k].append(r)
+                    matched = True
                     break
+            if not matched and candidates:
+                # Use the first candidate as the canonical "unmatched"
+                # key — same shape as wanted_keys so #652 can later
+                # consult this registry with identical key arithmetic.
+                uk = candidates[0]
+                bucket = unmatched_clusters.get(uk)
+                if bucket is None:
+                    bucket = {
+                        "sample_title": r["title"],
+                        "sample_url": r["url"],
+                        "upload_ids": set(),
+                    }
+                    unmatched_clusters[uk] = bucket
+                uid = extract_upload_id(r["url"])
+                if uid:
+                    bucket["upload_ids"].add(uid)
     print(f"  {total_entries:,} total entries scanned in {time.time()-t0:.1f}s")
     print(f"  {film_shape_count:,} film-shape entries")
     print(f"  {len(clusters):,} clusters matched wanted set")
+    print(f"  {len(unmatched_clusters):,} clusters did NOT match (#657 registry)")
 
     if conn_for_matches is not None:
         conn_for_matches.close()
@@ -547,6 +573,50 @@ def main() -> int:
         cur.execute("SELECT COUNT(*) FROM films")
         films_count_before = cur.fetchone()[0]
         print(f"films baseline count: {films_count_before:,}")
+
+        # ---- #657: persist unmatched-cluster registry ----
+        # UPSERT happens up front (separate from the films loop) so the
+        # observability data lands on disk even if a later step aborts.
+        # `upload_count` is replaced with this run's snapshot rather than
+        # accumulated — repeated sightings of the same upload_id should
+        # not inflate the count.
+        if unmatched_clusters:
+            unmatched_upsert_sql = """
+                INSERT INTO prehrajto_unmatched_clusters
+                    (cluster_key, year, duration_bucket,
+                     sample_title, sample_url, upload_count,
+                     first_seen_at, last_seen_at, last_attempt_at,
+                     attempt_count, last_failure_reason)
+                VALUES
+                    (%(cluster_key)s, %(year)s, %(duration_bucket)s,
+                     %(sample_title)s, %(sample_url)s, %(upload_count)s,
+                     NOW(), NOW(), NOW(), 1,
+                     'no films match for cluster key (importer skip)')
+                ON CONFLICT (cluster_key, year, duration_bucket) DO UPDATE SET
+                    sample_title        = EXCLUDED.sample_title,
+                    sample_url          = EXCLUDED.sample_url,
+                    upload_count        = EXCLUDED.upload_count,
+                    last_seen_at        = EXCLUDED.last_seen_at,
+                    last_attempt_at     = EXCLUDED.last_attempt_at,
+                    attempt_count       = prehrajto_unmatched_clusters.attempt_count + 1,
+                    last_failure_reason = EXCLUDED.last_failure_reason
+                WHERE prehrajto_unmatched_clusters.resolved_at IS NULL
+            """
+            unmatched_rows = [
+                {
+                    "cluster_key": k[0],
+                    "year": k[1],
+                    "duration_bucket": k[2],
+                    "sample_title": v["sample_title"],
+                    "sample_url": v["sample_url"],
+                    "upload_count": len(v["upload_ids"]),
+                }
+                for k, v in unmatched_clusters.items()
+            ]
+            psycopg2.extras.execute_batch(
+                cur, unmatched_upsert_sql, unmatched_rows, page_size=500,
+            )
+            print(f"  unmatched registry upserted: {len(unmatched_rows):,} rows")
 
         # Pre-fetch imdb_id → film_id for all candidate imdb_ids (deduped —
         # many cluster keys can share the same IMDb ID).
@@ -856,6 +926,47 @@ def main() -> int:
             print(f"  legacy film_prehrajto_uploads → {mark_dead_legacy_total:,} rows flagged dead")
             print(f"  unified video_sources         → {mark_dead_vs_total:,} rows flagged dead")
             print(f"  ({time.time()-t_md:.1f}s)")
+
+        # ---- #657: mark resolved unmatched clusters ----
+        # Any cluster key that DID match wanted_keys this run AND now
+        # exists as a row in `films` should be flagged resolved in the
+        # registry. The match goes through the same (cluster_key, year,
+        # duration_bucket) triple #657 stored, so direct hits get
+        # cleared. Indirect hits (upload's first candidate differs from
+        # the films-side candidate that won the match — e.g. localized
+        # vs. original_title) are left for a later run to clear when the
+        # cluster shows up under that exact form, or for the operator
+        # to clean up manually. False negatives here are harmless.
+        resolved_pairs: list[dict] = []
+        for key in clusters:
+            match = matches_by_key.get(key)
+            if not match:
+                continue
+            film_id = imdb_to_film_id.get(match["imdb_id"])
+            if film_id is None:
+                continue
+            resolved_pairs.append({
+                "cluster_key": key[0],
+                "year": key[1],
+                "duration_bucket": key[2],
+                "film_id": film_id,
+            })
+        if resolved_pairs:
+            update_resolved_sql = """
+                UPDATE prehrajto_unmatched_clusters
+                   SET resolved_at      = NOW(),
+                       resolved_film_id = %(film_id)s
+                 WHERE resolved_at IS NULL
+                   AND cluster_key      = %(cluster_key)s
+                   AND year IS NOT DISTINCT FROM %(year)s
+                   AND duration_bucket  = %(duration_bucket)s
+            """
+            psycopg2.extras.execute_batch(
+                cur, update_resolved_sql, resolved_pairs, page_size=500,
+            )
+            print(f"  unmatched registry: marked-resolved attempts = "
+                  f"{len(resolved_pairs):,} (rowcount may be lower — "
+                  f"only previously-unresolved entries flip)")
 
         # ---- Invariant: films count unchanged ----
         # In live mode with batched commits, earlier batches are already committed;

--- a/scripts/import-prehrajto-uploads.py
+++ b/scripts/import-prehrajto-uploads.py
@@ -575,11 +575,19 @@ def main() -> int:
         print(f"films baseline count: {films_count_before:,}")
 
         # ---- #657: persist unmatched-cluster registry ----
-        # UPSERT happens up front (separate from the films loop) so the
-        # observability data lands on disk even if a later step aborts.
-        # `upload_count` is replaced with this run's snapshot rather than
-        # accumulated — repeated sightings of the same upload_id should
-        # not inflate the count.
+        # UPSERT happens before the films loop so this observability data
+        # lands within the same transaction as the films work — keeping
+        # them coupled means a fatal error rolls both back together
+        # (including dry-run, which is the desired behavior). On
+        # subsequent sightings we refresh `last_seen_at` + the snapshot
+        # fields, but explicitly leave `last_attempt_at`,
+        # `attempt_count`, and `last_failure_reason` untouched: the
+        # current importer doesn't call TMDB / try to resolve, so a
+        # sitemap parse is NOT a resolution attempt and bumping those
+        # fields would defeat #652's planned 7-day skip-window arithmetic
+        # and overwrite TMDB-specific failure diagnostics it will set.
+        # `last_failure_reason` uses COALESCE so the initial generic
+        # reason persists only until #652 sets a more specific one.
         if unmatched_clusters:
             unmatched_upsert_sql = """
                 INSERT INTO prehrajto_unmatched_clusters
@@ -597,9 +605,9 @@ def main() -> int:
                     sample_url          = EXCLUDED.sample_url,
                     upload_count        = EXCLUDED.upload_count,
                     last_seen_at        = EXCLUDED.last_seen_at,
-                    last_attempt_at     = EXCLUDED.last_attempt_at,
-                    attempt_count       = prehrajto_unmatched_clusters.attempt_count + 1,
-                    last_failure_reason = EXCLUDED.last_failure_reason
+                    last_failure_reason = COALESCE(
+                        prehrajto_unmatched_clusters.last_failure_reason,
+                        EXCLUDED.last_failure_reason)
                 WHERE prehrajto_unmatched_clusters.resolved_at IS NULL
             """
             unmatched_rows = [


### PR DESCRIPTION
<!-- claude-session: 98d65447-0cc0-4c98-a612-a9b5c0699023 -->

Closes #657

## Summary

- Persists every film-shape cluster the prehraj.to importer cannot match against the `films` table into a new `prehrajto_unmatched_clusters` registry.
- Surfaces them at `/admin/prehrajto/unmatched` (sortable table + CSV export), so the operator sees which titles consistently get dropped and where the matching heuristic is too strict.
- Marks rows `resolved_at` when matching catches up (operator adds the film, or films-side candidates broaden).
- This is a prerequisite for #652 (auto-import brand-new films via TMDB + Gemma): #652 will consult `last_attempt_at` to skip clusters that recently failed TMDB lookup, instead of burning rate-limit each day on the same nematche.

## Why this matters

Today the importer silently drops unmatched clusters — we don't know how many films we miss, which titles propadají sítem, or whether previously unmatched clusters got resolved. After this PR we have the persistent log + dashboard.

Sample of what the dashboard surfaces on prod (top by upload_count):

| Cluster key | Year | Uploads | Sample title |
|---|---|---|---|
| boykaundisputedivvobraze | 2016 | 77 | Boyka Undisputed IV (2016) CZtit |
| spiderman2 | 2004 | 51 | Spiderman 2, CZ dabing (2004) |
| karatekid | 2010 | 45 | Karate Kid 2010 CZ Dabing |
| sebevrazednyoddil | 2016 | 44 | Sebevražedný oddíl [CZ dabing, 2016] |
| spiderman3 | 2007 | 44 | Spiderman 3, CZ dabing (2007) |
| aliance | 2016 | 43 | Aliance 2016 CZ Dabing NOVINKA |
| needforspeed | 2014 | 38 | Need for Speed .2014.CZ Dabing |

Most of these are films we DO have in the DB — the registry exposes specific gaps in the matching heuristic (concatenated localized + original title forms that `cluster_key_candidates()` misses).

## What's in the PR

- `cr-infra/migrations/20260604_064_prehrajto_unmatched_clusters.sql` — new table + two partial indexes (unresolved-only by `upload_count DESC` and by `last_attempt_at`)
- `scripts/import-prehrajto-uploads.py` — collect unmatched film-shape rows during the parse loop, UPSERT to registry up front (so observability lands even if a later step aborts), and bulk-mark resolved at the end of the run
- `cr-web/src/handlers/admin_prehrajto.rs` + template — read-only dashboard with paginated table (top 500 by upload_count), aggregate stats over the full unresolved set, CSV export
- Tile on `/admin/` dashboard linking to it

## Test plan

- [x] `cargo check`, `cargo clippy -- -D warnings`, `cargo test --workspace`, `cargo fmt --check` — all green
- [x] Migration applied on `cr_dev` via `psql` — table + indexes created cleanly
- [x] Local importer dry-run against single sitemap shard: 2,591 unmatched clusters detected, UPSERT path works, mark-resolved logic exercised
- [x] Local cr-web: `/admin/prehrajto/unmatched` (HTTP 200, 324 KB) and `/admin/prehrajto/unmatched.csv` (HTTP 200, 99 KB) both render correctly
- [x] Cross-compiled `cr-web` (cargo zigbuild aarch64-musl), uploaded binary + script + migration to prod
- [x] Stopped + restarted `cr-web-1` container (bind-mount on `/opt/cr/cr-web-bin` — replaced host file directly)
- [x] Migration auto-applied on startup (logs: "Database migrations applied")
- [x] Ran importer on prod with `--limit 10 --no-mark-dead`: **45,739 unmatched clusters persisted**, 85,254 total uploads
- [x] Playwright E2E: `https://ceskarepublika.wiki/admin/prehrajto/unmatched` renders top 500 sorted by upload_count, sample URLs are clickable, **0 console errors**
- [x] `https://ceskarepublika.wiki/admin/` shows new "🔍 Prehraj.to nesparované" tile linking to the dashboard
- [x] CSV download via Playwright works (Content-Disposition triggers browser download)

## Out of scope (follow-ups in #656 epic)

- TMDB lookup integration — that's #652, which will consume the `last_attempt_at` field added here
- ID rotation observability — #658
- Per-source media verification (lang + resolution) — #659

🤖 Generated with [Claude Code](https://claude.com/claude-code)