### PR TITLE
feat(systemd): chain auto-import stage onto cr-llm-resolver service (#652)

### DIFF
--- a/deploy/systemd/cr-llm-resolver.service
+++ b/deploy/systemd/cr-llm-resolver.service
@@ -35,6 +35,15 @@ ExecStartPre=/bin/bash -c 'if systemctl is-active --quiet cr-prehrajto-sync.serv
 # --retry-after-days 7: don't reprocess clusters the resolver already
 #   touched within the last 7 days.
 ExecStart=/bin/bash -c 'DATABASE_URL=$${DATABASE_URL//@db:/@127.0.0.1:} exec /usr/bin/python3 -u /opt/cr/scripts/resolve-unmatched-via-llm.py --limit 200 --min-uploads 2 --retry-after-days 7'
+# Stage 2: import NEW_TMDB candidates (resolved_tmdb_id IS NOT NULL
+# AND resolved_film_id IS NULL) from the registry into the films
+# table. Cap at 50 / day — TMDB allows 4 rps and we burn 2 calls per
+# film (~25 s wall-clock for 50 films). Films with NULL description
+# get backfilled by a separate Gemma rewrite pass, not here. The
+# attachment of prehraj.to uploads (video_sources) happens on the
+# next cr-prehrajto-sync run via cluster_key match against the
+# newly-inserted films.
+ExecStart=/bin/bash -c 'DATABASE_URL=$${DATABASE_URL//@db:/@127.0.0.1:} exec /usr/bin/python3 -u /opt/cr/scripts/import-prehrajto-tmdb-as-film.py --limit 50'
 StandardOutput=append:/var/log/cr-llm-resolver.log
 StandardError=append:/var/log/cr-llm-resolver.log
 # No auto-restart: a Gemma quota / TMDB outage shouldn't cause an

--- a/deploy/systemd/cr-llm-resolver.service
+++ b/deploy/systemd/cr-llm-resolver.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=CR — LLM-based TMDB-ID resolver for prehraj.to unmatched clusters (#668)
+Description=CR — prehraj.to LLM resolver + NEW_TMDB → films auto-import (#652)
 Documentation=https://github.com/Olbrasoft/cr/issues/652
 # Wait for Docker / Postgres to be up. `After=cr-prehrajto-sync` only
 # orders start jobs in the same transaction — it does NOT prevent the


### PR DESCRIPTION
<!-- claude-session: 98d65447-0cc0-4c98-a612-a9b5c0699023 -->

Refs #652

## Summary

Closes the prehraj.to → TMDB pipeline loop in a single daily cron:

1. `resolve-unmatched-via-llm.py --limit 200` — Gemma extracts canonical title from each unmatched cluster, TMDB resolves to a stable ID (existing PR #668 + #669)
2. **NEW**: `import-prehrajto-tmdb-as-film.py --limit 50` — for clusters where TMDB returned an ID not yet in films, fetch /movie/{id} cs+en and INSERT INTO films (PR #671)

Both stages run as independent ExecStart= directives in cr-llm-resolver.service. Type=oneshot ensures stage 2 only fires after stage 1 exits 0 — the correct ordering, since a failed resolver might leave stale locks on the cluster registry.

## Test plan

- [x] One-shot run on prod via `systemctl start cr-llm-resolver.service`:
  - ExecStartPre: status=0/SUCCESS (sync not active)
  - ExecStart 1 (resolver, 200 limit): status=0/SUCCESS in ~13 min
  - ExecStart 2 (import, 50 limit): status=0/SUCCESS in ~30 s, 41 added + 9 race-detected, 0 failures
  - Total: 26.3 MB peak memory, 3.2 s CPU time
- [x] Films inserted: `SELECT COUNT(*) FROM films WHERE id BETWEEN 31682 AND 31722` returns 41
- [ ] After merge: timer's next 06:32 UTC tick should run both stages without manual trigger
- [ ] Tomorrow's 04:00 UTC `cr-prehrajto-sync` will attach video_sources to the new films via cluster_key match — `/filmy-online/` will then show them