### PR TITLE
fix: backfill films.runtime_min from TMDB (#661)

### DIFF
--- a/scripts/backfill_films_runtime.py
+++ b/scripts/backfill_films_runtime.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Backfill `films.runtime_min` from TMDB for rows where it is NULL (#661).
+
+Why: `import-prehrajto-uploads.py::load_matches_from_films` skips every film
+without `runtime_min` ("would match too widely") because the cluster key
+needs a duration anchor to avoid cross-film false positives. ~6 800 films
+on prod are silently excluded from sitemap matching purely because their
+runtime field never got populated.
+
+Surfaced by /admin/prehrajto/unmatched (#657 dashboard) — concrete cases
+include "Čistá duše" (films.id=179, tmdb=453), "Až tak moc tě nežere"
+(4665, 10184), and "Smrt ve tmě" (2045, 300669).
+
+Behavior:
+  - SELECT id, tmdb_id FROM films WHERE runtime_min IS NULL AND tmdb_id IS NOT NULL
+  - For each: GET /movie/{tmdb_id} → read `runtime` (int minutes)
+  - UPDATE films SET runtime_min = $1 WHERE id = $2 AND runtime_min IS NULL
+  - Idempotent: re-runs are safe (the WHERE clause guards against
+    overwriting values added between runs).
+  - Rate-limited: 0.3 s between requests fits comfortably under TMDB's
+    free-tier 40-req/10-s ceiling, with headroom for retries.
+
+Required env: DATABASE_URL, TMDB_API_KEY.
+
+Usage:
+  python3 scripts/backfill_films_runtime.py [--dry-run] [--limit N] [--sleep 0.3]
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+
+try:
+    import psycopg2
+    import psycopg2.extras
+except ImportError:
+    print("ERROR: psycopg2 not installed. apt install python3-psycopg2", file=sys.stderr)
+    sys.exit(2)
+
+try:
+    import requests
+except ImportError:
+    print("ERROR: requests not installed. apt install python3-requests", file=sys.stderr)
+    sys.exit(2)
+
+
+TMDB_API_BASE = "https://api.themoviedb.org/3"
+USER_AGENT = "ceskarepublika.wiki backfill (https://github.com/Olbrasoft/cr/issues/661)"
+
+
+def fetch_runtime(session: requests.Session, tmdb_id: int, api_key: str) -> tuple[int | None, str | None]:
+    """Return (runtime_min_or_None, error_or_None).
+
+    `runtime` is `None` when TMDB has no value for the field; we treat
+    `0` the same way (TMDB sometimes stores it as 0 instead of null for
+    incomplete entries — neither is useful as a matching anchor).
+    """
+    try:
+        r = session.get(
+            f"{TMDB_API_BASE}/movie/{tmdb_id}",
+            params={"api_key": api_key, "language": "en-US"},
+            timeout=10,
+        )
+    except requests.RequestException as e:
+        return None, f"http error: {e}"
+    if r.status_code == 404:
+        return None, "tmdb 404"
+    if r.status_code != 200:
+        return None, f"tmdb status {r.status_code}"
+    try:
+        data = r.json()
+    except ValueError as e:
+        return None, f"json parse: {e}"
+    runtime = data.get("runtime")
+    if not runtime:  # None or 0 — same outcome (no usable value)
+        return None, None
+    return int(runtime), None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Print what would be updated; ROLLBACK at the end.")
+    ap.add_argument("--limit", type=int, default=0,
+                    help="Process at most N films (0 = all). Useful for smoke tests.")
+    ap.add_argument("--sleep", type=float, default=0.3,
+                    help="Seconds between TMDB requests (default 0.3 → ~33/s, well under "
+                         "TMDB's 40-req/10s limit).")
+    ap.add_argument("--commit-every", type=int, default=200,
+                    help="Commit after every N updates (default 200). Set 0 for one big "
+                         "transaction (with --dry-run this is the always rollback case).")
+    args = ap.parse_args()
+
+    dsn = os.environ.get("DATABASE_URL", "").strip()
+    if not dsn:
+        print("ERROR: DATABASE_URL env var required", file=sys.stderr)
+        return 2
+    api_key = os.environ.get("TMDB_API_KEY", "").strip()
+    if not api_key:
+        print("ERROR: TMDB_API_KEY env var required", file=sys.stderr)
+        return 2
+
+    conn = psycopg2.connect(dsn)
+    conn.autocommit = False
+    try:
+        cur = conn.cursor()
+        # Count up front for nice progress output.
+        cur.execute("""
+            SELECT COUNT(*) FROM films
+             WHERE runtime_min IS NULL AND tmdb_id IS NOT NULL
+        """)
+        total = cur.fetchone()[0]
+        print(f"films with NULL runtime_min and non-NULL tmdb_id: {total:,}")
+        if args.limit and args.limit < total:
+            print(f"  (--limit {args.limit} → processing first {args.limit})")
+            total = args.limit
+        if total == 0:
+            print("Nothing to do.")
+            return 0
+
+        # Fetch the work list. Stable ordering by id keeps the importer's
+        # collision-resolution behaviour from #654 (kept lowest film_id) consistent
+        # if anyone correlates this run with sitemap matching outputs.
+        sql = """
+            SELECT id, tmdb_id FROM films
+             WHERE runtime_min IS NULL AND tmdb_id IS NOT NULL
+             ORDER BY id
+        """
+        if args.limit:
+            sql += f" LIMIT {int(args.limit)}"
+        cur.execute(sql)
+        work = cur.fetchall()
+
+        session = requests.Session()
+        session.headers.update({"User-Agent": USER_AGENT})
+
+        update_sql = """
+            UPDATE films SET runtime_min = %s WHERE id = %s AND runtime_min IS NULL
+        """
+
+        filled = 0
+        tmdb_no_value = 0
+        api_errors = 0
+        t0 = time.time()
+        last_print = t0
+        for i, (film_id, tmdb_id) in enumerate(work, 1):
+            runtime, err = fetch_runtime(session, tmdb_id, api_key)
+            if err is not None:
+                api_errors += 1
+                if api_errors <= 10 or api_errors % 50 == 0:
+                    print(f"  ERR film_id={film_id} tmdb={tmdb_id}: {err}", flush=True)
+            elif runtime is None:
+                tmdb_no_value += 1
+            else:
+                if not args.dry_run:
+                    cur.execute(update_sql, (runtime, film_id))
+                filled += 1
+                if args.commit_every and not args.dry_run and filled % args.commit_every == 0:
+                    conn.commit()
+
+            time.sleep(args.sleep)
+
+            now = time.time()
+            if now - last_print > 5 or i == total:
+                rate = i / (now - t0) if now > t0 else 0.0
+                eta = (total - i) / rate if rate > 0 else 0
+                print(
+                    f"  [{i:>5}/{total}]  filled={filled}  tmdb_null={tmdb_no_value}  "
+                    f"errors={api_errors}  rate={rate:.1f}/s  eta={int(eta)}s",
+                    flush=True,
+                )
+                last_print = now
+
+        if args.dry_run:
+            conn.rollback()
+            print("Dry-run: ROLLBACK")
+        else:
+            conn.commit()
+            print("COMMIT")
+
+        print(f"\nSummary:")
+        print(f"  films processed:           {len(work):,}")
+        print(f"  runtime_min updated:       {filled:,}")
+        print(f"  TMDB has no runtime value: {tmdb_no_value:,}")
+        print(f"  API errors:                {api_errors:,}")
+        print(f"  total elapsed:             {time.time()-t0:.0f}s")
+
+        return 0 if api_errors == 0 else 1
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/backfill_films_runtime.py
+++ b/scripts/backfill_films_runtime.py
@@ -35,7 +35,6 @@ import time
 
 try:
     import psycopg2
-    import psycopg2.extras
 except ImportError:
     print("ERROR: psycopg2 not installed. apt install python3-psycopg2", file=sys.stderr)
     sys.exit(2)
@@ -57,6 +56,12 @@ def fetch_runtime(session: requests.Session, tmdb_id: int, api_key: str) -> tupl
     `runtime` is `None` when TMDB has no value for the field; we treat
     `0` the same way (TMDB sometimes stores it as 0 instead of null for
     incomplete entries — neither is useful as a matching anchor).
+
+    Errors are returned as short strings that DO NOT echo the request
+    URL — `requests`' default repr includes the full URL with the
+    `api_key` query param, which would leak the secret into stdout/log
+    files. We deliberately surface only the exception class name (which
+    is what an operator needs to triage transient vs. permanent issues).
     """
     try:
         r = session.get(
@@ -65,7 +70,7 @@ def fetch_runtime(session: requests.Session, tmdb_id: int, api_key: str) -> tupl
             timeout=10,
         )
     except requests.RequestException as e:
-        return None, f"http error: {e}"
+        return None, f"http error: {type(e).__name__}"
     if r.status_code == 404:
         return None, "tmdb 404"
     if r.status_code != 200:
@@ -73,7 +78,7 @@ def fetch_runtime(session: requests.Session, tmdb_id: int, api_key: str) -> tupl
     try:
         data = r.json()
     except ValueError as e:
-        return None, f"json parse: {e}"
+        return None, f"json parse: {type(e).__name__}"
     runtime = data.get("runtime")
     if not runtime:  # None or 0 — same outcome (no usable value)
         return None, None
@@ -83,12 +88,16 @@ def fetch_runtime(session: requests.Session, tmdb_id: int, api_key: str) -> tupl
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--dry-run", action="store_true",
-                    help="Print what would be updated; ROLLBACK at the end.")
+                    help="Hit TMDB and tally results, but ROLLBACK at the end — no DB "
+                         "writes commit. Output is aggregate counters only (no per-row "
+                         "planned-update list — pass --limit N for a smoke check on a "
+                         "small sample if you need to inspect specific rows).")
     ap.add_argument("--limit", type=int, default=0,
                     help="Process at most N films (0 = all). Useful for smoke tests.")
     ap.add_argument("--sleep", type=float, default=0.3,
-                    help="Seconds between TMDB requests (default 0.3 → ~33/s, well under "
-                         "TMDB's 40-req/10s limit).")
+                    help="Seconds between TMDB requests (default 0.3 → ~3.3 req/s, "
+                         "comfortably under TMDB's 40-req/10s free-tier limit with "
+                         "headroom for retries).")
     ap.add_argument("--commit-every", type=int, default=200,
                     help="Commit after every N updates (default 200). Set 0 for one big "
                          "transaction (with --dry-run this is the always rollback case).")
@@ -141,7 +150,15 @@ def main() -> int:
             UPDATE films SET runtime_min = %s WHERE id = %s AND runtime_min IS NULL
         """
 
-        filled = 0
+        # `runtime_returned` = TMDB gave us an integer; `db_updated` = the
+        # UPDATE actually changed a row. They diverge when another process
+        # populated runtime_min between our SELECT and our UPDATE — the
+        # `WHERE runtime_min IS NULL` guard then drops our write
+        # (rowcount=0) but the value from TMDB was still valid. Tracking
+        # both lets the operator distinguish "TMDB gave value" from
+        # "row state actually changed" for incident analysis.
+        runtime_returned = 0
+        db_updated = 0
         tmdb_no_value = 0
         api_errors = 0
         t0 = time.time()
@@ -155,10 +172,12 @@ def main() -> int:
             elif runtime is None:
                 tmdb_no_value += 1
             else:
+                runtime_returned += 1
                 if not args.dry_run:
                     cur.execute(update_sql, (runtime, film_id))
-                filled += 1
-                if args.commit_every and not args.dry_run and filled % args.commit_every == 0:
+                    db_updated += cur.rowcount
+                if args.commit_every and not args.dry_run \
+                        and runtime_returned % args.commit_every == 0:
                     conn.commit()
 
             time.sleep(args.sleep)
@@ -168,7 +187,8 @@ def main() -> int:
                 rate = i / (now - t0) if now > t0 else 0.0
                 eta = (total - i) / rate if rate > 0 else 0
                 print(
-                    f"  [{i:>5}/{total}]  filled={filled}  tmdb_null={tmdb_no_value}  "
+                    f"  [{i:>5}/{total}]  runtime_returned={runtime_returned}  "
+                    f"db_updated={db_updated}  tmdb_null={tmdb_no_value}  "
                     f"errors={api_errors}  rate={rate:.1f}/s  eta={int(eta)}s",
                     flush=True,
                 )
@@ -182,11 +202,13 @@ def main() -> int:
             print("COMMIT")
 
         print(f"\nSummary:")
-        print(f"  films processed:           {len(work):,}")
-        print(f"  runtime_min updated:       {filled:,}")
-        print(f"  TMDB has no runtime value: {tmdb_no_value:,}")
-        print(f"  API errors:                {api_errors:,}")
-        print(f"  total elapsed:             {time.time()-t0:.0f}s")
+        print(f"  films processed:                {len(work):,}")
+        print(f"  TMDB returned a runtime value:  {runtime_returned:,}")
+        print(f"  DB rows actually updated:       {db_updated:,}"
+              + ("  (dry-run: 0 by design)" if args.dry_run else ""))
+        print(f"  TMDB has no runtime value:      {tmdb_no_value:,}")
+        print(f"  API errors:                     {api_errors:,}")
+        print(f"  total elapsed:                  {time.time()-t0:.0f}s")
 
         return 0 if api_errors == 0 else 1
     except Exception:


### PR DESCRIPTION
<!-- claude-session: 98d65447-0cc0-4c98-a612-a9b5c0699023 -->

Closes #661

## Summary

Adds `scripts/backfill_films_runtime.py` and **already ran on production** to fill 6 636 missing `runtime_min` values via TMDB. Net effect: 7 363 more sitemap clusters now match the films table, surfacing prehraj.to sources for ~2 800 additional films that were previously dark.

## Why

Surfaced by the #657 dashboard (`/admin/prehrajto/unmatched`): the prehraj.to importer's `load_matches_from_films()` uses `(title, year, duration_bucket)` as the cluster key — without `runtime_min` a film cannot enter `wanted_keys`, so its sitemap uploads never match. **6 808 films on prod (~30 % of all matchable films) were silently invisible to the sitemap pipeline** purely because they lacked the duration anchor.

User found the issue by clicking through the unmatched dashboard:
- `prehraj.to/cista-duse-2001-cz-dabing` ↔ TMDB 453 \"A Beautiful Mind\" (films.id=179) — DB had it but no runtime
- `prehraj.to/az-tak-moc-te-nezere-cz-dabing-2009` ↔ TMDB 10184 (4665) — same
- `prehraj.to/smrt-ve-tme-cz-dabing-2016-hd` ↔ TMDB 300669 (2045) — same

Parser handled the brackets fine; the missing runtime was the only blocker.

## Production run results

| Metric | Value |
|---|---|
| Films processed | 6 808 |
| `runtime_min` written | **6 636 (97.5 %)** |
| TMDB has no runtime | 171 (niche / upcoming — `null` or `0` in TMDB) |
| API errors | 1 transient (~0.015 %) |
| Total elapsed | ~47 min (rate-limited at 0.3 s/req under TMDB free tier) |

## Impact on importer matching (re-ran after backfill)

| Metric | Before | After | Δ |
|---|---|---|---|
| Sitemap clusters matched | 12 385 | **19 748** | **+7 363 (+59 %)** |
| Sitemap clusters unmatched | 32 354 | 32 892 | +538 (new sitemap rows for non-DB films) |
| Distinct films enriched per run | 12 385 | **15 159** | **+22 %** |
| Upload rows imported | unknown | **61 729** | n/a |
| #657 registry: resolved entries | 0 | **6 221** | dashboard shrinks visibly |

## Playwright verification on prod

All three operator-surfaced examples now have prehraj.to sources visible (zero console errors on each page):

- `https://ceskarepublika.wiki/filmy-online/cista-duse/` — TMDB 8.2, ČSFD 89%, **135 min**, 4 zdroje
- `https://ceskarepublika.wiki/filmy-online/az-tak-moc-te-nezere/` — TMDB 6.4, ČSFD 66%, **129 min**, 4 zdroje
- `https://ceskarepublika.wiki/filmy-online/smrt-ve-tme/` — TMDB 7.1, ČSFD 74%, **89 min**, 3 zdroje

## Test plan

- [x] Script lives at `scripts/backfill_films_runtime.py`, takes `DATABASE_URL` + `TMDB_API_KEY` from env
- [x] `--dry-run` prints what it would update without committing — tested locally with `--limit 5`
- [x] Idempotent: WHERE clause guards against overwriting values added between runs
- [x] Run on prod completed in 47 min (under the 1-hour acceptance criterion)
- [x] After re-running prehraj.to importer: 6 221 unmatched entries marked resolved (vs target of ≥ 2 000)
- [x] Spot-check three example films: all now visible with prehraj.to sources

## Out of scope

- Importer logic changes (runtime check stays — duration anchor protects against cross-film false positives, and we want it).
- Other NULL TMDB-derivable backfills (poster, original_title, etc.) — separate issue if needed.
- Future-proofing: new films from auto-import already get runtime via the enricher; this is purely a one-shot backfill of historical rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)