### PR TITLE
refactor(search): replace no-store with private/max-age=60 best-practice cache

### DIFF
--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -800,12 +800,16 @@ pub async fn films_list(
     }
 }
 
-/// True when `?q=…` is a real search query — same trim+length gate
-/// the search predicate uses. Single source of truth so the
-/// search-cache branch and the predicate gate can't drift apart
-/// (Copilot review on #674).
+/// True when `?q=…` is a real search query — same trim+length
+/// gate the search predicate uses (`raw_q` filters `t.len() >= 2`,
+/// byte length). Single source of truth so the search-cache branch
+/// and the predicate gate can't drift apart (Copilot review on
+/// #674 and #675 — the latter caught this helper using
+/// `chars().count()` instead of byte `len()`, which would split
+/// on a single multibyte char like `á` and leave that real search
+/// page uncached).
 fn is_active_search(q: Option<&str>) -> bool {
-    q.map(str::trim).is_some_and(|t| t.chars().count() >= 2)
+    q.map(str::trim).is_some_and(|t| t.len() >= 2)
 }
 
 /// Serialize the current filter params into a BTreeMap keyed by query
@@ -2024,11 +2028,11 @@ mod tests {
 
     #[test]
     fn is_active_search_gate_matches_predicate_threshold() {
-        // Must mirror `raw_q`'s `len() >= 2` filter so the
-        // search-cache branch in `films_list` and the search
-        // predicate gate stay in sync — Copilot review on #674
-        // caught the original looser check letting `?q=a` mark
-        // non-search pages with the search cache header.
+        // Must mirror the search predicate's `t.len() >= 2`
+        // (byte length, not char count) so a single multibyte
+        // char like `á` (2 bytes, 1 char) hits both branches.
+        // Drift here would leave real search pages uncached
+        // (#675 review).
         assert!(!is_active_search(None));
         assert!(!is_active_search(Some("")));
         assert!(!is_active_search(Some("   ")));
@@ -2036,21 +2040,20 @@ mod tests {
         assert!(!is_active_search(Some("  a  ")));
         assert!(is_active_search(Some("ab")));
         assert!(is_active_search(Some("  ab  ")));
-        // Diacritic-only counts as a real character — `chars().count()`
-        // on "á" is 1 (single grapheme), but "áb" is 2.
-        assert!(!is_active_search(Some("á")));
+        // Single multibyte char: 2 bytes ≥ 2 → active. The byte-
+        // length gate is what the search predicate uses, so this
+        // must stay true.
+        assert!(is_active_search(Some("á")));
         assert!(is_active_search(Some("áb")));
     }
 
     #[test]
-    fn search_cached_json_helper_uses_private_short_max_age() {
-        // Lock the contract: every body wrapped by
-        // `search_cached_json` must come back with the standard
-        // `private, max-age=60` policy. Two failure modes to guard:
-        //   - regression to bare `no-store` (wasteful, what we
-        //     replaced),
-        //   - missing `private` (would let CF / ISP caches store
-        //     query-derived responses).
+    fn search_cached_json_helper_locks_exact_cache_policy() {
+        // Lock the exact policy: substring matching on `max-age=60`
+        // would let `max-age=600` pass silently; substring on
+        // `private` would let `public, private` pass. The whole
+        // point of this header is the precise policy, so assert
+        // bytes-equal.
         let resp = super::super::search_cached_json(Vec::<u8>::new());
         let cc = resp
             .headers()
@@ -2058,17 +2061,16 @@ mod tests {
             .expect("Cache-Control header must be set")
             .to_str()
             .unwrap();
-        assert!(cc.contains("private"), "missing `private`: {cc}");
-        assert!(cc.contains("max-age=60"), "missing `max-age=60`: {cc}");
-        assert!(!cc.contains("public"), "must not be `public`: {cc}");
-        assert!(!cc.contains("no-store"), "must not be `no-store`: {cc}");
+        assert_eq!(cc, "private, max-age=60", "exact policy required");
     }
 
     #[test]
-    fn search_cached_html_helper_uses_private_short_max_age() {
-        // Same contract for the HTML helper used by
+    fn search_cached_html_helper_locks_exact_cache_policy() {
+        // Same exact-match contract for the HTML helper used by
         // `films_list` / `series_list` / `tv_porady_list` on the
-        // search-active branch.
+        // search-active branch. A future regression to something
+        // like `private, max-age=60, no-store` (which would stop
+        // browsers from reusing the page entirely) must fail here.
         let resp = super::super::search_cached_html(String::from("<p>hi</p>"));
         let cc = resp
             .headers()
@@ -2076,9 +2078,7 @@ mod tests {
             .expect("Cache-Control header must be set")
             .to_str()
             .unwrap();
-        assert!(cc.contains("private"), "missing `private`: {cc}");
-        assert!(cc.contains("max-age=60"), "missing `max-age=60`: {cc}");
-        assert!(!cc.contains("public"), "must not be `public`: {cc}");
+        assert_eq!(cc, "private, max-age=60", "exact policy required");
     }
 
     #[test]

--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -788,21 +788,22 @@ pub async fn films_list(
         full_query,
     };
     let html = tmpl.render()?;
-    // Search-result HTML is `?q=`-derived: don't let the browser pin
-    // it via heuristic / bfcache (#673 follow-up). Gate matches the
-    // actual search predicate (`raw_q` filters `len() >= 2`), so
-    // `?q=a` still gets the cacheable default listing.
+    // Search-result HTML is `?q=`-derived: tag it `private,
+    // max-age=60` so the browser can reuse it for back-button /
+    // repeat-search but no shared cache hangs on to it. Gate
+    // matches the actual search predicate (`raw_q` filters
+    // `len() >= 2`), so `?q=a` still gets the default listing.
     if is_active_search(params.q.as_deref()) {
-        Ok(super::no_store_html(html))
+        Ok(super::search_cached_html(html))
     } else {
         Ok(Html(html).into_response())
     }
 }
 
 /// True when `?q=…` is a real search query — same trim+length gate
-/// the search predicate uses. Single source of truth so the no-store
-/// branch and the predicate gate can't drift apart (Copilot review
-/// on #674).
+/// the search predicate uses. Single source of truth so the
+/// search-cache branch and the predicate gate can't drift apart
+/// (Copilot review on #674).
 fn is_active_search(q: Option<&str>) -> bool {
     q.map(str::trim).is_some_and(|t| t.chars().count() >= 2)
 }
@@ -1171,7 +1172,7 @@ pub async fn films_search(
 ) -> WebResult<Response> {
     let q = params.get("q").map(|s| s.trim()).unwrap_or("");
     if q.len() < 2 {
-        return Ok(super::no_store_json(Vec::<SearchResult>::new()));
+        return Ok(super::search_cached_json(Vec::<SearchResult>::new()));
     }
 
     let mut rows = search_films_by_title(&state.db, q).await?;
@@ -1195,7 +1196,7 @@ pub async fn films_search(
         })
         .collect();
 
-    Ok(super::no_store_json(results))
+    Ok(super::search_cached_json(results))
 }
 
 async fn search_films_by_title(db: &sqlx::PgPool, q: &str) -> Result<Vec<SearchRow>, sqlx::Error> {
@@ -2023,10 +2024,11 @@ mod tests {
 
     #[test]
     fn is_active_search_gate_matches_predicate_threshold() {
-        // Must mirror `raw_q`'s `len() >= 2` filter so the no-store
-        // branch in `films_list` and the search predicate gate stay
-        // in sync — Copilot review on #674 caught the original
-        // looser check letting `?q=a` mark non-search pages no-store.
+        // Must mirror `raw_q`'s `len() >= 2` filter so the
+        // search-cache branch in `films_list` and the search
+        // predicate gate stay in sync — Copilot review on #674
+        // caught the original looser check letting `?q=a` mark
+        // non-search pages with the search cache header.
         assert!(!is_active_search(None));
         assert!(!is_active_search(Some("")));
         assert!(!is_active_search(Some("   ")));
@@ -2041,31 +2043,42 @@ mod tests {
     }
 
     #[test]
-    fn no_store_json_helper_attaches_cache_control() {
-        // Lock the contract: every body wrapped by `no_store_json`
-        // must come back with `Cache-Control: no-store`. Without this
-        // header mobile browsers can heuristically cache autocomplete
-        // fetches and serve a stale payload across deploys (#673
-        // follow-up incident).
-        let resp = super::super::no_store_json(Vec::<u8>::new());
+    fn search_cached_json_helper_uses_private_short_max_age() {
+        // Lock the contract: every body wrapped by
+        // `search_cached_json` must come back with the standard
+        // `private, max-age=60` policy. Two failure modes to guard:
+        //   - regression to bare `no-store` (wasteful, what we
+        //     replaced),
+        //   - missing `private` (would let CF / ISP caches store
+        //     query-derived responses).
+        let resp = super::super::search_cached_json(Vec::<u8>::new());
         let cc = resp
             .headers()
             .get(axum::http::header::CACHE_CONTROL)
-            .expect("Cache-Control header must be set");
-        assert_eq!(cc.to_str().unwrap(), "no-store");
+            .expect("Cache-Control header must be set")
+            .to_str()
+            .unwrap();
+        assert!(cc.contains("private"), "missing `private`: {cc}");
+        assert!(cc.contains("max-age=60"), "missing `max-age=60`: {cc}");
+        assert!(!cc.contains("public"), "must not be `public`: {cc}");
+        assert!(!cc.contains("no-store"), "must not be `no-store`: {cc}");
     }
 
     #[test]
-    fn no_store_html_helper_attaches_cache_control() {
+    fn search_cached_html_helper_uses_private_short_max_age() {
         // Same contract for the HTML helper used by
-        // `films_list` / `series_list` / `tv_porady_list` when a
-        // search query is active.
-        let resp = super::super::no_store_html(String::from("<p>hi</p>"));
+        // `films_list` / `series_list` / `tv_porady_list` on the
+        // search-active branch.
+        let resp = super::super::search_cached_html(String::from("<p>hi</p>"));
         let cc = resp
             .headers()
             .get(axum::http::header::CACHE_CONTROL)
-            .expect("Cache-Control header must be set");
-        assert_eq!(cc.to_str().unwrap(), "no-store");
+            .expect("Cache-Control header must be set")
+            .to_str()
+            .unwrap();
+        assert!(cc.contains("private"), "missing `private`: {cc}");
+        assert!(cc.contains("max-age=60"), "missing `max-age=60`: {cc}");
+        assert!(!cc.contains("public"), "must not be `public`: {cc}");
     }
 
     #[test]

--- a/cr-web/src/handlers/mod.rs
+++ b/cr-web/src/handlers/mod.rs
@@ -56,23 +56,42 @@ pub use voices::voices;
 
 // --- Shared response helpers ---
 
-/// Wrap a JSON-serializable body with `Cache-Control: no-store`.
+/// Cache directive used by the diacritics-aware search responses
+/// (`/api/films/search`, `/api/series/search`, `/api/tv-porady/search`,
+/// and the `?q=…`-derived HTML on `/filmy-online/`, `/serialy-online/`,
+/// `/tv-porady/`).
 ///
-/// Used by the diacritics-aware search APIs (`/api/films/search`,
-/// `/api/series/search`, `/api/tv-porady/search`) so mobile browsers
-/// don't apply heuristic caching to autocomplete fetches and pin a
-/// stale payload across deploys (#673 → #674 follow-up).
-pub(crate) fn no_store_json<T: serde::Serialize>(body: T) -> Response {
-    ([(header::CACHE_CONTROL, "no-store")], axum::Json(body)).into_response()
+/// `private` keeps shared caches (Cloudflare, ISPs, corporate proxies)
+/// out — these responses are query-derived and may differ per user
+/// once auth lands. `max-age=60` lets the browser reuse the response
+/// for up to a minute, which saves a round trip on:
+///   - rapid back/forward navigation (bfcache and HTTP cache),
+///   - re-typing the same autocomplete query,
+///   - returning to a search-result page from a film detail.
+///
+/// One minute is short enough that newly-imported films / episodes
+/// (cr-llm-resolver runs daily) show up promptly while still cutting
+/// the duplicate-fetch traffic that motivated the #674 incident — the
+/// earlier `no-store` policy was the strict but wasteful first fix;
+/// this is the standard recommendation for query-dependent dynamic
+/// content.
+const SEARCH_CACHE_CONTROL: &str = "private, max-age=60";
+
+/// Wrap a JSON-serializable body with the standard search cache
+/// header. See `SEARCH_CACHE_CONTROL` for the rationale.
+pub(crate) fn search_cached_json<T: serde::Serialize>(body: T) -> Response {
+    (
+        [(header::CACHE_CONTROL, SEARCH_CACHE_CONTROL)],
+        axum::Json(body),
+    )
+        .into_response()
 }
 
-/// Wrap a rendered HTML body with `Cache-Control: no-store`. Same
-/// motivation as `no_store_json` — used by search-result listing
-/// pages (`/filmy-online/?q=…` etc.) where the response depends
-/// entirely on the user's query and bfcache / heuristic browser
-/// caching can serve a stale page after a deploy.
-pub(crate) fn no_store_html(html: String) -> Response {
-    ([(header::CACHE_CONTROL, "no-store")], Html(html)).into_response()
+/// Wrap a rendered HTML body with the standard search cache header.
+/// Used by the `?q=…`-active branches of the listing handlers; the
+/// default (no-query) branch keeps its existing caching behavior.
+pub(crate) fn search_cached_html(html: String) -> Response {
+    ([(header::CACHE_CONTROL, SEARCH_CACHE_CONTROL)], Html(html)).into_response()
 }
 
 // --- DB row types ---

--- a/cr-web/src/handlers/series.rs
+++ b/cr-web/src/handlers/series.rs
@@ -505,11 +505,11 @@ pub async fn series_list(
 }
 
 /// True when `?q=…` is a real search query — same trim+length gate
-/// the search predicate uses. Single source of truth so the
-/// search-cache branch and the predicate gate can't drift apart
-/// (Copilot review on #674).
+/// the search predicate uses (`search_q` filters `t.len() >= 2`,
+/// byte length). Single source of truth so the search-cache branch
+/// and the predicate gate can't drift apart on multibyte chars.
 fn is_active_search(q: Option<&str>) -> bool {
-    q.map(str::trim).is_some_and(|t| t.chars().count() >= 2)
+    q.map(str::trim).is_some_and(|t| t.len() >= 2)
 }
 
 /// Latest-episode-per-series query. Supports include/exclude genre slug lists

--- a/cr-web/src/handlers/series.rs
+++ b/cr-web/src/handlers/series.rs
@@ -491,22 +491,23 @@ pub async fn series_list(
         series_genres_map,
     };
     let html = tmpl.render()?;
-    // Search-result HTML is `?q=`-derived: no-store keeps mobile
-    // bfcache / heuristic caching from pinning a stale page (#673
-    // follow-up). Gate matches the actual search predicate above
-    // (`search_q` filters `len() >= 2`) — `?q=a` still gets the
-    // cacheable default listing.
+    // Search-result HTML is `?q=`-derived: tag it `private,
+    // max-age=60` so the browser may reuse it for a minute on
+    // back-button / repeat-search, but no shared cache stores
+    // it. Gate matches the actual search predicate above
+    // (`search_q` filters `len() >= 2`) — `?q=a` still gets
+    // the default cacheable listing.
     if is_active_search(params.q.as_deref()) {
-        Ok(super::no_store_html(html))
+        Ok(super::search_cached_html(html))
     } else {
         Ok(Html(html).into_response())
     }
 }
 
 /// True when `?q=…` is a real search query — same trim+length gate
-/// the search predicate uses. Single source of truth so the no-store
-/// branch and the predicate gate can't drift apart (Copilot review
-/// on #674).
+/// the search predicate uses. Single source of truth so the
+/// search-cache branch and the predicate gate can't drift apart
+/// (Copilot review on #674).
 fn is_active_search(q: Option<&str>) -> bool {
     q.map(str::trim).is_some_and(|t| t.chars().count() >= 2)
 }
@@ -1155,7 +1156,7 @@ pub async fn series_search(
 ) -> WebResult<Response> {
     let q = params.get("q").map(|s| s.trim()).unwrap_or("");
     if q.len() < 2 {
-        return Ok(super::no_store_json(Vec::<SeriesSearchResult>::new()));
+        return Ok(super::search_cached_json(Vec::<SeriesSearchResult>::new()));
     }
     let pattern = format!("%{q}%");
     let starts_pattern = format!("{q}%");
@@ -1192,7 +1193,7 @@ pub async fn series_search(
         })
         .collect();
 
-    Ok(super::no_store_json(results))
+    Ok(super::search_cached_json(results))
 }
 
 pub async fn series_cover(

--- a/cr-web/src/handlers/tv_porady.rs
+++ b/cr-web/src/handlers/tv_porady.rs
@@ -317,10 +317,11 @@ pub async fn tv_porady_list(
 }
 
 /// True when `?q=…` is a real search query — same trim+length gate
-/// the search predicate uses. Single source of truth so the
-/// search-cache branch and the predicate gate can't drift apart.
+/// the search predicate uses (`search_q` filters `t.len() >= 2`,
+/// byte length). Single source of truth so the search-cache branch
+/// and the predicate gate can't drift apart on multibyte chars.
 fn is_active_search(q: Option<&str>) -> bool {
-    q.map(str::trim).is_some_and(|t| t.chars().count() >= 2)
+    q.map(str::trim).is_some_and(|t| t.len() >= 2)
 }
 
 async fn fetch_latest_episode_cards(

--- a/cr-web/src/handlers/tv_porady.rs
+++ b/cr-web/src/handlers/tv_porady.rs
@@ -304,20 +304,21 @@ pub async fn tv_porady_list(
         search_query,
     };
     let html = tmpl.render()?;
-    // Search-result HTML is `?q=`-derived: no-store keeps mobile
-    // bfcache / heuristic caching from pinning a stale page (#673
-    // / #674 parity with films and series). Gate matches the search
-    // predicate (`search_q` filters `len() >= 2`).
+    // Search-result HTML is `?q=`-derived: tag it `private,
+    // max-age=60` so the browser may reuse it for a minute on
+    // back-button / repeat-search but no shared cache stores it.
+    // Parity with films and series (#673 / #674). Gate matches
+    // the search predicate (`search_q` filters `len() >= 2`).
     if is_active_search(params.q.as_deref()) {
-        Ok(super::no_store_html(html))
+        Ok(super::search_cached_html(html))
     } else {
         Ok(Html(html).into_response())
     }
 }
 
 /// True when `?q=…` is a real search query — same trim+length gate
-/// the search predicate uses. Single source of truth so the no-store
-/// branch and the predicate gate can't drift apart.
+/// the search predicate uses. Single source of truth so the
+/// search-cache branch and the predicate gate can't drift apart.
 fn is_active_search(q: Option<&str>) -> bool {
     q.map(str::trim).is_some_and(|t| t.chars().count() >= 2)
 }
@@ -381,7 +382,7 @@ pub async fn tv_porady_search(
 ) -> WebResult<Response> {
     let q = params.get("q").map(|s| s.trim()).unwrap_or("");
     if q.len() < 2 {
-        return Ok(super::no_store_json(Vec::<TvPoradSearchResult>::new()));
+        return Ok(super::search_cached_json(Vec::<TvPoradSearchResult>::new()));
     }
     let pattern = format!("%{q}%");
     let starts_pattern = format!("{q}%");
@@ -418,7 +419,7 @@ pub async fn tv_porady_search(
         })
         .collect();
 
-    Ok(super::no_store_json(results))
+    Ok(super::search_cached_json(results))
 }
 
 /// GET /tv-porady/{slug}/ — TV pořad detail with episode list.


### PR DESCRIPTION
<!-- claude-session: 2a9d2a6f-393f-4d32-bfd9-71a66bafae38 -->

Follow-up to #674. `no-store` was the strict-but-wasteful first fix to break out of a stale-mobile incident. With the user now on fresh bytes, switch to the standard recommendation for query-dependent dynamic content:

```
Cache-Control: private, max-age=60
```

## Why

| Directive | Effect |
|---|---|
| `private` | No shared cache (Cloudflare, ISPs, corporate proxies) stores the response — query-derived and per-user when auth lands |
| `max-age=60` | Browser reuses for up to a minute → bfcache, repeat-search, back-from-detail all hit the cache |

60 seconds is short enough that newly-imported content (cr-llm-resolver runs daily) appears promptly, but it cuts the duplicate-fetch traffic that `no-store` forced on every interaction.

## Changes

- `handlers/mod.rs`: `no_store_json` / `no_store_html` → `search_cached_json` / `search_cached_html`. Single `SEARCH_CACHE_CONTROL` constant.
- `films.rs`, `series.rs`, `tv_porady.rs`: call sites + inline comments.
- Regression tests now lock the `private` + `max-age=60` contract and explicitly reject `public` and `no-store`.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p cr-web` (45 passed)
- [x] Cross-compile + deployed to prod, `/health` 200
- [x] `curl -I` on prod confirms:
  - `/filmy-online/?q=ab` → `cache-control: private, max-age=60`
  - `/serialy-online/?q=ab` → `cache-control: private, max-age=60`
  - `/tv-porady/?q=ab` → `cache-control: private, max-age=60`
  - `/api/films/search?q=ab` / `/api/series/search?q=ab` / `/api/tv-porady/search?q=ab` → same
  - `/filmy-online/` (no `q`) → no `cache-control` (intentional, default listing keeps existing behavior)
- [x] Diacritics search still functional: `/api/films/search?q=laska%20nebeska` returns both Láska-titled films

🤖 Generated with [Claude Code](https://claude.com/claude-code)