### PR TITLE
fix(auto-import): enforce one film per TMDB id, merge 8 historical duplicates

### DIFF
--- a/cr-infra/migrations/20260509_067a_films_sktorrent_columns.sql
+++ b/cr-infra/migrations/20260509_067a_films_sktorrent_columns.sql
@@ -1,0 +1,27 @@
+-- Backfill film-level SK Torrent columns that exist in production but were
+-- never explicitly added to the `films` table by an in-repo migration.
+--
+-- History: migration 026 (`add_sktorrent_columns`) used `ALTER TABLE IF
+-- EXISTS movies / IF EXISTS films` to add `sktorrent_video_id` and
+-- `sktorrent_cdn`. On the original prod DB those ALTERs landed on the
+-- legacy `movies` table and survived the rename to `films`. On a fresh CI
+-- DB neither table exists at that point, so both ALTERs are no-ops, the
+-- subsequent `CREATE TABLE films` in migration 028 creates the table
+-- without any sktorrent columns, and nothing in the migration history
+-- adds them back. Prod and CI schemas have silently diverged ever since
+-- (`has_dub`, `has_subtitles`, `sktorrent_qualities` followed the same
+-- path via undocumented manual ALTERs on prod).
+--
+-- Migration 068 below is the first migration that actually references
+-- these columns at parse time (in the `_films_merge_map` snapshot CTE),
+-- which surfaces the drift as a CI failure. This migration squashes the
+-- gap: every column is `ADD COLUMN IF NOT EXISTS`, so prod is a strict
+-- no-op while CI gets the missing columns before 068 runs.
+ALTER TABLE films
+    ADD COLUMN IF NOT EXISTS sktorrent_video_id  INTEGER,
+    ADD COLUMN IF NOT EXISTS sktorrent_cdn       SMALLINT,
+    ADD COLUMN IF NOT EXISTS sktorrent_qualities VARCHAR(50),
+    ADD COLUMN IF NOT EXISTS has_dub             BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS has_subtitles       BOOLEAN NOT NULL DEFAULT false;
+
+CREATE INDEX IF NOT EXISTS idx_films_sktorrent_video_id ON films (sktorrent_video_id);

--- a/cr-infra/migrations/20260510_068_films_tmdb_unique.sql
+++ b/cr-infra/migrations/20260510_068_films_tmdb_unique.sql
@@ -1,0 +1,134 @@
+-- Enforce one film row per TMDB id and clean up the 8 historical duplicates
+-- that the SK Torrent auto-import produced.
+--
+-- Background: `upsert_film` (auto-import) used to look the existing film up
+-- by `imdb_id` only. Films imported from earlier sources (e.g. legacy
+-- prehrajto-only flow) had `imdb_id = NULL` even though they had `tmdb_id`
+-- set, so the SKT pass treated them as new and inserted a second row. The
+-- newer prehrajto auto-match then picked the older row (where the uploads
+-- already lived) and skipped the new one as `no_acceptable`, leaving the
+-- film visible twice in the catalogue with the sources split between the
+-- two rows. See production audit: 8 pairs sharing tmdb_id, in every pair
+-- the older row carries the prehrajto sources and the newer row carries
+-- the SKT video — exact pattern this migration consolidates.
+--
+-- Plan:
+--   1) Snapshot the duplicates (and the values we need to backfill onto
+--      the canonical row) into a temp table. Lowest id per tmdb_id wins.
+--   2) Re-point every FK on the duplicate rows to the canonical row.
+--   3) Delete the duplicate film rows. Doing this BEFORE the backfill is
+--      important: there is already a UNIQUE index on `films.imdb_id`, and
+--      the duplicate row carries the imdb_id we want to copy onto the
+--      canonical — so the canonical UPDATE would otherwise hit a unique
+--      violation while both rows still exist with the same imdb_id.
+--   4) Backfill canonical from the snapshot (only fills NULL fields, so
+--      we never overwrite curated values).
+--   5) Add the partial UNIQUE index on `films(tmdb_id) WHERE tmdb_id IS
+--      NOT NULL` so future INSERT paths cannot regress.
+--
+-- The merge logic is generic — it works on any duplicates, not just the
+-- 8 known cases — so re-running on a fresh DB is a no-op.
+
+-- 1) Snapshot duplicates + the per-row values needed for backfill.
+CREATE TEMPORARY TABLE _films_merge_map AS
+SELECT
+    f.id AS dup_id,
+    c.keep_id,
+    f.imdb_id,
+    f.sktorrent_video_id,
+    f.sktorrent_cdn,
+    f.sktorrent_qualities,
+    f.sktorrent_added_at,
+    f.has_dub,
+    f.has_subtitles,
+    f.imdb_rating,
+    f.csfd_rating,
+    f.tmdb_poster_path
+FROM films f
+JOIN (
+    SELECT tmdb_id, MIN(id) AS keep_id
+    FROM films
+    WHERE tmdb_id IS NOT NULL
+    GROUP BY tmdb_id
+    HAVING COUNT(*) > 1
+) c USING (tmdb_id)
+WHERE f.id <> c.keep_id;
+
+-- 2) Re-point FK references from duplicate rows to the canonical row.
+--    `video_sources`, `film_prehrajto_uploads`, `film_sledujteto_uploads`
+--    have unique constraints on (provider_id, external_id) / upload_id /
+--    file_id respectively, so a given upload can only live on one film at
+--    a time across the whole table — no collisions are possible when
+--    moving rows between two films that share a tmdb_id.
+UPDATE video_sources vs
+   SET film_id = m.keep_id
+  FROM _films_merge_map m
+ WHERE vs.film_id = m.dup_id;
+
+UPDATE film_prehrajto_uploads fpu
+   SET film_id = m.keep_id
+  FROM _films_merge_map m
+ WHERE fpu.film_id = m.dup_id;
+
+UPDATE film_sledujteto_uploads fsu
+   SET film_id = m.keep_id
+  FROM _films_merge_map m
+ WHERE fsu.film_id = m.dup_id;
+
+UPDATE film_sources fs
+   SET film_id = m.keep_id
+  FROM _films_merge_map m
+ WHERE fs.film_id = m.dup_id;
+
+UPDATE prehrajto_unmatched_clusters puc
+   SET resolved_film_id = m.keep_id
+  FROM _films_merge_map m
+ WHERE puc.resolved_film_id = m.dup_id;
+
+-- film_genres has composite PK (film_id, genre_id) so the duplicate row may
+-- already share a (film_id, genre_id) row with the canonical (auto-import
+-- inherits the same TMDB genres on insert). Insert the missing ones, then
+-- delete the originals.
+INSERT INTO film_genres (film_id, genre_id)
+SELECT m.keep_id, fg.genre_id
+  FROM film_genres fg
+  JOIN _films_merge_map m ON m.dup_id = fg.film_id
+ON CONFLICT (film_id, genre_id) DO NOTHING;
+
+DELETE FROM film_genres fg
+ USING _films_merge_map m
+ WHERE fg.film_id = m.dup_id;
+
+-- 3) Drop the duplicate film rows now that nothing references them. This
+--    must precede the canonical backfill so the UNIQUE(imdb_id) index
+--    isn't violated mid-transaction (the dup carries the imdb_id we're
+--    about to copy onto the canonical).
+DELETE FROM films f
+ USING _films_merge_map m
+ WHERE f.id = m.dup_id;
+
+-- 4) Backfill the canonical row from the snapshot. COALESCE so we only
+--    fill columns the canonical lacks — a manually-curated rating or a
+--    different SKT id on the canonical wins over the duplicate's value.
+UPDATE films keep
+   SET imdb_id              = COALESCE(keep.imdb_id, m.imdb_id),
+       sktorrent_video_id   = COALESCE(keep.sktorrent_video_id, m.sktorrent_video_id),
+       sktorrent_cdn        = COALESCE(keep.sktorrent_cdn, m.sktorrent_cdn),
+       sktorrent_qualities  = COALESCE(keep.sktorrent_qualities, m.sktorrent_qualities),
+       sktorrent_added_at   = COALESCE(keep.sktorrent_added_at, m.sktorrent_added_at),
+       has_dub              = keep.has_dub OR m.has_dub,
+       has_subtitles        = keep.has_subtitles OR m.has_subtitles,
+       imdb_rating          = COALESCE(keep.imdb_rating, m.imdb_rating),
+       csfd_rating          = COALESCE(keep.csfd_rating, m.csfd_rating),
+       tmdb_poster_path     = COALESCE(keep.tmdb_poster_path, m.tmdb_poster_path)
+  FROM _films_merge_map m
+ WHERE keep.id = m.keep_id;
+
+DROP TABLE _films_merge_map;
+
+-- 5) Future-proof: prevent a second row per TMDB id. Partial because some
+--    legacy / manual films legitimately lack a tmdb_id and we don't want
+--    to merge those (no shared identifier).
+CREATE UNIQUE INDEX IF NOT EXISTS films_tmdb_id_unique
+    ON films (tmdb_id)
+    WHERE tmdb_id IS NOT NULL;

--- a/cr-infra/migrations/20260608_068_films_tmdb_unique.sql
+++ b/cr-infra/migrations/20260608_068_films_tmdb_unique.sql
@@ -75,10 +75,21 @@ UPDATE film_sledujteto_uploads fsu
   FROM _films_merge_map m
  WHERE fsu.film_id = m.dup_id;
 
-UPDATE film_sources fs
-   SET film_id = m.keep_id
-  FROM _films_merge_map m
- WHERE fs.film_id = m.dup_id;
+-- `film_sources` is a legacy table that exists in production (~70k rows
+-- referencing `films`) but was never created by an in-repo migration —
+-- another piece of pre-068 schema drift, same family as the films
+-- sktorrent columns 067a backfills. Guard the UPDATE with `to_regclass`
+-- so a fresh CI database (no `film_sources` table) treats it as a no-op
+-- while prod still re-points the rows.
+DO $$
+BEGIN
+    IF to_regclass('public.film_sources') IS NOT NULL THEN
+        UPDATE film_sources fs
+           SET film_id = m.keep_id
+          FROM _films_merge_map m
+         WHERE fs.film_id = m.dup_id;
+    END IF;
+END $$;
 
 UPDATE prehrajto_unmatched_clusters puc
    SET resolved_film_id = m.keep_id

--- a/cr-infra/migrations/20260608_068_films_tmdb_unique.sql
+++ b/cr-infra/migrations/20260608_068_films_tmdb_unique.sql
@@ -128,7 +128,12 @@ DROP TABLE _films_merge_map;
 
 -- 5) Future-proof: prevent a second row per TMDB id. Partial because some
 --    legacy / manual films legitimately lack a tmdb_id and we don't want
---    to merge those (no shared identifier).
+--    to merge those (no shared identifier). Same upgrade pattern as
+--    migration 050 used for `imdb_id`: create the new UNIQUE index first,
+--    then drop the old non-unique one (`idx_films_tmdb_id` from migration
+--    028) so query plans don't regress if the CREATE blew up.
 CREATE UNIQUE INDEX IF NOT EXISTS films_tmdb_id_unique
     ON films (tmdb_id)
     WHERE tmdb_id IS NOT NULL;
+
+DROP INDEX IF EXISTS idx_films_tmdb_id;

--- a/scripts/auto_import/enricher.py
+++ b/scripts/auto_import/enricher.py
@@ -130,13 +130,23 @@ def upsert_film(
         csfd_rating = None
 
     # --- Path A: film already in DB? ---
+    # Look up by imdb_id first (most reliable) and fall back to tmdb_id —
+    # legacy films imported before the IMDb linkage existed have only
+    # tmdb_id set, so the imdb_id-only lookup used to miss them and create
+    # a duplicate row. The DB now enforces a partial UNIQUE on tmdb_id, so
+    # the duplicate INSERT below would crash; we resolve it here by
+    # treating the legacy row as the canonical match and backfilling its
+    # imdb_id from this run's TMDB resolution.
     cur.execute(
-        "SELECT id, sktorrent_video_id FROM films WHERE imdb_id = %s",
-        (movie.imdb_id,),
+        "SELECT id, sktorrent_video_id, imdb_id FROM films "
+        "WHERE imdb_id = %s OR tmdb_id = %s "
+        "ORDER BY (imdb_id IS NOT NULL) DESC, id "
+        "LIMIT 1",
+        (movie.imdb_id, movie.tmdb_id),
     )
     row = cur.fetchone()
     if row is not None:
-        film_id, existing_skt = row
+        film_id, existing_skt, existing_imdb = row
         if existing_skt is not None:
             log.info("film %d (imdb=%s) already has SKT %d — skipping",
                      film_id, movie.imdb_id, existing_skt)
@@ -145,12 +155,14 @@ def upsert_film(
         # reflects any previously linked source (e.g. Bombuj) and we only want
         # to OR-in the new signal from SK Torrent, not downgrade to False.
         # Backfill ratings via COALESCE — only fill if DB value is NULL, so
-        # manually-curated numbers are never overwritten.
+        # manually-curated numbers are never overwritten. Same idea for
+        # imdb_id: only fill it if missing.
         cur.execute(
             "UPDATE films SET sktorrent_video_id = %s, sktorrent_cdn = %s, "
             "sktorrent_qualities = %s, "
             "has_dub = has_dub OR %s, "
             "has_subtitles = has_subtitles OR %s, "
+            "imdb_id = COALESCE(imdb_id, %s), "
             "imdb_rating = COALESCE(imdb_rating, %s), "
             "csfd_rating = COALESCE(csfd_rating, %s), "
             "tmdb_poster_path = COALESCE(tmdb_poster_path, %s), "
@@ -158,6 +170,7 @@ def upsert_film(
             "WHERE id = %s",
             (sktorrent_video_id, sktorrent_cdn, qualities_str,
              has_dub, has_subtitles,
+             movie.imdb_id,
              movie.vote_average, csfd_rating,
              movie.poster_path,
              film_id),

--- a/scripts/auto_import/enricher.py
+++ b/scripts/auto_import/enricher.py
@@ -138,7 +138,7 @@ def upsert_film(
     # treating the legacy row as the canonical match and backfilling its
     # imdb_id from this run's TMDB resolution.
     cur.execute(
-        "SELECT id, sktorrent_video_id, imdb_id FROM films "
+        "SELECT id, sktorrent_video_id FROM films "
         "WHERE imdb_id = %s OR tmdb_id = %s "
         "ORDER BY (imdb_id IS NOT NULL) DESC, id "
         "LIMIT 1",
@@ -146,7 +146,7 @@ def upsert_film(
     )
     row = cur.fetchone()
     if row is not None:
-        film_id, existing_skt, existing_imdb = row
+        film_id, existing_skt = row
         if existing_skt is not None:
             log.info("film %d (imdb=%s) already has SKT %d — skipping",
                      film_id, movie.imdb_id, existing_skt)


### PR DESCRIPTION
<!-- claude-session: b54cb8cf-7fda-4006-b684-9957e548cbe8 -->

## Background

User reported that today's auto-import (run #61) marked the prehraj.to results for "Vládkyně Ayesha / She (1965)" as `nezpůsobilé` even though the search returned 6 strong matches with the right title, year and runtime. Two films from the same run had the same problem (Ayesha + Útěk na čarodějnou horu).

## Root cause

`scripts/auto_import/enricher.py:upsert_film` looked existing films up only by `imdb_id`. The corresponding films were already in the catalogue from the legacy prehrajto-only import flow with `imdb_id = NULL` and only `tmdb_id` populated — so the `imdb_id`-only lookup missed them and the SKT pass inserted a second row. The newer prehrajto matcher then found uploads already attached to the OLDER row (whose year + runtime matched), `_is_existing_owner_worse_match` correctly refused to re-point them onto the new row, and the new row surfaced as `no_acceptable`.

Production audit found 8 duplicate pairs sharing this exact pattern (older row `imdb_id NULL`, newer row `imdb_id` set, both same `tmdb_id`).

## Changes

- **Migration `20260510_068_films_tmdb_unique.sql`**:
  - For every `tmdb_id` group with >1 row, lowest id wins. FKs from `video_sources`, `film_prehrajto_uploads`, `film_sledujteto_uploads`, `film_sources`, `film_genres`, `prehrajto_unmatched_clusters` are re-pointed to the canonical id.
  - Canonical row's `imdb_id` / sktorrent metadata / ratings / poster path / has_dub / has_subtitles backfilled from the duplicate via COALESCE / OR (curated values on canonical never overwritten).
  - Duplicate rows DELETEd before the canonical UPDATE so the existing UNIQUE on `films.imdb_id` doesn't conflict mid-transaction.
  - Adds partial UNIQUE index `films_tmdb_id_unique ON films(tmdb_id) WHERE tmdb_id IS NOT NULL` so future inserts cannot regress.

- **`scripts/auto_import/enricher.py`**: `upsert_film` now does `WHERE imdb_id = %s OR tmdb_id = %s ORDER BY (imdb_id IS NOT NULL) DESC, id LIMIT 1` and backfills `imdb_id` via COALESCE on UPDATE — so legacy rows get enriched on the next SKT pass instead of triggering a duplicate INSERT.

## Test plan

- [x] `cargo check`, `cargo zigbuild --release` — green
- [x] Migration applied on prod (run inside the binary's startup sqlx migrator)
- [x] `SELECT COUNT(*) FROM (SELECT tmdb_id FROM films WHERE tmdb_id IS NOT NULL GROUP BY tmdb_id HAVING COUNT(*)>1) x` → `0` after migration (was `8`)
- [x] `films.films_tmdb_id_unique` index present on prod
- [x] Playwright check at https://ceskarepublika.wiki/filmy-online/vladkyne-ayesha/ — page renders, SK Torrent + Přehraj.to source tabs both visible, all 6 prehraj.to uploads listed (CZ Dabing variants + CZsub/CZtit), 0 console errors
- [x] Health check 200 after restart