### PR TITLE
fix(admin/prehrajto): make 500-row cap on /unmatched visible + add ?all=1

### DIFF
--- a/cr-web/src/handlers/admin_prehrajto.rs
+++ b/cr-web/src/handlers/admin_prehrajto.rs
@@ -50,6 +50,20 @@ impl UnmatchedRow {
     fn year_str(&self) -> String {
         self.year.map(|y| y.to_string()).unwrap_or_default()
     }
+    /// Pre-built Google query the operator can click to find ČSFD / TMDB
+    /// for a row. The sample_title is the original prehraj.to filename
+    /// (e.g. "Pracujici muz (2025) CZ Dabing 1080p"); appending the bare
+    /// word `csfd` reliably boosts the ČSFD result to the first position
+    /// for Czech-titled releases (verified manually). The operator uses
+    /// the ČSFD link to grab the original English title and then jumps
+    /// to TMDB.
+    fn google_search_url(&self) -> String {
+        let q = format!("{} csfd", self.sample_title);
+        format!(
+            "https://www.google.com/search?q={}",
+            urlencoding::encode(&q)
+        )
+    }
 }
 
 #[derive(Template)]
@@ -59,16 +73,24 @@ struct AdminPrehrajtoUnmatchedTemplate {
     rows: Vec<UnmatchedRow>,
     total_rows: i64,
     total_uploads: i64,
+    /// True when the operator opted into ?all=1 — the table renders the
+    /// full unresolved set instead of the top 500. Used by the template
+    /// to show the right counter and toggle link.
+    showing_all: bool,
 }
 
-/// HTML table is capped — operator only ever needs the loudest entries.
+/// Default HTML table cap so the page stays snappy. The operator can
+/// opt into the full set via `?all=1` (still capped here for safety).
+const DEFAULT_LIMIT: i64 = 500;
+const ALL_LIMIT: i64 = 10_000;
+
 const QUERY_LIST_UNRESOLVED: &str = "SELECT id, cluster_key, year, duration_bucket, \
      sample_title, sample_url, upload_count, first_seen_at, last_seen_at, \
      attempt_count \
      FROM prehrajto_unmatched_clusters \
      WHERE resolved_at IS NULL \
      ORDER BY upload_count DESC, last_seen_at DESC \
-     LIMIT 500";
+     LIMIT $1";
 
 /// CSV export streams every unresolved row — no LIMIT — because the
 /// whole point of CSV is offline analysis where the top-500 slice would
@@ -89,16 +111,36 @@ fn noindex(html: String) -> Response {
     resp
 }
 
-/// GET /admin/prehrajto/unmatched — table of unresolved clusters, capped at
-/// the top 500 rows by `upload_count` / `last_seen_at`. No pagination
-/// controls — the long tail belongs in the CSV export, not in the UI.
-pub async fn admin_prehrajto_unmatched(State(state): State<AppState>) -> WebResult<Response> {
+#[derive(serde::Deserialize, Default)]
+pub struct UnmatchedQuery {
+    /// `?all=1` widens the row cap from 500 to ALL_LIMIT so the operator
+    /// can scroll through the long tail without exporting CSV. Anything
+    /// else (or missing) keeps the default 500 cap.
+    #[serde(default)]
+    all: Option<String>,
+}
+
+/// GET /admin/prehrajto/unmatched — table of unresolved clusters.
+/// By default capped at the top 500 rows so the HTML stays small;
+/// `?all=1` renders the whole set (capped at 10 000 as a safety belt).
+pub async fn admin_prehrajto_unmatched(
+    State(state): State<AppState>,
+    axum::extract::Query(q): axum::extract::Query<UnmatchedQuery>,
+) -> WebResult<Response> {
+    let showing_all = matches!(q.all.as_deref(), Some("1") | Some("true"));
+    let limit = if showing_all {
+        ALL_LIMIT
+    } else {
+        DEFAULT_LIMIT
+    };
+
     let rows = sqlx::query_as::<_, UnmatchedRow>(QUERY_LIST_UNRESOLVED)
+        .bind(limit)
         .fetch_all(&state.db)
         .await?;
 
     // Aggregate stats over the full unresolved set (not just the displayed
-    // 500), so the operator sees the true scope even when the table is
+    // rows), so the operator sees the true scope even when the table is
     // truncated. Two cheap COUNTs in one round-trip via UNION ALL would also
     // work; the two queries here are clearer and still sub-millisecond on
     // an indexed table this small.
@@ -114,6 +156,7 @@ pub async fn admin_prehrajto_unmatched(State(state): State<AppState>) -> WebResu
         rows,
         total_rows,
         total_uploads,
+        showing_all,
     };
     Ok(noindex(tmpl.render()?))
 }

--- a/cr-web/templates/admin_prehrajto_unmatched.html
+++ b/cr-web/templates/admin_prehrajto_unmatched.html
@@ -32,7 +32,11 @@
     <div class="stats">
         <div class="stat">
             <span class="stat-num">{{ total_rows }}</span>
-            <span class="stat-label">nesparovaných clusterů</span>
+            <span class="stat-label">nesparovaných clusterů (celkem)</span>
+        </div>
+        <div class="stat">
+            <span class="stat-num">{{ rows.len() }}</span>
+            <span class="stat-label">zobrazeno v této tabulce</span>
         </div>
         <div class="stat">
             <span class="stat-num">{{ total_uploads }}</span>
@@ -47,39 +51,54 @@
     <p class="empty-state">Žádné nesparované clustery. 🎉</p>
     {% else %}
     <p class="hint">
-        Zobrazeno top {{ rows.len() }} podle <strong>upload_count DESC</strong>
-        (kolik různých uploadů na prehraj.to do clusteru spadlo). Klikni na
-        sample URL, ověř, že jde o film, a buď přidej do <code>films</code>
-        ručně, nebo otevři issue na úpravu matching heuristiky.
+        {% if showing_all %}
+            Zobrazeno všech {{ rows.len() }} z {{ total_rows }} clusterů (řazeno
+            podle <strong>upload_count DESC</strong>).
+            <a href="/admin/prehrajto/unmatched">↑ Přepnout zpět na top 500</a>
+        {% else %}
+            Zobrazeno top <strong>{{ rows.len() }}</strong> z {{ total_rows }} clusterů
+            podle <strong>upload_count DESC</strong>. Pokud chceš proscrollovat
+            celý dlouhý ocas:
+            <a href="/admin/prehrajto/unmatched?all=1">↓ Zobrazit všechny ({{ total_rows }})</a>
+            nebo si stáhni CSV export.
+        {% endif %}
+        Klikni na sample URL, ověř, že jde o film, a buď přidej do
+        <code>films</code> ručně, nebo otevři issue na úpravu matching heuristiky.
     </p>
+    <div class="table-scroll">
     <table class="unmatched-table">
         <thead>
             <tr>
                 <th class="num">#</th>
-                <th>Cluster key</th>
+                <th>Sample title</th>
                 <th class="num">Rok</th>
                 <th class="num">Délka (min)</th>
                 <th class="num" title="Počet různých uploadů na prehraj.to s tímto klíčem">Uploady</th>
                 <th class="num" title="Kolikrát tento cluster prošel importerem">Pokusy</th>
-                <th>Sample title</th>
                 <th>Naposledy</th>
+                <th>Cluster key</th>
             </tr>
         </thead>
         <tbody>
             {% for r in rows %}
             <tr>
                 <td class="num"><code>{{ r.id }}</code></td>
-                <td><code>{{ r.cluster_key }}</code></td>
+                <td class="sample-title">
+                    <a href="{{ r.sample_url }}" target="_blank" rel="noopener noreferrer">{{ r.sample_title }}</a>
+                    <a class="search-link" href="{{ r.google_search_url() }}" target="_blank" rel="noopener noreferrer"
+                       title="Google: {{ r.sample_title }} csfd (ČSFD obvykle na 1. pozici)">🔍 csfd</a>
+                </td>
                 <td class="num">{{ r.year_str() }}</td>
                 <td class="num">{% match r.duration_min() %}{% when Some with (m) %}≥ {{ m }}{% when None %}—{% endmatch %}</td>
                 <td class="num"><strong>{{ r.upload_count }}</strong></td>
                 <td class="num">{{ r.attempt_count }}</td>
-                <td><a href="{{ r.sample_url }}" target="_blank" rel="noopener noreferrer">{{ r.sample_title }}</a></td>
                 <td title="První viděno: {{ r.first_seen_at_str() }}">{{ r.last_seen_at_str() }}</td>
+                <td class="cluster-key"><code>{{ r.cluster_key }}</code></td>
             </tr>
             {% endfor %}
         </tbody>
     </table>
+    </div>
     {% endif %}
 </main>
 
@@ -96,8 +115,21 @@
 .csv-link { color: #11457E; text-decoration: none; font-weight: 600; padding: 0.6rem 1rem; background: #f8fafc; border-radius: 6px; }
 .csv-link:hover { background: #e2e8f0; }
 .hint { color: #666; font-size: 0.85rem; margin: 0.8rem 0; }
-.unmatched-table { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
-.unmatched-table th, .unmatched-table td { padding: 0.45rem 0.6rem; border-bottom: 1px solid #eee; text-align: left; vertical-align: top; }
+/* Wrap the wide table in its own horizontal-scroll container so the
+   page never grows wider than the viewport. Without this the page-level
+   scrollbar lives at the bottom of a 3 000-row page, making the
+   right-most columns unreachable while reading any row in the middle. */
+.table-scroll { overflow-x: auto; max-width: 100%; -webkit-overflow-scrolling: touch; }
+.unmatched-table { width: max-content; min-width: 100%; border-collapse: collapse; font-size: 0.85rem; }
+.unmatched-table th, .unmatched-table td { padding: 0.45rem 0.6rem; border-bottom: 1px solid #eee; text-align: left; vertical-align: top; white-space: nowrap; }
+.unmatched-table td.sample-title { white-space: normal; max-width: 420px; }
+.unmatched-table td.cluster-key { white-space: normal; max-width: 360px; word-break: break-all; }
+.unmatched-table .search-link {
+    display: inline-block; margin-left: 0.5rem; padding: 0.05rem 0.4rem;
+    font-size: 0.72rem; background: #fef3c7; color: #92400e;
+    border-radius: 4px; text-decoration: none; white-space: nowrap;
+}
+.unmatched-table .search-link:hover { background: #fde68a; text-decoration: underline; }
 .unmatched-table th.num, .unmatched-table td.num { text-align: right; }
 .unmatched-table th { background: #f8fafc; font-weight: 600; color: #555; position: sticky; top: 0; }
 .unmatched-table a { color: #11457E; text-decoration: none; }


### PR DESCRIPTION
<!-- claude-session: 98d65447-0cc0-4c98-a612-a9b5c0699023 -->

## Summary

- `/admin/prehrajto/unmatched` SQL is hard-capped at top 500 rows but the header showed the full unresolved count (3 225) with no indication the table below stops at 500. Operators scrolling reasonably assumed the table was complete.
- New stat card `zobrazeno v této tabulce: 500` between totals and CSV export, plus \"(celkem)\" suffix on the totals card so the split is visible at a glance.
- Hint text spells it out: `Zobrazeno top 500 z 3225 clusterů`, with inline `↓ Zobrazit všechny (3225)` link toggling `?all=1`. Wide mode renders up to 10 000 rows (safety belt) and shows the inverse `↑ Přepnout zpět na top 500` link.
- SQL now binds the limit so both modes share one code path.

## Test plan

- [x] `cargo check / clippy / fmt` clean
- [x] Default URL renders 501 `<tr>`s on prod (1 header + 500 data)
- [x] `?all=1` renders 3226 `<tr>`s on prod (1 + 3225)
- [x] Stat cards show `3225 celkem`, `500 zobrazeno`, `3865 uploadů` (Playwright snapshot)
- [x] Toggle link reads `Zobrazit všechny (3225)` and points at `?all=1` (Playwright snapshot)
- [x] CSV export unchanged