### PR TITLE
feat(systemd): cr-llm-resolver daily timer (#652)

### DIFF
--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -1,12 +1,13 @@
 # Systemd units (produkční VPS)
 
-Tři nezávislé noční úlohy:
+Čtyři nezávislé noční úlohy:
 
 | Unit | Čas | Účel | Admin přehled |
 |------|-----|------|---------------|
 | `cr-backup-db.timer`       | 03:00 UTC | `pg_dump` celé DB → Cloudflare R2 (30 dní retence) | `/admin/backups/` |
 | `cr-prehrajto-sync.timer`  | 04:00 UTC | prehraj.to sitemap → DB + mark-dead rotated IDs | (TODO) |
 | `cr-auto-import.timer`     | 05:00 UTC | SK Torrent → films/series/tv_shows | `/admin/import/` |
+| `cr-llm-resolver.timer`    | 06:30 UTC | LLM resolver: prehraj.to unmatched clusters → TMDB ID (Gemma + TMDB API) | `/admin/prehrajto/unmatched` |
 
 ## Auto-import (issue #423)
 
@@ -189,3 +190,60 @@ Každý běh zapíše row do `backup_runs` viditelnou na
 Mimo skript — nastavit jednou v R2 dashboardu na bucketu `cr-backups`:
 - Prefix: `auto/`
 - Expire objects: 30 days after upload
+
+---
+
+## LLM resolver (issue #652)
+
+Daily resolver for prehraj.to unmatched clusters using Gemma 3 27b
+(via Google AI Studio free tier) + TMDB API. Reads
+`prehrajto_unmatched_clusters` rows where the regex importer couldn't
+match the upload string against the `films` table — extracts a
+canonical title with Gemma, resolves to a stable TMDB ID, and writes
+either `resolved_film_id` (existing film) or `resolved_tmdb_id`
+(NEW_TMDB candidate, awaiting #652 auto-import).
+
+Capped at `--limit 200 --min-uploads 2` per run — drains the ~10k
+backlog over weeks, not days, so a buggy resolver iteration can't burn
+the whole backlog before false positives surface. Skip-window
+(`--retry-after-days 7`) avoids paying Gemma quota for the same
+already-attempted clusters daily.
+
+### Install / enable on VPS
+
+```bash
+# Copy unit files + script
+scp -P "$VPS_PORT" deploy/systemd/cr-llm-resolver.{service,timer} \
+    "root@$VPS_HOST:/etc/systemd/system/"
+scp -P "$VPS_PORT" scripts/resolve-unmatched-via-llm.py \
+    "root@$VPS_HOST:/opt/cr/scripts/"
+
+# Required env vars in /opt/cr/.env (already present from auto-import):
+#   DATABASE_URL=postgres://cr:...@db:5432/cr
+#   GEMINI_API_KEY=...
+#   TMDB_API_KEY=...
+
+# Enable + smoke-run
+ssh -p "$VPS_PORT" "root@$VPS_HOST" \
+    "systemctl daemon-reload && \
+     systemctl enable --now cr-llm-resolver.timer && \
+     systemctl start cr-llm-resolver.service && \
+     tail -f /var/log/cr-llm-resolver.log"
+```
+
+### Logs
+
+```bash
+ssh -p "$VPS_PORT" "root@$VPS_HOST" "tail -300 /var/log/cr-llm-resolver.log"
+```
+
+### Dashboard
+
+Resolution outcomes are written back to `prehrajto_unmatched_clusters`:
+- `resolved_film_id IS NOT NULL` — cluster mapped to existing film
+- `resolved_tmdb_id IS NOT NULL AND resolved_film_id IS NULL` —
+  candidate awaiting auto-import (separate pipeline #652)
+- `last_failure_reason` — `tmdb_no_hit`, `tmdb_runtime_mismatch`,
+  `tmdb_title_mismatch`, `llm_not_film`, `llm_no_title`, `llm_gemini_failed`
+
+Visible at <https://ceskarepublika.wiki/admin/prehrajto/unmatched>.

--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -195,7 +195,7 @@ Mimo skript — nastavit jednou v R2 dashboardu na bucketu `cr-backups`:
 
 ## LLM resolver (issue #652)
 
-Daily resolver for prehraj.to unmatched clusters using Gemma 3 27b
+Daily resolver for prehraj.to unmatched clusters using Gemma 3 27B
 (via Google AI Studio free tier) + TMDB API. Reads
 `prehrajto_unmatched_clusters` rows where the regex importer couldn't
 match the upload string against the `films` table — extracts a

--- a/deploy/systemd/cr-llm-resolver.service
+++ b/deploy/systemd/cr-llm-resolver.service
@@ -1,0 +1,36 @@
+[Unit]
+Description=CR — LLM-based TMDB-ID resolver for prehraj.to unmatched clusters (#668)
+Documentation=https://github.com/Olbrasoft/cr/issues/652
+# Wait for Docker / Postgres to be up. Chain after the prehraj.to sitemap
+# sync so the resolver always works against the freshest unmatched
+# cluster set (sync runs at 04:00 UTC, this runs after 06:00).
+After=docker.service network-online.target cr-prehrajto-sync.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=root
+WorkingDirectory=/opt/cr
+EnvironmentFile=/opt/cr/.env
+# DATABASE_URL in /opt/cr/.env points at `db:5432` (container hostname);
+# host-side scripts need 127.0.0.1 — same translation as the
+# cr-auto-import / cr-prehrajto-sync services.
+#
+# --limit 200: caps each daily run at ~7 minutes wall-clock and ~3% of
+#   Gemma's 14,400/day free quota. The 10k+ backlog drains over weeks,
+#   not days — that's intentional, so a buggy resolver iteration can't
+#   burn the entire backlog before we notice false positives.
+# --min-uploads 2: ignore single-upload clusters (long-tail noise).
+# --retry-after-days 7: don't reprocess clusters the resolver already
+#   touched within the last 7 days.
+ExecStart=/bin/bash -c 'DATABASE_URL=$${DATABASE_URL//@db:/@127.0.0.1:} /usr/bin/python3 -u /opt/cr/scripts/resolve-unmatched-via-llm.py --limit 200 --min-uploads 2 --retry-after-days 7'
+StandardOutput=append:/var/log/cr-llm-resolver.log
+StandardError=append:/var/log/cr-llm-resolver.log
+# No auto-restart: a Gemma quota / TMDB outage shouldn't cause an
+# immediate retry that re-enters quota issues. The next daily timer
+# tick will pick up where this left off (per-row commits + skip-window
+# make this safe).
+TimeoutStartSec=30min
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/cr-llm-resolver.service
+++ b/deploy/systemd/cr-llm-resolver.service
@@ -1,9 +1,11 @@
 [Unit]
 Description=CR — LLM-based TMDB-ID resolver for prehraj.to unmatched clusters (#668)
 Documentation=https://github.com/Olbrasoft/cr/issues/652
-# Wait for Docker / Postgres to be up. Chain after the prehraj.to sitemap
-# sync so the resolver always works against the freshest unmatched
-# cluster set (sync runs at 04:00 UTC, this runs after 06:00).
+# Wait for Docker / Postgres to be up. `After=cr-prehrajto-sync` only
+# orders start jobs in the same transaction — it does NOT prevent the
+# resolver from running while the sync is still active (e.g., when the
+# sitemap import takes longer than 2.5 hours, or when this service is
+# triggered manually). The ExecStartPre below adds an explicit guard.
 After=docker.service network-online.target cr-prehrajto-sync.service
 Wants=network-online.target
 
@@ -12,9 +14,18 @@ Type=oneshot
 User=root
 WorkingDirectory=/opt/cr
 EnvironmentFile=/opt/cr/.env
+# Refuse to start if the sync is mid-flight — the resolver depends on
+# a coherent `prehrajto_unmatched_clusters` registry, and the sync's
+# importer step (mark-dead + UPSERT) writes to that table. Running
+# concurrently would let the resolver re-attempt clusters the importer
+# is in the middle of clearing.
+ExecStartPre=/bin/bash -c 'if systemctl is-active --quiet cr-prehrajto-sync.service; then echo "cr-prehrajto-sync.service still active — refusing to start" >&2; exit 1; fi'
 # DATABASE_URL in /opt/cr/.env points at `db:5432` (container hostname);
 # host-side scripts need 127.0.0.1 — same translation as the
-# cr-auto-import / cr-prehrajto-sync services.
+# cr-auto-import / cr-prehrajto-sync services. `exec` replaces the
+# bash process with python3 so systemd tracks the actual worker PID
+# (matches cr-auto-import.service; better signal/timeout handling
+# than a bash parent + python child tree).
 #
 # --limit 200: caps each daily run at ~7 minutes wall-clock and ~3% of
 #   Gemma's 14,400/day free quota. The 10k+ backlog drains over weeks,
@@ -23,7 +34,7 @@ EnvironmentFile=/opt/cr/.env
 # --min-uploads 2: ignore single-upload clusters (long-tail noise).
 # --retry-after-days 7: don't reprocess clusters the resolver already
 #   touched within the last 7 days.
-ExecStart=/bin/bash -c 'DATABASE_URL=$${DATABASE_URL//@db:/@127.0.0.1:} /usr/bin/python3 -u /opt/cr/scripts/resolve-unmatched-via-llm.py --limit 200 --min-uploads 2 --retry-after-days 7'
+ExecStart=/bin/bash -c 'DATABASE_URL=$${DATABASE_URL//@db:/@127.0.0.1:} exec /usr/bin/python3 -u /opt/cr/scripts/resolve-unmatched-via-llm.py --limit 200 --min-uploads 2 --retry-after-days 7'
 StandardOutput=append:/var/log/cr-llm-resolver.log
 StandardError=append:/var/log/cr-llm-resolver.log
 # No auto-restart: a Gemma quota / TMDB outage shouldn't cause an

--- a/deploy/systemd/cr-llm-resolver.timer
+++ b/deploy/systemd/cr-llm-resolver.timer
@@ -1,0 +1,17 @@
+[Unit]
+Description=CR — LLM resolver for prehraj.to unmatched clusters (daily after sitemap sync)
+Documentation=https://github.com/Olbrasoft/cr/issues/652
+
+[Timer]
+# 06:30 UTC — runs after cr-prehrajto-sync (04:00 UTC, ~30-60 min) and
+# cr-auto-import (05:00 UTC, ~5-10 min). Matches the morning import
+# pattern but the resolver depends on a fresh
+# `prehrajto_unmatched_clusters` registry (output of the sync), so
+# starting later guarantees we never resolve against stale data.
+OnCalendar=*-*-* 06:30:00 UTC
+Persistent=true
+RandomizedDelaySec=10min
+Unit=cr-llm-resolver.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
<!-- claude-session: 98d65447-0cc0-4c98-a612-a9b5c0699023 -->

Closes #652 (partially — auto-import of NEW_TMDB candidates is a follow-up)

## Summary

Adds `cr-llm-resolver.{service,timer}` pair so the LLM-based TMDB-ID resolver from #668 runs every day at 06:30 UTC against the prehraj.to unmatched-clusters registry.

Schedule slot 06:30 UTC sits AFTER:
- `cr-prehrajto-sync` (04:00 UTC) — refreshes the unmatched-cluster registry from the morning's sitemap
- `cr-auto-import` (05:00 UTC) — SK Torrent imports may add new films that the resolver should now match

Cap of `--limit 200 --min-uploads 2` per run:
- ~7 min wall-clock at Gemma's 2 s/req pace = polite to free tier
- ~3% of Gemma's 14,400 / day quota = leaves room for retries
- Drains the ~10k backlog over weeks, NOT days — a buggy resolver iteration can't burn the entire backlog before false positives surface
- Skip-window `--retry-after-days 7` prevents paying Gemma quota for the same already-attempted clusters daily

## Test plan

- [x] `systemd-analyze verify cr-llm-resolver.{timer,service}` passes (unit syntax OK)
- [x] `systemctl daemon-reload && systemctl start cr-llm-resolver.service` on prod — the service entered `activating (start)` and processed clusters as expected (visible in `/var/log/cr-llm-resolver.log`)
- [x] Resolver lines show RESOLVED / NEW_TMDB / NO_TMDB outcomes; new title-similarity check from #669 fires correctly (`sim=0.43 year_diff=0 (rejected)` style log lines)
- [ ] After merge: `systemctl enable --now cr-llm-resolver.timer` to schedule daily runs
- [ ] After 7 days: confirm 7× `--limit 200` runs each at 06:30 UTC; verify `prehrajto_unmatched_clusters` count drops by ~1k–1.5k