### PR TITLE
fix(prehrajto-resolver): title-similarity gate to reject ambiguous TMDB matches

### DIFF
--- a/scripts/resolve-unmatched-via-llm.py
+++ b/scripts/resolve-unmatched-via-llm.py
@@ -166,20 +166,26 @@ def _title_match_acceptable(best_sim: float,
        - sim ≥ 0.95 (near-exact) → accept regardless of year. Handles
          "2001: Vesmírná Odysea (2001)" → 1968 Kubrick: title nails it,
          the upload "year" is the in-title number not release year.
-       - 0.85 ≤ sim < 0.95 → accept only if year_diff ≤ 15 (block the
-         remake trap: "Freaky Friday 2003" → 'Freakier Friday' 2025
-         scored sim=0.86, year_diff=25 → reject).
-       - 0.50 ≤ sim < 0.85 → accept only if year_diff ≤ 5 (typical
-         medium-confidence match where year is the disambiguator).
+       - 0.85 ≤ sim < 0.95 → accept only if year_diff is known AND
+         year_diff ≤ 15 (block the remake trap: "Freaky Friday 2003"
+         → 'Freakier Friday' 2025 scored sim=0.86, year_diff=25 →
+         reject). Unknown year_diff falls into the same bucket as
+         too-far year_diff because the year gate's whole point is to
+         catch these strong-but-not-exact cases — accepting on title
+         alone there reintroduces the false positives this guard was
+         added to block.
+       - 0.50 ≤ sim < 0.85 → accept only if year_diff is known AND
+         year_diff ≤ 5 (typical medium-confidence match where year
+         is the disambiguator).
        - sim < 0.50 → always reject.
     """
     if best_sim >= _TITLE_SIM_NEAR_EXACT:
         return True
     if best_sim >= _TITLE_SIM_STRONG:
-        return year_diff is None or year_diff <= _YEAR_DIFF_REMAKE
+        return year_diff is not None and year_diff <= _YEAR_DIFF_REMAKE
     if best_sim < _TITLE_SIM_MIN:
         return False
-    return year_diff is None or year_diff <= _YEAR_DIFF_MAX
+    return year_diff is not None and year_diff <= _YEAR_DIFF_MAX
 
 
 def _extract_json(text: str) -> Optional[dict]:
@@ -403,7 +409,8 @@ def main() -> int:
     # for NEW_TMDB candidates.
     resolver_reasons = (
         "llm_gemini_failed", "llm_bad_shape", "llm_not_film", "llm_no_title",
-        "tmdb_no_hit", "tmdb_runtime_mismatch", "awaiting_film_import",
+        "tmdb_no_hit", "tmdb_runtime_mismatch", "tmdb_title_mismatch",
+        "awaiting_film_import",
     )
     cur.execute("""
         SELECT id, sample_title, year, duration_bucket * 3 AS dur_min, upload_count
@@ -556,9 +563,13 @@ def main() -> int:
             [tmdb_title, tmdb_original_title],
         )
         if not _title_match_acceptable(best_sim, year_diff):
+            # Record the failure reason WITHOUT writing `resolved_tmdb_id`
+            # — that column is reserved for "TMDB ID known and ready for
+            # auto-import" (#652) and is partially indexed for the
+            # dashboard. Storing a rejected candidate there would
+            # pollute the import queue.
             counters["NO_TMDB"] += 1
-            _record_attempt(rid, reason="tmdb_title_mismatch",
-                            tmdb_id=tmdb_id)
+            _record_attempt(rid, reason="tmdb_title_mismatch")
             print(f"[{i:>3}] NO_TMDB    {sample_title[:60]} → "
                   f"tmdb={tmdb_id} '{tmdb_title}' {tmdb_year} "
                   f"sim={best_sim:.2f} year_diff={year_diff} (rejected)",

--- a/scripts/resolve-unmatched-via-llm.py
+++ b/scripts/resolve-unmatched-via-llm.py
@@ -40,11 +40,13 @@ Output: prints one line per cluster with the resolution outcome:
 from __future__ import annotations
 
 import argparse
+import difflib
 import json
 import os
 import re
 import sys
 import time
+import unicodedata
 import urllib.parse
 from typing import Optional
 
@@ -113,6 +115,71 @@ Hint duration in minutes (may be wrong): __DURATION__
 
 
 _JSON_RE = re.compile(r"\{[^{}]*\}", re.DOTALL)
+
+# Title similarity acceptance — see `_title_match_acceptable()` for the
+# combined title × year decision logic. Tuned against the false-positive
+# inventory from the first 500-cluster batch (e.g. "MÉDA TED 2"→Bear with
+# Two Lovers, "SAW 8"→Příchozí 2017, "Skurvenej Pátek 2000"→Freakier
+# Friday 2025): Gemma + TMDB-popularity sort can both point at a wrong
+# film when the upload string is ambiguous, so we cross-check Gemma's
+# extracted title (original AND English form) against TMDB's localized
+# `title` AND `original_title` and gate by year proximity.
+_TITLE_SIM_NEAR_EXACT = 0.95  # accept regardless of year
+_TITLE_SIM_STRONG     = 0.85  # accept if year_diff ≤ remake-window
+_TITLE_SIM_MIN        = 0.50  # below: reject outright
+_YEAR_DIFF_REMAKE     = 15    # strong-similarity, far years → likely remake
+_YEAR_DIFF_MAX        = 5     # medium-similarity gate
+
+_NORMALIZE_KEEP_RE = re.compile(r"[^a-z0-9 ]+")
+
+
+def _normalize_for_match(s: str) -> str:
+    """Lowercase + strip diacritics + drop punctuation, for fuzzy title
+    comparison. Mirrors how the regex matcher normalizes — keeps Czech
+    "Doba ľadová"/"Doba ledová" / English-Czech variants comparable."""
+    nfd = unicodedata.normalize("NFD", s)
+    no_marks = "".join(c for c in nfd if unicodedata.category(c) != "Mn")
+    return _NORMALIZE_KEEP_RE.sub(" ", no_marks.lower()).strip()
+
+
+def _title_similarity(a: Optional[str], b: Optional[str]) -> float:
+    if not a or not b:
+        return 0.0
+    return difflib.SequenceMatcher(
+        None, _normalize_for_match(a), _normalize_for_match(b)
+    ).ratio()
+
+
+def _best_title_similarity(gemma_titles: list[Optional[str]],
+                           tmdb_titles: list[Optional[str]]) -> float:
+    return max(
+        (_title_similarity(g, t) for g in gemma_titles for t in tmdb_titles),
+        default=0.0,
+    )
+
+
+def _title_match_acceptable(best_sim: float,
+                            year_diff: Optional[int]) -> bool:
+    """3-tier accept rule, tuned to reject the remake/sequel trap
+    without false-rejecting legitimate diacritic / language variants:
+
+       - sim ≥ 0.95 (near-exact) → accept regardless of year. Handles
+         "2001: Vesmírná Odysea (2001)" → 1968 Kubrick: title nails it,
+         the upload "year" is the in-title number not release year.
+       - 0.85 ≤ sim < 0.95 → accept only if year_diff ≤ 15 (block the
+         remake trap: "Freaky Friday 2003" → 'Freakier Friday' 2025
+         scored sim=0.86, year_diff=25 → reject).
+       - 0.50 ≤ sim < 0.85 → accept only if year_diff ≤ 5 (typical
+         medium-confidence match where year is the disambiguator).
+       - sim < 0.50 → always reject.
+    """
+    if best_sim >= _TITLE_SIM_NEAR_EXACT:
+        return True
+    if best_sim >= _TITLE_SIM_STRONG:
+        return year_diff is None or year_diff <= _YEAR_DIFF_REMAKE
+    if best_sim < _TITLE_SIM_MIN:
+        return False
+    return year_diff is None or year_diff <= _YEAR_DIFF_MAX
 
 
 def _extract_json(text: str) -> Optional[dict]:
@@ -468,7 +535,35 @@ def main() -> int:
 
         tmdb_id = tmdb_hit["id"]
         tmdb_title = tmdb_hit.get("title")
+        tmdb_original_title = tmdb_hit.get("original_title")
         tmdb_year = tmdb_hit.get("release_date", "????")[:4]
+
+        # Title similarity check — drop matches where Gemma's extracted
+        # title doesn't actually look like the TMDB hit's title. Without
+        # this, ambiguous upload strings ("MÉDA TED 2"→'Dva milenci a
+        # medvěd', "SAW 8"→'Příchozí', "Skurvenej Pátek (2000)"→
+        # 'Mezi námi děvčaty 2' (2025)) slip through because both
+        # Gemma and TMDB-popularity sort happily point at a wrong film.
+        # Compare Gemma's `title` AND `title_en` against TMDB's
+        # `title` (cs-CZ localized) AND `original_title`, take the
+        # max — and gate by year proximity for medium-similarity
+        # cases. See module-level `_TITLE_SIM_*` constants.
+        year_diff: Optional[int] = None
+        if tmdb_year.isdigit() and year_extr is not None:
+            year_diff = abs(int(tmdb_year) - int(year_extr))
+        best_sim = _best_title_similarity(
+            [title_extr, title_en],
+            [tmdb_title, tmdb_original_title],
+        )
+        if not _title_match_acceptable(best_sim, year_diff):
+            counters["NO_TMDB"] += 1
+            _record_attempt(rid, reason="tmdb_title_mismatch",
+                            tmdb_id=tmdb_id)
+            print(f"[{i:>3}] NO_TMDB    {sample_title[:60]} → "
+                  f"tmdb={tmdb_id} '{tmdb_title}' {tmdb_year} "
+                  f"sim={best_sim:.2f} year_diff={year_diff} (rejected)",
+                  flush=True)
+            continue
 
         # Runtime sanity check — drop matches where TMDB's runtime
         # differs from the cluster's reported duration by more than


### PR DESCRIPTION
<!-- claude-session: 7c3b161d-8356-4752-8d86-71ddceb899bb -->

## Summary

The LLM resolver (#668) picked the top TMDB hit by name+year+popularity, which
let false positives slip through on the first 500-cluster batch — Gemma
extracted a generic title and TMDB-popularity sort pointed at the wrong film.

Concrete misses from the first run on prod:

| Cluster | Wrong resolve |
|---|---|
| `MÉDA TED 2 CZ DABING 2015` | → `Dva milenci a medvěd` 2016 |
| `SAW 8 [ENG dabing, 2017]` | → `Příchozí` (Arrival) 2017 |
| `Skurvenej Pátek (2000)` | → `Mezi námi děvčaty 2` 2025 |
| `Push (2015)` | → `Pusher 2` / `Dealer 2` 2004 |
| `Vo štvorici po opici 3 (2013)` | → `Kung Fu Panda 3` 2016 |

This PR adds a 3-tier title-similarity gate (`difflib.ratio` after diacritic+punct normalization, comparing Gemma's `title` AND `title_en` against TMDB's localized `title` AND `original_title`):

- `sim ≥ 0.95` (near-exact) → accept regardless of year (handles "2001: Vesmírná Odysea (2001)" upload of the 1968 Kubrick film, where the in-title 2001 isn't the release year)
- `0.85 ≤ sim < 0.95` → accept only if `year_diff ≤ 15` (blocks the remake/sequel trap: Skurvenej Pátek 2000 → Freakier Friday 2025 scored sim=0.86, year_diff=25)
- `0.50 ≤ sim < 0.85` → accept only if `year_diff ≤ 5`
- `sim < 0.50` → always reject

New failure code `tmdb_title_mismatch` joins the resolver's skip-window so we don't burn Gemma quota retrying the same rejection daily.

## Test plan

- [x] 12 hand-curated similarity cases pass (5 known false positives + 7 known true positives including diacritic variants like `Doba ľadová` ↔ `Doba ledová`, year-in-title `2001: Vesmírná Odysea`, English-vs-Czech title pairs)
- [x] Smoke-tested on prod with `--limit 30 --retry-after-days 0`: 14 NEW_TMDB + 16 NO_TMDB; new sim gate caught `Macko-Pú`→`Králův dvojník` (sim=0.35, year_diff=54) as expected
- [x] Existing skip-window mechanism unchanged; new `tmdb_title_mismatch` code added to `resolver_reasons` so retried clusters get the same N-day cooldown
- [ ] Production batch run (next `--limit 500` run) — RESOLVED count should drop ~5-10% as the gate filters previously-misresolved cases