### PR TITLE
feat(search): match film and series titles regardless of diacritics

### DIFF
--- a/cr-infra/migrations/20260606_066_unaccent_extension.sql
+++ b/cr-infra/migrations/20260606_066_unaccent_extension.sql
@@ -4,7 +4,9 @@
 -- list and autocomplete handlers, where ILIKE is wrapped in
 -- `unaccent(...)` on both the column and the bound pattern.
 --
--- Diacritic-exact ILIKE matches stay first in result ordering — only
--- when the exact pattern returns nothing do unaccented matches fill in.
+-- Both diacritic-exact and unaccent-only matches come back from the
+-- same query; ORDER BY then ranks raw-ILIKE (diacritic-exact) hits
+-- ahead of unaccent-only hits via a leading CASE bucket — it's a
+-- prioritization, not a conditional fallback.
 -- See cr-web/src/handlers/films.rs and cr-web/src/handlers/series.rs.
 CREATE EXTENSION IF NOT EXISTS unaccent;

--- a/cr-infra/migrations/20260606_066_unaccent_extension.sql
+++ b/cr-infra/migrations/20260606_066_unaccent_extension.sql
@@ -1,0 +1,10 @@
+-- Enable the `unaccent` extension so search queries on /filmy-online/
+-- and /serialy-online/ can match titles regardless of diacritics
+-- ("laska nebeska" finds "Láska nebeská"). Used by the films/series
+-- list and autocomplete handlers, where ILIKE is wrapped in
+-- `unaccent(...)` on both the column and the bound pattern.
+--
+-- Diacritic-exact ILIKE matches stay first in result ordering — only
+-- when the exact pattern returns nothing do unaccented matches fill in.
+-- See cr-web/src/handlers/films.rs and cr-web/src/handlers/series.rs.
+CREATE EXTENSION IF NOT EXISTS unaccent;

--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -2002,7 +2002,55 @@ fn not_found_response() -> Response {
 
 #[cfg(test)]
 mod tests {
-    use super::{FilmsQuery, normalize_query};
+    use super::{FilmsQuery, FilmsSearchMode, normalize_query};
+
+    #[test]
+    fn predicate_wraps_columns_in_unaccent() {
+        // Both modes must run unaccent() on the column AND on the bound
+        // pattern — that's how diacritics-insensitive matching works
+        // (#673). Lock the shape so we don't accidentally drop the
+        // wrapper from one side of an ILIKE in a future refactor.
+        let primary = FilmsSearchMode::Primary.predicate(1);
+        assert!(
+            primary.contains("unaccent(f.title) ILIKE unaccent($1)"),
+            "{primary}"
+        );
+        assert!(
+            primary.contains("unaccent(f.original_title) ILIKE unaccent($1)"),
+            "{primary}"
+        );
+
+        let title_year = FilmsSearchMode::TitleYear.predicate(1);
+        assert!(
+            title_year
+                .contains("unaccent(CONCAT_WS(' ', f.title, f.year::text)) ILIKE unaccent($1)"),
+            "{title_year}"
+        );
+        assert!(
+            title_year.contains(
+                "unaccent(CONCAT_WS(' ', f.original_title, f.year::text)) ILIKE unaccent($1)"
+            ),
+            "{title_year}"
+        );
+    }
+
+    #[test]
+    fn raw_predicate_does_not_use_unaccent() {
+        // raw_predicate is the ORDER BY tiebreaker that keeps
+        // diacritic-exact hits in front. If unaccent() leaks in here,
+        // every row becomes "exact" and the priority bucket collapses.
+        let primary = FilmsSearchMode::Primary.raw_predicate(1);
+        assert!(!primary.contains("unaccent"), "{primary}");
+        assert!(primary.contains("f.title ILIKE $1"), "{primary}");
+        assert!(primary.contains("f.original_title ILIKE $1"), "{primary}");
+
+        let title_year = FilmsSearchMode::TitleYear.raw_predicate(1);
+        assert!(!title_year.contains("unaccent"), "{title_year}");
+        assert!(
+            title_year.contains("CONCAT_WS(' ', f.title, f.year::text) ILIKE $1"),
+            "{title_year}"
+        );
+    }
 
     fn query_with_jazyk(jazyk: Option<&str>) -> FilmsQuery {
         FilmsQuery {

--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -1184,10 +1184,16 @@ pub async fn films_search(
 async fn search_films_by_title(db: &sqlx::PgPool, q: &str) -> Result<Vec<SearchRow>, sqlx::Error> {
     let pattern = format!("%{q}%");
     let starts_pattern = format!("{q}%");
+    // WHERE matches via `unaccent()` so "laska nebeska" finds "Láska
+    // nebeská" (#673). ORDER BY keeps the raw ILIKE in the CASE
+    // arms — rows whose title literally contains the query (with the
+    // user's diacritics) win bucket 0/1/2; rows that only match after
+    // unaccent fall to bucket 3, behind the diacritic-exact hits.
     sqlx::query_as::<_, SearchRow>(
         "SELECT slug, title, year, imdb_rating \
          FROM films \
-         WHERE title ILIKE $1 OR original_title ILIKE $1 \
+         WHERE unaccent(title) ILIKE unaccent($1) \
+            OR unaccent(original_title) ILIKE unaccent($1) \
          ORDER BY \
            CASE WHEN title ILIKE $2 THEN 0 \
                 WHEN title ILIKE $1 THEN 1 \
@@ -1211,8 +1217,8 @@ async fn search_films_by_title_year(
     sqlx::query_as::<_, SearchRow>(
         "SELECT slug, title, year, imdb_rating \
          FROM films \
-         WHERE CONCAT_WS(' ', title, year::text) ILIKE $1 \
-            OR CONCAT_WS(' ', original_title, year::text) ILIKE $1 \
+         WHERE unaccent(CONCAT_WS(' ', title, year::text)) ILIKE unaccent($1) \
+            OR unaccent(CONCAT_WS(' ', original_title, year::text)) ILIKE unaccent($1) \
          ORDER BY \
            CASE WHEN CONCAT_WS(' ', title, year::text) ILIKE $2 THEN 0 \
                 WHEN CONCAT_WS(' ', title, year::text) ILIKE $1 THEN 1 \
@@ -1252,6 +1258,25 @@ enum FilmsSearchMode {
 
 impl FilmsSearchMode {
     fn predicate(self, bind_idx: usize) -> String {
+        match self {
+            Self::Primary => {
+                format!(
+                    "(unaccent(f.title) ILIKE unaccent(${bind_idx}) \
+                     OR unaccent(f.original_title) ILIKE unaccent(${bind_idx}))"
+                )
+            }
+            Self::TitleYear => format!(
+                "(unaccent(CONCAT_WS(' ', f.title, f.year::text)) ILIKE unaccent(${bind_idx}) \
+                 OR unaccent(CONCAT_WS(' ', f.original_title, f.year::text)) ILIKE unaccent(${bind_idx}))"
+            ),
+        }
+    }
+
+    /// Same shape as `predicate` but without the `unaccent()` wrapper —
+    /// matches only when the column literally contains the user's
+    /// diacritics. Used in ORDER BY to push diacritic-exact hits in
+    /// front of unaccent-only hits.
+    fn raw_predicate(self, bind_idx: usize) -> String {
         match self {
             Self::Primary => {
                 format!("(f.title ILIKE ${bind_idx} OR f.original_title ILIKE ${bind_idx})")
@@ -1388,10 +1413,22 @@ async fn run_films_query(
     }
     let count_row = cq.fetch_one(db).await?;
 
+    // When a search is active, push rows whose title literally contains
+    // the user's query (with diacritics) ahead of rows that match only
+    // after `unaccent()` — see #673. The search pattern is bound at $1.
+    let order_clause = if search_pattern.is_some() {
+        format!(
+            "(CASE WHEN {raw} THEN 0 ELSE 1 END), {order}",
+            raw = mode.raw_predicate(1)
+        )
+    } else {
+        order.to_string()
+    };
+
     let films_query = format!(
         "SELECT {FILM_COLUMNS} \
          FROM films f {where_clause} \
-         ORDER BY {order} \
+         ORDER BY {order_clause} \
          LIMIT ${limit_idx} OFFSET ${offset_idx}",
         limit_idx = bind_idx,
         offset_idx = bind_idx + 1

--- a/cr-web/src/handlers/series.rs
+++ b/cr-web/src/handlers/series.rs
@@ -385,9 +385,16 @@ pub async fn series_list(
 
     // Search mode: show series results (by title). No search: show latest-
     // episode-per-series grid (bombuj.si style).
+    //
+    // Search uses `unaccent()` so "laska nebeska" matches "Láska nebeská"
+    // (#673). Diacritic-exact ILIKE hits are pushed in front of unaccent-
+    // only hits via the leading CASE in ORDER BY — when the user typed
+    // diacritics, rows whose title literally contains them rank first.
     let (total_count, series, episodes) = if let Some(ref pattern) = search_q {
         let count_row = sqlx::query_as::<_, CountRow>(
-            "SELECT count(*) as count FROM series WHERE title ILIKE $1 OR original_title ILIKE $1",
+            "SELECT count(*) as count FROM series \
+             WHERE unaccent(title) ILIKE unaccent($1) \
+                OR unaccent(original_title) ILIKE unaccent($1)",
         )
         .bind(pattern)
         .fetch_one(&state.db)
@@ -399,8 +406,11 @@ pub async fn series_list(
              s.season_count, s.episode_count, s.added_at, \
              s.tmdb_poster_path \
              FROM series s \
-             WHERE s.title ILIKE $1 OR s.original_title ILIKE $1 \
-             ORDER BY {order} LIMIT $2 OFFSET $3"
+             WHERE unaccent(s.title) ILIKE unaccent($1) \
+                OR unaccent(s.original_title) ILIKE unaccent($1) \
+             ORDER BY \
+               (CASE WHEN s.title ILIKE $1 OR s.original_title ILIKE $1 THEN 0 ELSE 1 END), \
+               {order} LIMIT $2 OFFSET $3"
         );
         let rows = sqlx::query_as::<_, SeriesRow>(&query)
             .bind(pattern)
@@ -1131,10 +1141,15 @@ pub async fn series_search(
     }
     let pattern = format!("%{q}%");
     let starts_pattern = format!("{q}%");
+    // WHERE matches via `unaccent()` so "laska nebeska" finds "Láska
+    // nebeská" (#673). The CASE in ORDER BY uses raw ILIKE: rows whose
+    // title literally contains the user's diacritics rank in buckets
+    // 0–2, unaccent-only matches drop to bucket 3.
     let rows = sqlx::query_as::<_, SeriesSearchRow>(
         "SELECT slug, title, first_air_year, imdb_rating \
          FROM series \
-         WHERE title ILIKE $1 OR original_title ILIKE $1 \
+         WHERE unaccent(title) ILIKE unaccent($1) \
+            OR unaccent(original_title) ILIKE unaccent($1) \
          ORDER BY \
            CASE WHEN title ILIKE $2 THEN 0 \
                 WHEN title ILIKE $1 THEN 1 \


### PR DESCRIPTION
<!-- claude-session: 2a9d2a6f-393f-4d32-bfd9-71a66bafae38 -->

## Summary

- /filmy-online/ and /serialy-online/ search now matches regardless of diacritics — "laska nebeska" finds "Láska nebeská".
- Same fix applied to both autocomplete APIs (`/api/films/search`, `/api/series/search`) and to the films-listing page (`films_list` with paging).
- WHERE wraps both column and bound pattern in `unaccent(...)`. Ordering keeps raw ILIKE in the CASE: rows whose title literally contains the user's diacritics win the top buckets; unaccent-only matches drop behind them.
- Adds migration `20260606_066_unaccent_extension.sql` (`CREATE EXTENSION IF NOT EXISTS unaccent`). Production already has the extension installed, so the migration is a no-op there.

## Test plan

- [x] `cargo check`, `cargo clippy --workspace -- -D warnings`, `cargo fmt --check`, `cargo test --workspace` (40 passed)
- [x] Migration applied on prod via cross-compile + `scp` deploy: `_sqlx_migrations` shows `20260606`, `/health` returns 200
- [x] Playwright on `https://ceskarepublika.wiki`:
  - [x] `/filmy-online/?q=laska+nebeska` → 2 hits (Ach, ta láska nebeská…; Láska nebeská)
  - [x] `/filmy-online/?q=láska+nebeská` → same 2 hits, "Láska nebeská" first (raw-ILIKE bucket)
  - [x] `/serialy-online/?q=cernobyl` → 1 hit (Černobyl)
  - [x] `/serialy-online/?q=černobyl` → 1 hit (Černobyl)
  - [x] Autocomplete on `/filmy-online/` for `laska nebeska` → both films
  - [x] 0 console errors / warnings on each page
- [x] API smoke:
  - `/api/films/search?q=laska%20nebeska` returns both films
  - `/api/series/search?q=simpsonovi` returns Simpsonovi

🤖 Generated with [Claude Code](https://claude.com/claude-code)