### PR TITLE
feat(auto-import): attach prehraj.to sources after every new SK Torrent film

### DIFF
--- a/cr-infra/migrations/20260607_067_import_prehrajto_status.sql
+++ b/cr-infra/migrations/20260607_067_import_prehrajto_status.sql
@@ -1,0 +1,25 @@
+-- Track whether the daily auto-import attempted (and matched) prehraj.to
+-- search after each new SK Torrent film. Surfaced on /admin/import/{N} so
+-- the operator sees which films picked up a prehrajto source automatically
+-- and which need manual triage. Counters on `import_runs` summarize the
+-- whole run for the dashboard list view.
+--
+-- `prehrajto_status` values written by `scripts/auto-import.py`:
+--   matched        — at least one accepted hit was written / re-pointed
+--   no_results     — search returned 0 hits
+--   no_acceptable  — hits found but all rejected (low sim / wrong duration)
+--   error          — non-blocking exception during search/write
+--   blocked        — proxy / prehraj.to returned non-200 (run aborts)
+ALTER TABLE import_items
+    ADD COLUMN IF NOT EXISTS prehrajto_status      text,
+    ADD COLUMN IF NOT EXISTS prehrajto_rows_written integer NOT NULL DEFAULT 0;
+
+ALTER TABLE import_items
+    ADD CONSTRAINT import_items_prehrajto_status_check
+    CHECK (prehrajto_status IS NULL OR prehrajto_status IN
+           ('matched', 'no_results', 'no_acceptable', 'error', 'blocked'));
+
+ALTER TABLE import_runs
+    ADD COLUMN IF NOT EXISTS prehrajto_attempted    integer NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS prehrajto_matched      integer NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS prehrajto_rows_written integer NOT NULL DEFAULT 0;

--- a/cr-web/src/handlers/admin_import.rs
+++ b/cr-web/src/handlers/admin_import.rs
@@ -40,6 +40,17 @@ struct ImportRunRow {
     updated_episodes: i32,
     failed_count: i32,
     skipped_count: i32,
+    /// Summary counters for the prehraj.to search pass that the daily
+    /// auto-import runs after every added/updated film. `attempted` is
+    /// the number of films we searched, `matched` how many got at least
+    /// one new prehrajto upload attached, and `rows_written` the total
+    /// `video_sources` rows inserted/re-pointed.
+    #[sqlx(default)]
+    prehrajto_attempted: i32,
+    #[sqlx(default)]
+    prehrajto_matched: i32,
+    #[sqlx(default)]
+    prehrajto_rows_written: i32,
     error_message: Option<String>,
 }
 
@@ -102,6 +113,22 @@ struct ImportItemRow {
     failure_step: Option<String>,
     failure_message: Option<String>,
     raw_log: Option<JsonValue>,
+    /// Outcome of the prehraj.to search pass for this film:
+    /// `matched` / `no_results` / `no_acceptable` / `error` / `blocked`.
+    /// NULL for non-film rows or when the pre-#651 importer wrote the row.
+    #[sqlx(default)]
+    prehrajto_status: Option<String>,
+    /// Number of `video_sources(provider='prehrajto')` rows inserted or
+    /// re-pointed during the search pass. Zero when status != matched.
+    #[sqlx(default)]
+    prehrajto_rows_written: Option<i32>,
+    /// Title pulled in via the `films` JOIN — used to build the
+    /// `https://prehraj.to/hledej/{title (year)}` link the operator
+    /// clicks when checking a film the script couldn't auto-match.
+    #[sqlx(default)]
+    target_film_title: Option<String>,
+    #[sqlx(default)]
+    target_film_year: Option<i16>,
 }
 
 impl ImportItemRow {
@@ -178,6 +205,66 @@ impl ImportItemRow {
             _ => None,
         }
     }
+
+    /// Short Czech label for the prehraj.to search outcome — matched /
+    /// 0 hits / nezpůsobilé výsledky / chyba / blocked. Returns None if
+    /// the row is non-film or pre-dates the integration.
+    fn prehrajto_label(&self) -> Option<&'static str> {
+        match self.prehrajto_status.as_deref() {
+            Some("matched") => Some("✓ nalezeno"),
+            Some("no_results") => Some("0 výsledků"),
+            Some("no_acceptable") => Some("nezpůsobilé"),
+            Some("error") => Some("⚠ chyba"),
+            Some("blocked") => Some("⚠ blocked"),
+            _ => None,
+        }
+    }
+
+    /// CSS class hook so the template can colour-tag the prehrajto cell.
+    fn prehrajto_class(&self) -> &'static str {
+        match self.prehrajto_status.as_deref() {
+            Some("matched") => "prh-matched",
+            Some("no_results") => "prh-empty",
+            Some("no_acceptable") => "prh-empty",
+            Some("error") | Some("blocked") => "prh-error",
+            _ => "prh-none",
+        }
+    }
+
+    /// Pre-built `https://prehraj.to/hledej/{title (year)}` URL the
+    /// operator clicks when the auto-match missed something. Returns
+    /// None for non-film rows (no title to query with).
+    fn prehrajto_search_url(&self) -> Option<String> {
+        let title = self.target_film_title.as_deref()?;
+        let q = match self.target_film_year {
+            Some(y) => format!("{} ({})", title, y),
+            None => title.to_string(),
+        };
+        // Mirror the script's query cleanup: prehraj.to returns 404
+        // when the path contains `/`, `?`, `#`, etc., even URL-encoded.
+        let cleaned: String = q
+            .chars()
+            .map(|c| {
+                if matches!(c, '/' | '?' | '#' | '&' | '%') {
+                    ' '
+                } else {
+                    c
+                }
+            })
+            .collect();
+        let cleaned = cleaned.split_whitespace().collect::<Vec<_>>().join(" ");
+        Some(format!(
+            "https://prehraj.to/hledej/{}",
+            urlencoding::encode(&cleaned)
+        ))
+    }
+
+    fn prehrajto_rows_written_str(&self) -> String {
+        match self.prehrajto_rows_written.unwrap_or(0) {
+            0 => String::new(),
+            n => format!("{n}×"),
+        }
+    }
 }
 
 #[derive(Template)]
@@ -215,7 +302,9 @@ pub async fn admin_import_list(State(state): State<AppState>) -> WebResult<Respo
         "SELECT id, started_at, finished_at, status, trigger, scanned_pages, \
          scanned_videos, checkpoint_before, checkpoint_after, added_films, \
          added_series, added_episodes, added_tv_shows, added_tv_episodes, \
-         updated_films, updated_episodes, failed_count, skipped_count, error_message \
+         updated_films, updated_episodes, failed_count, skipped_count, \
+         prehrajto_attempted, prehrajto_matched, prehrajto_rows_written, \
+         error_message \
          FROM import_runs ORDER BY started_at DESC LIMIT 30",
     )
     .fetch_all(&state.db)
@@ -291,7 +380,9 @@ pub async fn admin_import_detail(
         "SELECT id, started_at, finished_at, status, trigger, scanned_pages, \
          scanned_videos, checkpoint_before, checkpoint_after, added_films, \
          added_series, added_episodes, added_tv_shows, added_tv_episodes, \
-         updated_films, updated_episodes, failed_count, skipped_count, error_message \
+         updated_films, updated_episodes, failed_count, skipped_count, \
+         prehrajto_attempted, prehrajto_matched, prehrajto_rows_written, \
+         error_message \
          FROM import_runs WHERE id = $1",
     )
     .bind(run_id)
@@ -308,13 +399,16 @@ pub async fn admin_import_detail(
          i.target_film_id, i.target_series_id, i.target_episode_id, \
          i.target_tv_show_id, i.target_tv_episode_id, \
          f.slug AS target_film_slug, \
+         f.title AS target_film_title, \
+         f.year AS target_film_year, \
          s.slug AS target_series_slug, \
          e.slug AS target_episode_slug, \
          es.slug AS target_episode_series_slug, \
          ts.slug AS target_tv_show_slug, \
          te.slug AS target_tv_episode_slug, \
          tes.slug AS target_tv_episode_show_slug, \
-         i.failure_step, i.failure_message, i.raw_log \
+         i.failure_step, i.failure_message, i.raw_log, \
+         i.prehrajto_status, i.prehrajto_rows_written \
          FROM import_items i \
          LEFT JOIN films f     ON f.id   = i.target_film_id \
          LEFT JOIN series s    ON s.id   = i.target_series_id \

--- a/cr-web/templates/admin_import_detail.html
+++ b/cr-web/templates/admin_import_detail.html
@@ -53,6 +53,20 @@
             <span class="count count-failed">{{ run.failed_count }} selhalo</span>
             <span class="count count-skipped">⊘{{ run.skipped_count }} přeskočeno</span>
         </div>
+        <div class="counts">
+            <span class="count count-prh"
+                  title="Filmy, u kterých skript po importu hledal prehraj.to (jen filmy, ne seriály)">
+                prehraj.to: hledáno {{ run.prehrajto_attempted }} ×
+            </span>
+            <span class="count count-prh-ok"
+                  title="Z toho filmů, kde skript našel a navázal aspoň jeden prehraj.to upload">
+                ✓ navázáno {{ run.prehrajto_matched }} ×
+            </span>
+            <span class="count count-prh-rows"
+                  title="Celkem přidaných nebo přesměrovaných video_sources řádků">
+                +{{ run.prehrajto_rows_written }} prehraj.to zdrojů
+            </span>
+        </div>
         <div>
             <a href="/admin/import/{{ run.id }}.json" title="Strojitelný JSON export">📋 JSON export</a>
         </div>
@@ -71,7 +85,7 @@
         {% else %}
         <table class="items-table">
             <thead>
-                <tr><th>Akce</th><th>SK Torrent</th><th>Detekce</th><th>IMDB</th><th>Náš detail</th></tr>
+                <tr><th>Akce</th><th>SK Torrent</th><th>Detekce</th><th>IMDB</th><th>Náš detail</th><th>prehraj.to</th></tr>
             </thead>
             <tbody>
                 {% for it in added %}
@@ -81,6 +95,15 @@
                     <td>{{ it.detected_type.as_deref().unwrap_or("?") }}{% match it.season_episode() %}{% when Some with (se) %} {{ se }}{% when None %}{% endmatch %}</td>
                     <td>{% match it.imdb_url() %}{% when Some with (u) %}<a href="{{ u }}" target="_blank" rel="noopener" title="IMDB">{{ it.imdb_id.as_deref().unwrap_or("") }}</a>{% when None %}—{% endmatch %}</td>
                     <td>{% match it.target_url() %}{% when Some with (u) %}<a href="{{ u }}" title="Detail">→</a>{% when None %}—{% endmatch %}</td>
+                    <td class="{{ it.prehrajto_class() }}">
+                        {% match it.prehrajto_label() %}{% when Some with (lab) %}
+                            <span class="prh-label">{{ lab }}</span>
+                            {% if it.prehrajto_rows_written_str() != "" %}<span class="prh-rows">{{ it.prehrajto_rows_written_str() }}</span>{% endif %}
+                        {% when None %}—{% endmatch %}
+                        {% match it.prehrajto_search_url() %}{% when Some with (u) %}
+                            <a class="prh-search" href="{{ u }}" target="_blank" rel="noopener" title="Hledat na prehraj.to">🔍</a>
+                        {% when None %}{% endmatch %}
+                    </td>
                 </tr>
                 {% endfor %}
             </tbody>
@@ -93,7 +116,7 @@
         <p class="empty-state">Žádné doplněné zdroje.</p>
         {% else %}
         <table class="items-table">
-            <thead><tr><th>Akce</th><th>SK Torrent</th><th>IMDB</th><th>Náš detail</th></tr></thead>
+            <thead><tr><th>Akce</th><th>SK Torrent</th><th>IMDB</th><th>Náš detail</th><th>prehraj.to</th></tr></thead>
             <tbody>
                 {% for it in updated %}
                 <tr>
@@ -101,6 +124,15 @@
                     <td><a href="{{ it.sktorrent_url }}" target="_blank" rel="noopener" title="{{ it.sktorrent_title }}">{{ it.sktorrent_title }}</a></td>
                     <td>{% match it.imdb_url() %}{% when Some with (u) %}<a href="{{ u }}" target="_blank" rel="noopener" title="IMDB">{{ it.imdb_id.as_deref().unwrap_or("") }}</a>{% when None %}—{% endmatch %}</td>
                     <td>{% match it.target_url() %}{% when Some with (u) %}<a href="{{ u }}" title="Detail">→</a>{% when None %}—{% endmatch %}</td>
+                    <td class="{{ it.prehrajto_class() }}">
+                        {% match it.prehrajto_label() %}{% when Some with (lab) %}
+                            <span class="prh-label">{{ lab }}</span>
+                            {% if it.prehrajto_rows_written_str() != "" %}<span class="prh-rows">{{ it.prehrajto_rows_written_str() }}</span>{% endif %}
+                        {% when None %}—{% endmatch %}
+                        {% match it.prehrajto_search_url() %}{% when Some with (u) %}
+                            <a class="prh-search" href="{{ u }}" target="_blank" rel="noopener" title="Hledat na prehraj.to">🔍</a>
+                        {% when None %}{% endmatch %}
+                    </td>
                 </tr>
                 {% endfor %}
             </tbody>
@@ -158,6 +190,17 @@
 .count-updated { background: #dbeafe; color: #1e40af; }
 .count-failed { background: #fee2e2; color: #991b1b; }
 .count-skipped { background: #f3f4f6; color: #6b7280; }
+.count-prh { background: #ede9fe; color: #5b21b6; }
+.count-prh-ok { background: #c7d2fe; color: #3730a3; }
+.count-prh-rows { background: #ddd6fe; color: #5b21b6; }
+.prh-matched { background: rgba(16,185,129,0.08); }
+.prh-empty { color: #6b7280; }
+.prh-error { background: rgba(239,68,68,0.08); color: #991b1b; }
+.prh-none { color: #9ca3af; }
+.prh-label { font-size: 0.78rem; font-weight: 600; }
+.prh-rows { margin-left: 0.3rem; font-size: 0.72rem; color: #6b21a8; font-weight: 600; }
+.prh-search { margin-left: 0.4rem; text-decoration: none; opacity: 0.55; }
+.prh-search:hover { opacity: 1; }
 .error-msg { color: #991b1b; font-size: 0.85rem; }
 .tabs { display: flex; gap: 0.3rem; border-bottom: 2px solid #e5e7eb; margin-bottom: 1rem; }
 .tab { background: none; border: none; padding: 0.6rem 1rem; cursor: pointer; font-size: 0.92rem; color: #555; border-bottom: 2px solid transparent; margin-bottom: -2px; }

--- a/cr-web/templates/admin_import_list.html
+++ b/cr-web/templates/admin_import_list.html
@@ -57,6 +57,7 @@
                 <th>Doplněno</th>
                 <th>Selhalo</th>
                 <th>Přeskočeno</th>
+                <th title="prehraj.to: navázáno / hledáno (rows)">prehraj.to</th>
             </tr>
         </thead>
         <tbody>
@@ -76,6 +77,12 @@
                 <td>{{ r.updated_films + r.updated_episodes }}</td>
                 <td class="{% if r.failed_count > 0 %}error-cell{% endif %}">{{ r.failed_count }}</td>
                 <td>{{ r.skipped_count }}</td>
+                <td title="filmů s nalezeným prehraj.to / pokusů (+rows přidaných řádků)">
+                    {% if r.prehrajto_attempted > 0 %}
+                        <strong>{{ r.prehrajto_matched }}</strong>/{{ r.prehrajto_attempted }}
+                        <span class="prh-rows">+{{ r.prehrajto_rows_written }}</span>
+                    {% else %}—{% endif %}
+                </td>
             </tr>
             {% endfor %}
         </tbody>
@@ -110,5 +117,6 @@
 .run-now-form .btn-run { background: #11457E; color: white; border: none; padding: 0.4rem 1rem; border-radius: 4px; font-size: 0.9rem; font-weight: 600; cursor: pointer; }
 .run-now-form .btn-run:hover { background: #0d3a6e; }
 .run-now-form .hint { color: #64748b; font-size: 0.82rem; }
+.runs-table .prh-rows { font-size: 0.72rem; color: #6b21a8; font-weight: 600; }
 </style>
 {% endblock %}

--- a/scripts/auto-import.py
+++ b/scripts/auto-import.py
@@ -39,29 +39,30 @@ from pathlib import Path
 
 # Allow `python3 scripts/auto-import.py` from any cwd. Modules in scripts/
 # auto_import/*.py import via `scripts.auto_import.foo`, so we add the project
-# root (parent of scripts/) to sys.path.
+# root (parent of scripts/) to sys.path. We also add scripts/ itself so the
+# bare-name import of `video_sources_helper` (used both here AND from inside
+# `prehrajto_search.py`) resolves — it MUST happen before any auto_import
+# package import or transitive `from video_sources_helper import …` will fail.
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_PROJECT_ROOT / "scripts"))
 sys.path.insert(0, str(_PROJECT_ROOT))
 
-import psycopg2
-import requests
+import psycopg2  # noqa: E402
+import requests  # noqa: E402
 
-from scripts.auto_import.sktorrent_scanner import (
+from scripts.auto_import.sktorrent_scanner import (  # noqa: E402
     scan_new_videos, ScannedVideo, ScannerError,
 )
-from scripts.auto_import.sktorrent_detail import fetch_detail, DetailFetchError
-from scripts.auto_import.title_parser import parse_sktorrent_title, ParsedTitle
-from scripts.auto_import.tmdb_resolver import resolve_movie, resolve_tv
-from scripts.auto_import.enricher import upsert_film
-from scripts.auto_import.series_enricher import process_series_batch
-from scripts.auto_import.tv_show_enricher import process_tv_show_episode
-from scripts.auto_import.prehrajto_search import (
+from scripts.auto_import.sktorrent_detail import fetch_detail, DetailFetchError  # noqa: E402
+from scripts.auto_import.title_parser import parse_sktorrent_title, ParsedTitle  # noqa: E402
+from scripts.auto_import.tmdb_resolver import resolve_movie, resolve_tv  # noqa: E402
+from scripts.auto_import.enricher import upsert_film  # noqa: E402
+from scripts.auto_import.series_enricher import process_series_batch  # noqa: E402
+from scripts.auto_import.tv_show_enricher import process_tv_show_episode  # noqa: E402
+from scripts.auto_import.prehrajto_search import (  # noqa: E402
     BlockedError as PrehrajtoBlockedError,
     try_prehrajto_match,
 )
-# scripts/ also on path so we can import the dual-write helpers module by
-# its bare name (it doesn't live under the auto_import package).
-sys.path.insert(0, str(_PROJECT_ROOT / "scripts"))
 from video_sources_helper import get_provider_ids  # noqa: E402
 
 log = logging.getLogger("auto-import")
@@ -310,20 +311,25 @@ def _try_prehrajto_for_film(conn, *, film_id: int, providers: dict,
         counters["prehrajto_attempted"] += 1
         return "error", 0
     counters["prehrajto_attempted"] += 1
-    if result["written"] or result["repointed"]:
+    attached = result["written"] + result["repointed"] + result.get("refreshed", 0)
+    if attached:
         counters["prehrajto_matched"] += 1
-        counters["prehrajto_rows_written"] += result["written"]
+        # Run-level row counter only counts genuinely new state (insert
+        # or re-point), not pure refreshes — otherwise re-runs of the
+        # daily importer would inflate it indefinitely.
+        counters["prehrajto_rows_written"] += result["written"] + result["repointed"]
         log.info("  prehrajto match film_id=%d: written=%d repointed=%d "
-                 "(query=%r)", film_id, result["written"], result["repointed"],
+                 "refreshed=%d (query=%r)", film_id, result["written"],
+                 result["repointed"], result.get("refreshed", 0),
                  result["query"])
-        return "matched", result["written"]
+        return "matched", result["written"] + result["repointed"]
     if result["hits"] == 0:
         return "no_results", 0
     if result["accepted"] == 0:
         return "no_acceptable", 0
-    # Hits accepted but neither written nor repointed → all collisions
-    # with another film's existing rows. Tag as no_acceptable so the
-    # admin UI surfaces it as "search ran but didn't attach anything".
+    # Hits accepted but nothing attached to our film → all collisions
+    # with other films' existing rows where the title-evidence wasn't
+    # strong enough to re-point. Surface as no_acceptable in the admin UI.
     return "no_acceptable", 0
 
 

--- a/scripts/auto-import.py
+++ b/scripts/auto-import.py
@@ -55,6 +55,14 @@ from scripts.auto_import.tmdb_resolver import resolve_movie, resolve_tv
 from scripts.auto_import.enricher import upsert_film
 from scripts.auto_import.series_enricher import process_series_batch
 from scripts.auto_import.tv_show_enricher import process_tv_show_episode
+from scripts.auto_import.prehrajto_search import (
+    BlockedError as PrehrajtoBlockedError,
+    try_prehrajto_match,
+)
+# scripts/ also on path so we can import the dual-write helpers module by
+# its bare name (it doesn't live under the auto_import package).
+sys.path.insert(0, str(_PROJECT_ROOT / "scripts"))
+from video_sources_helper import get_provider_ids  # noqa: E402
 
 log = logging.getLogger("auto-import")
 
@@ -152,6 +160,9 @@ def _close_run(conn, run_id: int, status: str,
                updated_episodes = %s,
                failed_count = %s,
                skipped_count = %s,
+               prehrajto_attempted = %s,
+               prehrajto_matched = %s,
+               prehrajto_rows_written = %s,
                error_message = %s
            WHERE id = %s""",
         (
@@ -168,6 +179,9 @@ def _close_run(conn, run_id: int, status: str,
             counters["updated_episodes"],
             counters["failed_count"],
             counters["skipped_count"],
+            counters.get("prehrajto_attempted", 0),
+            counters.get("prehrajto_matched", 0),
+            counters.get("prehrajto_rows_written", 0),
             error_message,
             run_id,
         ),
@@ -196,7 +210,9 @@ def _insert_item(conn, *, run_id: int, video: ScannedVideo,
                  target_tv_episode_id: int | None = None,
                  failure_step: str | None = None,
                  failure_message: str | None = None,
-                 raw_log: dict | None = None) -> None:
+                 raw_log: dict | None = None,
+                 prehrajto_status: str | None = None,
+                 prehrajto_rows_written: int = 0) -> None:
     cur = conn.cursor()
     cur.execute(
         """INSERT INTO import_items
@@ -204,9 +220,10 @@ def _insert_item(conn, *, run_id: int, video: ScannedVideo,
             detected_type, imdb_id, tmdb_id, season, episode, action,
             target_film_id, target_series_id, target_episode_id,
             target_tv_show_id, target_tv_episode_id,
-            failure_step, failure_message, raw_log)
+            failure_step, failure_message, raw_log,
+            prehrajto_status, prehrajto_rows_written)
            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
-                   %s, %s, %s, %s, %s, %s, %s, %s)""",
+                   %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)""",
         (
             run_id, video.video_id, video.url, video.title,
             detected_type, imdb_id, tmdb_id,
@@ -217,6 +234,7 @@ def _insert_item(conn, *, run_id: int, video: ScannedVideo,
             target_tv_show_id, target_tv_episode_id,
             failure_step, failure_message,
             json.dumps(raw_log, ensure_ascii=False) if raw_log else None,
+            prehrajto_status, prehrajto_rows_written,
         ),
     )
 
@@ -256,9 +274,63 @@ def _langs_to_flags(langs: list[str]) -> tuple[bool, bool]:
     return has_dub, has_subs
 
 
+def _try_prehrajto_for_film(conn, *, film_id: int, providers: dict,
+                            prh_session: requests.Session,
+                            counters: dict) -> tuple[str, int]:
+    """Search prehraj.to for the just-added film and write hits.
+
+    Returns (status, rows_written) for storage on the import_items row.
+    Status is one of: matched, no_results, no_acceptable, error, blocked.
+    BlockedError is re-raised so the run aborts (we share the proxy with
+    the SK Torrent scanner — losing it kills both pipelines).
+    """
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT title, original_title, year, runtime_min "
+        "FROM films WHERE id = %s",
+        (film_id,),
+    )
+    row = cur.fetchone()
+    if not row:
+        return "error", 0
+    title, original_title, year, runtime_min = row
+    try:
+        result = try_prehrajto_match(
+            cur, providers, film_id,
+            title=title, original_title=original_title,
+            year=year, runtime_min=runtime_min, sess=prh_session,
+        )
+    except PrehrajtoBlockedError:
+        conn.rollback()
+        counters["prehrajto_attempted"] += 1
+        raise
+    except Exception as e:
+        log.warning("prehrajto match failed for film_id=%d: %s", film_id, e)
+        conn.rollback()
+        counters["prehrajto_attempted"] += 1
+        return "error", 0
+    counters["prehrajto_attempted"] += 1
+    if result["written"] or result["repointed"]:
+        counters["prehrajto_matched"] += 1
+        counters["prehrajto_rows_written"] += result["written"]
+        log.info("  prehrajto match film_id=%d: written=%d repointed=%d "
+                 "(query=%r)", film_id, result["written"], result["repointed"],
+                 result["query"])
+        return "matched", result["written"]
+    if result["hits"] == 0:
+        return "no_results", 0
+    if result["accepted"] == 0:
+        return "no_acceptable", 0
+    # Hits accepted but neither written nor repointed → all collisions
+    # with another film's existing rows. Tag as no_acceptable so the
+    # admin UI surfaces it as "search ran but didn't attach anything".
+    return "no_acceptable", 0
+
+
 def _process_film(conn, *, run_id: int, video: ScannedVideo,
                   parsed: ParsedTitle, detail, movies_covers: Path,
-                  counters: dict, tmdb_session: requests.Session) -> None:
+                  counters: dict, tmdb_session: requests.Session,
+                  providers: dict, prh_session: requests.Session) -> None:
     movie = resolve_movie(parsed, session=tmdb_session)
     if movie is None or not movie.imdb_id:
         _mark_skipped(conn, video.video_id, "tmdb_resolve_failed")
@@ -308,15 +380,49 @@ def _process_film(conn, *, run_id: int, video: ScannedVideo,
                      failure_step="already_imported",
                      failure_message="film already linked to this SK Torrent video")
         counters["skipped_count"] += 1
-    else:
+        conn.commit()
+        return
+
+    # Persist the upsert outcome before we touch the network — if the
+    # prehraj.to search fails, the import_items row already exists and
+    # surfaces the SK Torrent video correctly in the admin dashboard.
+    conn.commit()
+    if action == "added_film":
+        counters["added_films"] += 1
+    elif action == "updated_film":
+        counters["updated_films"] += 1
+
+    # Now try prehraj.to. Two reasons it runs even on `updated_film`:
+    # 1) updated_film means a film row matched an existing TMDB id but
+    #    the prehraj.to importer might still have missed it.
+    # 2) The check inside try_prehrajto_match is cheap; if the film
+    #    already has a prehrajto source, write_hits will simply refresh
+    #    the existing rows.
+    prh_status: str | None = None
+    prh_rows = 0
+    try:
+        prh_status, prh_rows = _try_prehrajto_for_film(
+            conn, film_id=film_id, providers=providers,
+            prh_session=prh_session, counters=counters,
+        )
+        conn.commit()
+    except PrehrajtoBlockedError as e:
+        # Record the import_items row anyway, then bubble up to abort run.
         _insert_item(conn, run_id=run_id, video=video, parsed=parsed,
                      detected_type="film",
                      imdb_id=movie.imdb_id, tmdb_id=movie.tmdb_id,
-                     action=action, target_film_id=film_id)
-        if action == "added_film":
-            counters["added_films"] += 1
-        elif action == "updated_film":
-            counters["updated_films"] += 1
+                     action=action, target_film_id=film_id,
+                     prehrajto_status="blocked",
+                     prehrajto_rows_written=0)
+        conn.commit()
+        raise
+
+    _insert_item(conn, run_id=run_id, video=video, parsed=parsed,
+                 detected_type="film",
+                 imdb_id=movie.imdb_id, tmdb_id=movie.tmdb_id,
+                 action=action, target_film_id=film_id,
+                 prehrajto_status=prh_status,
+                 prehrajto_rows_written=prh_rows)
     conn.commit()
 
 
@@ -565,6 +671,8 @@ def run(trigger: str, max_new: int) -> int:
         "added_tv_shows": 0, "added_tv_episodes": 0,
         "updated_films": 0, "updated_episodes": 0,
         "failed_count": 0, "skipped_count": 0,
+        "prehrajto_attempted": 0, "prehrajto_matched": 0,
+        "prehrajto_rows_written": 0,
     }
     checkpoint_after = checkpoint
     checkpoint_after_tv = checkpoint_tv
@@ -573,6 +681,8 @@ def run(trigger: str, max_new: int) -> int:
 
     skt_session = requests.Session()
     tmdb_session = requests.Session()
+    prh_session = requests.Session()
+    providers = get_provider_ids(conn.cursor())
 
     try:
         scan_generic = scan_new_videos(
@@ -648,10 +758,20 @@ def run(trigger: str, max_new: int) -> int:
                                  series_covers=series_covers,
                                  counters=counters, tmdb_session=tmdb_session)
             elif parsed.cz_title or parsed.en_title:
-                _process_film(conn, run_id=run_id, video=video,
-                              parsed=parsed, detail=detail,
-                              movies_covers=movies_covers,
-                              counters=counters, tmdb_session=tmdb_session)
+                try:
+                    _process_film(conn, run_id=run_id, video=video,
+                                  parsed=parsed, detail=detail,
+                                  movies_covers=movies_covers,
+                                  counters=counters,
+                                  tmdb_session=tmdb_session,
+                                  providers=providers,
+                                  prh_session=prh_session)
+                except PrehrajtoBlockedError as e:
+                    log.error("prehraj.to blocked — aborting run after "
+                              "current film: %s", e)
+                    status = "partial"
+                    error_message = f"prehrajto blocked: {e}"
+                    break
             else:
                 _insert_item(conn, run_id=run_id, video=video, parsed=parsed,
                              detected_type="unknown",
@@ -697,6 +817,7 @@ def run(trigger: str, max_new: int) -> int:
         finally:
             skt_session.close()
             tmdb_session.close()
+            prh_session.close()
             conn.close()
 
     log.info("run %d finished: status=%s counters=%s", run_id, status, counters)

--- a/scripts/auto_import/prehrajto_search.py
+++ b/scripts/auto_import/prehrajto_search.py
@@ -386,14 +386,27 @@ def write_hits(
     cur, providers: dict, film_id: int,
     hits_with_meta: list[tuple],
     our_titles: list[str] | None = None,
-) -> tuple[int, int, int]:
+) -> tuple[int, int, int, int]:
     """Insert / re-point accepted hits.
 
     `hits_with_meta` items: (hit, tier).
-    Returns (written, repointed, collision_skipped).
+    Returns (written, repointed, refreshed, collision_skipped).
+
+    Three "attached to our film" outcomes — distinguished so the caller
+    can keep run-level counters honest:
+
+    * `written`   — fresh `video_sources` row inserted (the upload had no
+                    previous record).
+    * `repointed` — cross-film re-point: row existed under another film
+                    but the title-evidence heuristic moved it to ours.
+    * `refreshed` — row already attached to our film; we just bumped
+                    `last_seen` / `title`. Counted separately so a re-run
+                    doesn't inflate `rows_written`, but still treated as
+                    a successful match by the caller.
     """
     written = 0
     repointed = 0
+    refreshed = 0
     skipped_collision = 0
     for hit, tier in hits_with_meta:
         lang = detect_lang(hit.title)
@@ -434,6 +447,9 @@ def write_hits(
 
         existing_id, existing_film_id = existing
         if existing_film_id == film_id:
+            # Already attached to us — just refresh mutable fields. Counted
+            # via `refreshed` so a re-run still reports the film as
+            # "matched" without inflating `written`.
             cur.execute("SAVEPOINT dw")
             try:
                 dual_write_prehrajto_upload(
@@ -442,7 +458,7 @@ def write_hits(
                     primary_upload_id=None,
                 )
                 cur.execute("RELEASE SAVEPOINT dw")
-                written += 1
+                refreshed += 1
             except psycopg2.errors.UniqueViolation:
                 cur.execute("ROLLBACK TO SAVEPOINT dw")
                 cur.execute("RELEASE SAVEPOINT dw")
@@ -463,6 +479,12 @@ def write_hits(
                      reason, hit.external_id, existing_film_id, film_id)
             continue
 
+        # Re-point both tables in lockstep. The legacy
+        # `film_prehrajto_uploads.upload_id` carries a UNIQUE constraint so
+        # a single upload exists exactly once across all films; if we only
+        # moved `video_sources` here, the legacy table would still claim
+        # the upload belongs to the old film and any reconciliation /
+        # backfill code that joins via `upload_id` would split-brain.
         cur.execute(
             "UPDATE video_sources "
             "   SET film_id = %s, "
@@ -474,12 +496,17 @@ def write_hits(
             (film_id, "cs" if lang in ("CZ_DUB", "CZ_NATIVE") else None,
              lang, existing_id),
         )
+        cur.execute(
+            "UPDATE film_prehrajto_uploads "
+            "   SET film_id = %s, last_seen_at = NOW() "
+            " WHERE upload_id = %s",
+            (film_id, hit.external_id),
+        )
         repointed += 1
         log.info("  RE-POINTED upload_id=%s row=%d: film=%d → film=%d (%s)",
                  hit.external_id, existing_id, existing_film_id,
                  film_id, reason)
-        written += 1
-    return written, repointed, skipped_collision
+    return written, repointed, refreshed, skipped_collision
 
 
 def try_prehrajto_match(
@@ -491,8 +518,13 @@ def try_prehrajto_match(
     """Search prehraj.to for a film and write matched hits.
 
     Single-film entry point used by the daily auto-import. Returns a
-    dict with counters: hits, accepted, written, repointed, collisions,
-    tier_counts. Caller is responsible for transaction control.
+    dict with counters: hits, accepted, written, repointed, refreshed,
+    collisions, tier_counts. Caller is responsible for transaction
+    control.
+
+    `attached = written + repointed + refreshed` is the right "did this
+    film end up with a prehrajto source?" signal. `written` alone tells
+    you only whether a NEW row was added during this run.
 
     Raises `BlockedError` if the proxy / prehraj.to misbehaves.
     """
@@ -517,13 +549,14 @@ def try_prehrajto_match(
     accepted = [(h, t) for h, t, _, _ in classified
                 if t in ("strong", "solid", "weak")]
 
-    written = repointed = collisions = 0
+    written = repointed = refreshed = collisions = 0
     if accepted:
-        written, repointed, collisions = write_hits(
+        written, repointed, refreshed, collisions = write_hits(
             cur, providers, film_id, accepted, our_titles=db_titles_full,
         )
     return {
         "query": query, "hits": len(hits), "accepted": len(accepted),
         "written": written, "repointed": repointed,
-        "collisions": collisions, "tier_counts": tier_counts,
+        "refreshed": refreshed, "collisions": collisions,
+        "tier_counts": tier_counts,
     }

--- a/scripts/auto_import/prehrajto_search.py
+++ b/scripts/auto_import/prehrajto_search.py
@@ -1,0 +1,529 @@
+"""Search prehraj.to for an upload matching a given film row.
+
+Originally lived as private functions inside `scripts/backfill-prehrajto-
+from-search.py`. Moved here so the daily auto-import can attach prehraj.to
+sources to films right after they're added from SK Torrent — without
+spawning a subprocess or duplicating the heuristic.
+
+Public API:
+
+    try_prehrajto_match(cur, providers, film_id, *,
+                        title, original_title, year, runtime_min,
+                        sess) -> dict
+
+`cur` is a psycopg2 cursor in an open transaction; the helper writes via
+`dual_write_prehrajto_upload` (and re-points cross-film collisions when
+the title evidence strongly favours `film_id`).
+
+Raises `BlockedError` when the CZ proxy / prehraj.to returns HTTP non-200
+or a suspiciously short body — propagate up so the caller can abort the
+run before burning more proxy quota.
+"""
+
+from __future__ import annotations
+
+import difflib
+import logging
+import re
+import time
+import unicodedata
+import urllib.parse
+from dataclasses import dataclass
+
+import psycopg2
+import requests
+from bs4 import BeautifulSoup
+
+from .cz_proxy import proxy_get
+
+# Re-exported so callers (backfill script, auto-import) can use a single
+# helper module without duplicating the dual-write helpers' import path.
+from video_sources_helper import dual_write_prehrajto_upload  # noqa: F401
+
+log = logging.getLogger(__name__)
+
+SEARCH_BASE = "https://prehraj.to/hledej/"
+SEARCH_SLEEP_S = 2.5
+SIM_GATE = 0.50
+YEAR_TOL = 1
+MIN_BODY_LEN = 5000
+DUR_TOL = 0.20
+DUR_HARD_REJECT = 0.50
+MAX_PAGES = 5
+
+EP_RE = re.compile(r"\b[Ss]\d{1,2}[Ee]\d{1,3}\b|\b\d{1,2}x\d{1,3}\b")
+_HIT_YEAR_RE = re.compile(r"\b(19\d{2}|20\d{2})\b")
+
+CZ_DUB_RE = re.compile(
+    r"(?:\bcz\s*dab(?:ing)?\b|\bczdab\w*|\bczdub\w*|"
+    r"\bcesk[aáyý]\s*dab(?:ing)?\b|\bc[zs]\s*dabing\b|cesky\s*dabing|cz\s*\.dab\b)",
+    re.IGNORECASE,
+)
+CZ_SUB_RE = re.compile(
+    r"(?:\bcz\s*tit(?:ulky)?\b|\bcztit\w*|\bcz\s*subs?\b|\bc[zs]\s*titulky\b|cesk[yé]\s*titulky)",
+    re.IGNORECASE,
+)
+SK_DUB_RE = re.compile(
+    r"(?:\bsk\s*dab(?:ing)?\b|\bskdab\w*|\bskdub\w*|\bsloven(?:sk[yáé]|ina)\s*dab(?:ing)?\b)",
+    re.IGNORECASE,
+)
+SK_SUB_RE = re.compile(r"(?:\bsk\s*tit(?:ulky)?\b|\bsktit\w*)", re.IGNORECASE)
+EN_ONLY_RE = re.compile(
+    r"(?:\bengsub\b|\beng\s*sub\b|\beng\s*only\b|\bengdub\b)", re.IGNORECASE
+)
+_RES_RE = re.compile(
+    r"(2160p|1080p|720p|480p|BDRip|BluRay|WEBRip|WEB[\s-]?DL|HDRip|DVDRip|HDTV|TVRip|CAM|TS)",
+    re.IGNORECASE,
+)
+
+
+class BlockedError(RuntimeError):
+    """Raised when prehraj.to (or the CZ proxy) appears to block us."""
+
+
+@dataclass
+class Hit:
+    href: str
+    external_id: str
+    title: str
+    duration_sec: int | None
+    filesize_bytes: int | None
+
+
+def detect_lang(title: str) -> str:
+    if not title:
+        return "UNKNOWN"
+    t = title.lower()
+    if CZ_DUB_RE.search(t):
+        return "CZ_DUB"
+    if SK_DUB_RE.search(t):
+        return "SK_DUB"
+    if CZ_SUB_RE.search(t):
+        return "CZ_SUB"
+    if SK_SUB_RE.search(t):
+        return "SK_SUB"
+    has_cz = bool(re.search(r"\bcz\b", t)) or bool(re.search(r"\bcesk[yáyé]", t))
+    if EN_ONLY_RE.search(t) and not has_cz:
+        return "EN"
+    return "UNKNOWN"
+
+
+def extract_resolution(title: str) -> str | None:
+    m = _RES_RE.search(title or "")
+    return m.group(1).lower() if m else None
+
+
+def ascii_fold(s: str) -> str:
+    """Lowercase + strip diacritics + normalize ampersand-equivalents +
+    fold release-style separators (`.`, `-`, `_`, `:`) to spaces.
+    """
+    s = unicodedata.normalize("NFKD", s)
+    s = "".join(c for c in s if not unicodedata.combining(c)).lower()
+    for token in (" and ", " und ", " & ", "&"):
+        s = s.replace(token, " a ")
+    for ch in ".,;:_-":
+        s = s.replace(ch, " ")
+    s = re.sub(r"\s+", " ", s).strip()
+    return s
+
+
+def _sim(a: str, b: str) -> float:
+    return difflib.SequenceMatcher(None, ascii_fold(a), ascii_fold(b)).ratio()
+
+
+def _parse_duration_to_sec(s: str | None) -> int | None:
+    if not s:
+        return None
+    parts = s.split(":")
+    try:
+        nums = [int(p) for p in parts]
+    except ValueError:
+        return None
+    if len(nums) == 3:
+        h, m, sec = nums
+        return h * 3600 + m * 60 + sec
+    if len(nums) == 2:
+        m, sec = nums
+        return m * 60 + sec
+    return None
+
+
+def parse_search_html(html: str) -> list[Hit]:
+    soup = BeautifulSoup(html, "html.parser")
+    hits: list[Hit] = []
+    seen_ext_ids: set[str] = set()
+    for div in soup.select("div.video__picture--container"):
+        a = div.find("a", href=True)
+        if not a:
+            continue
+        href = a["href"]
+        m = re.match(r"^/(.+?)/([0-9a-f]{8,})$", href)
+        if not m:
+            continue
+        _slug, ext_id = m.groups()
+        if ext_id in seen_ext_ids:
+            continue
+        seen_ext_ids.add(ext_id)
+        h3 = div.find("h3", class_="video__title")
+        title = h3.get_text(strip=True) if h3 else _slug
+        dur = div.find("div", class_="video__tag--time")
+        duration_sec = _parse_duration_to_sec(
+            dur.get_text(strip=True) if dur else None
+        )
+        sz = div.find("div", class_="video__tag--size")
+        filesize_bytes = None
+        if sz:
+            sz_text = sz.get_text(strip=True)
+            mz = re.match(r"^([\d\.]+)\s*(MB|GB)", sz_text, re.IGNORECASE)
+            if mz:
+                v = float(mz.group(1))
+                if mz.group(2).upper() == "GB":
+                    v *= 1024
+                filesize_bytes = int(v * 1024 * 1024)
+        hits.append(Hit(
+            href=href, external_id=ext_id, title=title,
+            duration_sec=duration_sec, filesize_bytes=filesize_bytes,
+        ))
+    return hits
+
+
+def classify_match(
+    hit: Hit, db_titles: list[str], year: int | None,
+    runtime_min: int | None,
+) -> tuple[str, float, dict]:
+    """Tier-based match classification.
+
+    Returns (tier, sim, meta) where tier ∈ strong, solid, weak,
+    reject_tv, reject_duration, reject_low_sim, reject. See backfill
+    script docstring for the rationale.
+    """
+    if EP_RE.search(hit.title):
+        return ("reject_tv", 0.0, {"reason": "tv_episode"})
+
+    best = 0.0
+    contains = False
+    hit_folded = ascii_fold(hit.title)
+    for t in db_titles:
+        s = _sim(hit.title, t)
+        if s > best:
+            best = s
+        t_folded = ascii_fold(t)
+        if len(t_folded) >= 4 and t_folded in hit_folded:
+            contains = True
+    if contains:
+        best = max(best, 1.0)
+
+    yr_m = _HIT_YEAR_RE.search(hit.title)
+    hit_year = int(yr_m.group(1)) if yr_m else None
+    year_match = bool(year and hit_year and abs(hit_year - year) <= YEAR_TOL)
+
+    hit_dur_min = (hit.duration_sec // 60) if hit.duration_sec else None
+    dur_match = None
+    dur_delta = None
+    if hit_dur_min and runtime_min:
+        dur_delta = abs(hit_dur_min - runtime_min) / runtime_min
+        dur_match = dur_delta <= DUR_TOL
+
+    meta = {
+        "contains": contains, "year_match": year_match,
+        "hit_year": hit_year, "hit_dur_min": hit_dur_min,
+        "dur_match": dur_match, "dur_delta": dur_delta,
+    }
+
+    if dur_delta is not None and dur_delta > DUR_HARD_REJECT:
+        return ("reject_duration", best, meta)
+
+    title_ok = best >= SIM_GATE or contains
+    if not title_ok:
+        return ("reject_low_sim", best, meta)
+
+    if year_match and dur_match:
+        return ("strong", best, meta)
+    if year_match or dur_match:
+        return ("solid", best, meta)
+    if hit_year is None and hit_dur_min is None:
+        return ("weak", best, meta)
+    return ("reject", best, meta)
+
+
+def build_query(title: str, original: str | None, year: int | None) -> str:
+    base = title or original or ""
+    if year:
+        base = f"{base} ({year})"
+    base = re.sub(r"[/?#&%]+", " ", base)
+    return re.sub(r"\s+", " ", base).strip()
+
+
+def _detect_max_page(html: str) -> int:
+    pages = re.findall(r"visualPaginator-page=(\d+)", html)
+    if not pages:
+        return 1
+    return min(MAX_PAGES, max(int(p) for p in pages))
+
+
+def search_prehrajto(
+    sess: requests.Session, query: str,
+    db_titles: list[str], db_year: int | None, db_runtime_min: int | None,
+) -> list[Hit]:
+    all_hits: list[Hit] = []
+    seen: set[str] = set()
+    db_titles_full = list(db_titles)
+    for t in list(db_titles):
+        folded = ascii_fold(t)
+        if folded != t.lower():
+            db_titles_full.append(folded)
+    have_strong = False
+    page = 1
+    max_page = MAX_PAGES
+    while page <= max_page:
+        if page == 1:
+            url = SEARCH_BASE + urllib.parse.quote(query, safe='')
+        else:
+            url = (
+                SEARCH_BASE + urllib.parse.quote(query, safe='')
+                + f"?videoListing-visualPaginator-page={page}"
+            )
+        r = proxy_get(url, sess, timeout=30)
+        if r.status_code != 200:
+            log.error("BLOCKED: HTTP %d for query=%r url=%s",
+                      r.status_code, query, url)
+            raise BlockedError(f"HTTP {r.status_code}")
+        body = r.text
+        if len(body) < MIN_BODY_LEN:
+            log.error("BLOCKED: short body len=%d for query=%r", len(body), query)
+            raise BlockedError(f"body too short ({len(body)})")
+        if page == 1:
+            max_page = _detect_max_page(body)
+        page_hits = parse_search_html(body)
+        new_hits = 0
+        for h in page_hits:
+            if h.external_id in seen:
+                continue
+            seen.add(h.external_id)
+            all_hits.append(h)
+            new_hits += 1
+            tier, _, _ = classify_match(h, db_titles_full, db_year, db_runtime_min)
+            if tier == "strong":
+                have_strong = True
+        if page == 1 and have_strong:
+            return all_hits
+        if new_hits == 0:
+            break
+        page += 1
+        if page <= max_page:
+            time.sleep(SEARCH_SLEEP_S)
+    return all_hits
+
+
+_FPU_UPSERT_SQL = """
+    INSERT INTO film_prehrajto_uploads
+        (film_id, upload_id, url, title, duration_sec, view_count,
+         lang_class, resolution_hint, last_seen_at, is_alive)
+    VALUES
+        (%(film_id)s, %(upload_id)s, %(url)s, %(title)s, %(duration_sec)s, %(view_count)s,
+         %(lang_class)s, %(resolution_hint)s, NOW(), TRUE)
+    ON CONFLICT (upload_id) DO UPDATE SET
+        url             = EXCLUDED.url,
+        title           = EXCLUDED.title,
+        duration_sec    = EXCLUDED.duration_sec,
+        lang_class      = EXCLUDED.lang_class,
+        resolution_hint = EXCLUDED.resolution_hint,
+        last_seen_at    = EXCLUDED.last_seen_at,
+        is_alive        = TRUE
+    WHERE film_prehrajto_uploads.film_id = EXCLUDED.film_id
+"""
+
+
+def _is_existing_owner_worse_match(
+    cur, existing_film_id: int, hit: Hit, our_film_id: int,
+    our_titles: list[str],
+) -> tuple[bool, str]:
+    if existing_film_id == our_film_id:
+        return False, "same_film"
+    cur.execute(
+        "SELECT title, year, runtime_min FROM films WHERE id = %s",
+        (existing_film_id,),
+    )
+    row = cur.fetchone()
+    if not row:
+        return True, "owner_missing"
+    o_title, o_year, o_runtime = row
+
+    yr_m = _HIT_YEAR_RE.search(hit.title)
+    hit_year = int(yr_m.group(1)) if yr_m else None
+    hit_dur_min = (hit.duration_sec // 60) if hit.duration_sec else None
+
+    if hit_year and o_year and abs(hit_year - o_year) > YEAR_TOL:
+        return True, f"year_mismatch hit={hit_year} owner={o_year}"
+    if hit_dur_min and o_runtime:
+        delta = abs(hit_dur_min - o_runtime) / o_runtime
+        if delta > DUR_TOL:
+            return True, (f"dur_mismatch hit={hit_dur_min}min "
+                          f"owner={o_runtime}min Δ={delta:.0%}")
+
+    hit_folded = ascii_fold(hit.title)
+    sim_to_us = max(_sim(hit.title, t) for t in our_titles) if our_titles else 0.0
+    contains_us = any(
+        ascii_fold(t) in hit_folded for t in our_titles
+        if t and len(ascii_fold(t)) >= 4
+    )
+    if contains_us:
+        sim_to_us = max(sim_to_us, 1.0)
+    sim_to_owner = _sim(hit.title, o_title) if o_title else 0.0
+    o_folded = ascii_fold(o_title) if o_title else ""
+    if o_folded and len(o_folded) >= 4 and o_folded in hit_folded:
+        sim_to_owner = max(sim_to_owner, 1.0)
+    if sim_to_us - sim_to_owner >= 0.20:
+        return True, (f"title_evidence sim_us={sim_to_us:.2f} "
+                      f"sim_owner={sim_to_owner:.2f}")
+
+    return False, (f"owner_consistent sim_us={sim_to_us:.2f} "
+                   f"sim_owner={sim_to_owner:.2f} "
+                   f"yr={o_year}/{hit_year} dur={o_runtime}/{hit_dur_min}")
+
+
+def write_hits(
+    cur, providers: dict, film_id: int,
+    hits_with_meta: list[tuple],
+    our_titles: list[str] | None = None,
+) -> tuple[int, int, int]:
+    """Insert / re-point accepted hits.
+
+    `hits_with_meta` items: (hit, tier).
+    Returns (written, repointed, collision_skipped).
+    """
+    written = 0
+    repointed = 0
+    skipped_collision = 0
+    for hit, tier in hits_with_meta:
+        lang = detect_lang(hit.title)
+        res = extract_resolution(hit.title)
+        url = "https://prehraj.to" + hit.href
+        row = {
+            "film_id": film_id, "upload_id": hit.external_id, "url": url,
+            "title": hit.title, "duration_sec": hit.duration_sec,
+            "view_count": None, "lang_class": lang, "resolution_hint": res,
+        }
+        cur.execute(_FPU_UPSERT_SQL, row)
+        cur.execute(
+            "SELECT id, film_id FROM video_sources "
+            "WHERE provider_id = %s AND external_id = %s",
+            (providers["prehrajto"], hit.external_id),
+        )
+        existing = cur.fetchone()
+
+        if existing is None:
+            cur.execute("SAVEPOINT dw")
+            try:
+                dual_write_prehrajto_upload(
+                    cur, providers=providers, film_id=film_id,
+                    upload_row={**row, "is_direct": False, "is_alive": True},
+                    primary_upload_id=None,
+                )
+                cur.execute("RELEASE SAVEPOINT dw")
+                written += 1
+            except psycopg2.errors.UniqueViolation as e:
+                cur.execute("ROLLBACK TO SAVEPOINT dw")
+                cur.execute("RELEASE SAVEPOINT dw")
+                log.warning(
+                    "dual_write race film_id=%d upload_id=%s (%s)",
+                    film_id, hit.external_id,
+                    getattr(getattr(e, "diag", None), "constraint_name", "unique"),
+                )
+            continue
+
+        existing_id, existing_film_id = existing
+        if existing_film_id == film_id:
+            cur.execute("SAVEPOINT dw")
+            try:
+                dual_write_prehrajto_upload(
+                    cur, providers=providers, film_id=film_id,
+                    upload_row={**row, "is_direct": False, "is_alive": True},
+                    primary_upload_id=None,
+                )
+                cur.execute("RELEASE SAVEPOINT dw")
+                written += 1
+            except psycopg2.errors.UniqueViolation:
+                cur.execute("ROLLBACK TO SAVEPOINT dw")
+                cur.execute("RELEASE SAVEPOINT dw")
+            continue
+
+        if tier != "strong":
+            skipped_collision += 1
+            log.info("  collision skipped (tier=%s): upload_id=%s on film=%d, ours=%d",
+                     tier, hit.external_id, existing_film_id, film_id)
+            continue
+
+        should_repoint, reason = _is_existing_owner_worse_match(
+            cur, existing_film_id, hit, film_id, our_titles or [],
+        )
+        if not should_repoint:
+            skipped_collision += 1
+            log.info("  collision keeps owner (%s): upload_id=%s on film=%d, ours=%d",
+                     reason, hit.external_id, existing_film_id, film_id)
+            continue
+
+        cur.execute(
+            "UPDATE video_sources "
+            "   SET film_id = %s, "
+            "       audio_lang = COALESCE(%s, audio_lang), "
+            "       lang_class = %s, "
+            "       audio_detected_by = COALESCE(audio_detected_by, 'title_regex'), "
+            "       updated_at = NOW() "
+            " WHERE id = %s",
+            (film_id, "cs" if lang in ("CZ_DUB", "CZ_NATIVE") else None,
+             lang, existing_id),
+        )
+        repointed += 1
+        log.info("  RE-POINTED upload_id=%s row=%d: film=%d → film=%d (%s)",
+                 hit.external_id, existing_id, existing_film_id,
+                 film_id, reason)
+        written += 1
+    return written, repointed, skipped_collision
+
+
+def try_prehrajto_match(
+    cur, providers: dict, film_id: int, *,
+    title: str, original_title: str | None,
+    year: int | None, runtime_min: int | None,
+    sess: requests.Session,
+) -> dict:
+    """Search prehraj.to for a film and write matched hits.
+
+    Single-film entry point used by the daily auto-import. Returns a
+    dict with counters: hits, accepted, written, repointed, collisions,
+    tier_counts. Caller is responsible for transaction control.
+
+    Raises `BlockedError` if the proxy / prehraj.to misbehaves.
+    """
+    query = build_query(title, original_title, year)
+    db_titles = [t for t in (title, original_title) if t]
+    db_titles_full = list(db_titles)
+    for t in list(db_titles):
+        folded = ascii_fold(t)
+        if folded != t.lower():
+            db_titles_full.append(folded)
+
+    hits = search_prehrajto(
+        sess, query, db_titles_full, year, runtime_min,
+    )
+    classified = [
+        (h, *classify_match(h, db_titles_full, year, runtime_min))
+        for h in hits
+    ]
+    tier_counts: dict[str, int] = {}
+    for _, t, _, _ in classified:
+        tier_counts[t] = tier_counts.get(t, 0) + 1
+    accepted = [(h, t) for h, t, _, _ in classified
+                if t in ("strong", "solid", "weak")]
+
+    written = repointed = collisions = 0
+    if accepted:
+        written, repointed, collisions = write_hits(
+            cur, providers, film_id, accepted, our_titles=db_titles_full,
+        )
+    return {
+        "query": query, "hits": len(hits), "accepted": len(accepted),
+        "written": written, "repointed": repointed,
+        "collisions": collisions, "tier_counts": tier_counts,
+    }

--- a/scripts/backfill-prehrajto-from-search.py
+++ b/scripts/backfill-prehrajto-from-search.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Backfill prehraj.to sources for films that already have a sktorrent source
+   but no prehrajto source.
+
+The sktorrent backfill more than doubled `films` last week. Many of those
+also exist on prehraj.to, but our `import-prehrajto-uploads.py` cron runs
+the OPPOSITE direction (sitemap → match TMDB) and does not retroactively
+cover films we add from other providers.
+
+This script flips the lookup: for each (film_id) with SKT but no PRH, we
+search `prehraj.to/hledej/{title (year)}` via the CZ proxy, classify hits
+and write accepted ones via the dual-write helper.
+
+Idempotent: re-runs are safe because upserts key on `upload_id`. The
+daily cron mode (--daily) skips films that got a PRH row in the past 7 days.
+
+Watchdog: any HTTP non-200 or suspiciously short body raises BlockedError
+and aborts the run (we share the CZ proxy with the sktorrent scanner —
+losing it kills two pipelines).
+
+The actual search/classify/write logic lives in
+`scripts/auto_import/prehrajto_search.py` so the daily auto-import can
+reuse it directly.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+
+import psycopg2
+import requests
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_PROJECT_ROOT))
+sys.path.insert(0, str(_PROJECT_ROOT / "scripts"))
+
+from scripts.auto_import.prehrajto_search import (  # noqa: E402
+    BlockedError, SEARCH_SLEEP_S, try_prehrajto_match,
+)
+from video_sources_helper import get_provider_ids  # noqa: E402
+
+log = logging.getLogger("backfill_prh")
+
+
+def _select_target_films(
+    cur, limit: int | None, daily: bool, only_film_id: int | None
+) -> list[tuple[int, str, str | None, int | None, int | None]]:
+    if only_film_id:
+        cur.execute(
+            "SELECT id, title, original_title, year, runtime_min "
+            "FROM films WHERE id = %s",
+            (only_film_id,),
+        )
+        return list(cur.fetchall())
+    where_extra = ""
+    if daily:
+        where_extra = """
+          AND NOT EXISTS (
+            SELECT 1 FROM film_prehrajto_uploads fpu
+             WHERE fpu.film_id = f.id
+               AND fpu.last_seen_at > NOW() - INTERVAL '7 days'
+          )
+        """
+    sql = f"""
+        SELECT f.id, f.title, f.original_title, f.year, f.runtime_min
+          FROM films f
+          JOIN video_sources vs1
+            ON vs1.film_id = f.id AND vs1.provider_id = 1
+         WHERE NOT EXISTS (
+              SELECT 1 FROM video_sources vs2
+               WHERE vs2.film_id = f.id AND vs2.provider_id = 2
+         )
+         {where_extra}
+         ORDER BY f.id DESC
+    """
+    if limit:
+        sql += " LIMIT %s"
+        cur.execute(sql, (limit,))
+    else:
+        cur.execute(sql)
+    return list(cur.fetchall())
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--limit", type=int, help="max films to process")
+    ap.add_argument("--film-id", type=int, help="single film_id (debug)")
+    ap.add_argument("--daily", action="store_true",
+                    help="skip films that got a PRH hit in the last 7 days")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="parse + score, but do not write to DB")
+    ap.add_argument("--commit-every", type=int, default=50)
+    ap.add_argument("-v", "--verbose", action="store_true")
+    args = ap.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+
+    db_url = os.environ.get("DATABASE_URL")
+    if not db_url:
+        log.error("DATABASE_URL not set")
+        return 2
+    db_url = db_url.replace("@db:", "@127.0.0.1:")  # prod→local SSH-tunnel rewrite
+
+    conn = psycopg2.connect(db_url)
+    conn.autocommit = False
+    cur = conn.cursor()
+
+    films = _select_target_films(cur, args.limit, args.daily, args.film_id)
+    log.info("selected %d films (limit=%s daily=%s film_id=%s)",
+             len(films), args.limit, args.daily, args.film_id)
+    if not films:
+        return 0
+
+    providers = get_provider_ids(cur)
+    sess = requests.Session()
+
+    counters = {
+        "films_total": len(films), "films_processed": 0,
+        "films_with_hits": 0, "films_no_hits": 0, "films_no_results": 0,
+        "rows_written": 0, "rows_repointed": 0,
+        "blocked": 0, "errors": 0,
+    }
+
+    t0 = time.time()
+    try:
+        for i, (film_id, title, orig, year, runtime_min) in enumerate(films, 1):
+            counters["films_processed"] += 1
+            try:
+                if args.dry_run:
+                    # In dry-run we still call try_prehrajto_match but
+                    # rollback any DB changes immediately afterwards. Cheap.
+                    cur.execute("SAVEPOINT dry")
+                result = try_prehrajto_match(
+                    cur, providers, film_id,
+                    title=title, original_title=orig, year=year,
+                    runtime_min=runtime_min, sess=sess,
+                )
+                if args.dry_run:
+                    cur.execute("ROLLBACK TO SAVEPOINT dry")
+                    cur.execute("RELEASE SAVEPOINT dry")
+            except BlockedError as e:
+                log.error("ABORT: blocked by prehraj.to — %s", e)
+                counters["blocked"] += 1
+                conn.rollback()
+                return 3
+            except Exception as e:
+                log.error("error film_id=%d: %s", film_id, e)
+                counters["errors"] += 1
+                conn.rollback()
+                time.sleep(SEARCH_SLEEP_S)
+                continue
+
+            tier_summary = {k: v for k, v in result["tier_counts"].items() if v}
+            if result["hits"] == 0:
+                counters["films_no_results"] += 1
+                log.info("[%d/%d] film_id=%d %r — 0 hits",
+                         i, len(films), film_id, result["query"])
+            elif result["accepted"] == 0:
+                counters["films_no_hits"] += 1
+                log.info("[%d/%d] film_id=%d %r — %d hits, no acceptable tier (%s)",
+                         i, len(films), film_id, result["query"],
+                         result["hits"], tier_summary)
+            else:
+                counters["films_with_hits"] += 1
+                counters["rows_written"] += result["written"]
+                counters["rows_repointed"] += result["repointed"]
+                log.info("[%d/%d] film_id=%d %r — %d hits → %s "
+                         "(written=%d repointed=%d collisions=%d)",
+                         i, len(films), film_id, result["query"],
+                         result["hits"], tier_summary,
+                         result["written"], result["repointed"],
+                         result["collisions"])
+
+            if not args.dry_run and i % args.commit_every == 0:
+                conn.commit()
+                log.info("COMMIT @ %d (rows_written=%d)",
+                         i, counters["rows_written"])
+            time.sleep(SEARCH_SLEEP_S)
+
+        if not args.dry_run:
+            conn.commit()
+    finally:
+        cur.close()
+        conn.close()
+
+    dur = time.time() - t0
+    log.info("finished: %s in %.0fs (%.2f films/s)",
+             counters, dur, counters["films_processed"] / max(dur, 1e-3))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/backfill-prehrajto-from-search.py
+++ b/scripts/backfill-prehrajto-from-search.py
@@ -47,7 +47,8 @@ log = logging.getLogger("backfill_prh")
 
 
 def _select_target_films(
-    cur, limit: int | None, daily: bool, only_film_id: int | None
+    cur, providers: dict, limit: int | None, daily: bool,
+    only_film_id: int | None,
 ) -> list[tuple[int, str, str | None, int | None, int | None]]:
     if only_film_id:
         cur.execute(
@@ -65,23 +66,25 @@ def _select_target_films(
                AND fpu.last_seen_at > NOW() - INTERVAL '7 days'
           )
         """
+    # Provider IDs are seeded per-DB and not guaranteed stable across
+    # environments, so resolve them by slug rather than hard-coding 1/2.
     sql = f"""
         SELECT f.id, f.title, f.original_title, f.year, f.runtime_min
           FROM films f
           JOIN video_sources vs1
-            ON vs1.film_id = f.id AND vs1.provider_id = 1
+            ON vs1.film_id = f.id AND vs1.provider_id = %(skt)s
          WHERE NOT EXISTS (
               SELECT 1 FROM video_sources vs2
-               WHERE vs2.film_id = f.id AND vs2.provider_id = 2
+               WHERE vs2.film_id = f.id AND vs2.provider_id = %(prh)s
          )
          {where_extra}
          ORDER BY f.id DESC
     """
+    params = {"skt": providers["sktorrent"], "prh": providers["prehrajto"]}
     if limit:
-        sql += " LIMIT %s"
-        cur.execute(sql, (limit,))
-    else:
-        cur.execute(sql)
+        sql += " LIMIT %(limit)s"
+        params["limit"] = limit
+    cur.execute(sql, params)
     return list(cur.fetchall())
 
 
@@ -112,13 +115,13 @@ def main() -> int:
     conn.autocommit = False
     cur = conn.cursor()
 
-    films = _select_target_films(cur, args.limit, args.daily, args.film_id)
+    providers = get_provider_ids(cur)
+    films = _select_target_films(cur, providers, args.limit, args.daily, args.film_id)
     log.info("selected %d films (limit=%s daily=%s film_id=%s)",
              len(films), args.limit, args.daily, args.film_id)
     if not films:
         return 0
 
-    providers = get_provider_ids(cur)
     sess = requests.Session()
 
     counters = {
@@ -172,11 +175,11 @@ def main() -> int:
                 counters["rows_written"] += result["written"]
                 counters["rows_repointed"] += result["repointed"]
                 log.info("[%d/%d] film_id=%d %r — %d hits → %s "
-                         "(written=%d repointed=%d collisions=%d)",
+                         "(written=%d repointed=%d refreshed=%d collisions=%d)",
                          i, len(films), film_id, result["query"],
                          result["hits"], tier_summary,
                          result["written"], result["repointed"],
-                         result["collisions"])
+                         result.get("refreshed", 0), result["collisions"])
 
             if not args.dry_run and i % args.commit_every == 0:
                 conn.commit()


### PR DESCRIPTION
<!-- claude-session: 98d65447-0cc0-4c98-a612-a9b5c0699023 -->

## Summary

- Daily auto-import now searches prehraj.to and attaches matching uploads to every new (or updated) SK Torrent film, in the same transaction. Closes the chronic gap where the prehraj.to sitemap importer never noticed films we added from sktorrent first.
- Reusable single-film helper `scripts/auto_import/prehrajto_search.py` shared between the auto-import hook and the existing batch backfill script.
- Admin views `/admin/import/` and `/admin/import/{N}` get a new \"prehraj.to\" column: per-film status (`✓ nalezeno` / `0 výsledků` / `nezpůsobilé` / `⚠ chyba` / `⚠ blocked`), plus a 🔍 link to the search the script ran for hand-verification. Run summary shows hledáno/navázáno/+rows counters.
- Two robustness fixes promoted from live debugging: `_ascii_fold` folds `. - _ :` to spaces (so `Megalodon.The.Frenzy.2023.1080p` matches `Megalodon: The Frenzy`); `_build_query` strips `/?#&%` (so `9 a 1/2 týdne II (1997)` doesn't 404).
- Schema: migration 067 adds `import_items.prehrajto_status` + `prehrajto_rows_written`, plus three counters on `import_runs`. Default 0, historic runs render unchanged.

## Test plan

- [x] `cargo check -p cr-web` clean
- [x] `cargo clippy -p cr-web -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Migration 067 applied to dev + prod, web container restarts cleanly (`Database migrations applied`)
- [x] Manual production run of the new `try_prehrajto_match` against three sktorrent films (Alberto Tomba, Adriano Olivetti, 22 andělů) — handler returned the expected hit/tier breakdowns
- [x] Backfill loop on the 18 missing-prehrajto films from run #55: 12 newly attached (Megalodon, Žár těla, Důvěrný informátor, 9 a 1/2 týdne II, …); one re-point exercised (Žár těla 1981 → film 35068, away from owner 33436 with year 1992)
- [x] `/admin/import/55` rendered via Playwright on production: prehraj.to column header + per-row 🔍 links visible, run-summary counters present (showing 0/0/0 for run #55, which predates the integration), no console errors
- [x] `/admin/import/` list view shows new compact column `M/N +K`
- [ ] First post-merge cron run (~tomorrow 05:00 UTC) populates the new counters with non-zero values