### PR TITLE
fix(auto-import): switch Gemma to working model + backfill 37 raw-EN films

### DIFF
--- a/scripts/auto_import/gemma_writer.py
+++ b/scripts/auto_import/gemma_writer.py
@@ -18,10 +18,22 @@ import time
 
 import requests
 
-MODEL = "gemma-3-27b-it"
-URL_TPL = f"https://generativelanguage.googleapis.com/v1beta/models/{MODEL}:generateContent?key={{}}"
+URL_TPL = ("https://generativelanguage.googleapis.com/v1beta/models/"
+           "{model}:generateContent?key={key}")
 DEFAULT_TIMEOUT = 120
 RATE_LIMIT_PAUSE = 60
+
+# Try models in this order. Google's `gemma-4-31b-it` started returning
+# HTTP 500 INTERNAL on every prompt around 2026-05-10 (verified independently
+# with all four production keys + a one-word "Řekni ahoj" payload). The
+# 26B-A4B variant works fine and produces equivalent quality CS output, so
+# it's now primary; we keep 31B in the fallback chain so the moment Google
+# fixes the outage we transparently regain access to it (and so a future
+# regression in 26B doesn't kill the import path either). The auto-import
+# silently fell back to raw TMDB EN overview for every single film during
+# the outage — that's the bug this list prevents.
+MODELS = ["gemma-4-26b-a4b-it", "gemma-4-31b-it"]
+MODEL = MODELS[0]  # backwards-compat for callers that import the symbol
 
 log = logging.getLogger(__name__)
 
@@ -68,23 +80,28 @@ def _build_prompt_series(title: str, year: int | None, sources: list[tuple[str, 
     return "\n".join(parts)
 
 
-def _call(prompt: str, key: str, timeout: int = DEFAULT_TIMEOUT) -> str | None:
+def _call(prompt: str, key: str, timeout: int = DEFAULT_TIMEOUT,
+          model: str = MODEL) -> str | None:
     """Single Gemini call. Returns generated text or None on safety-filter / error."""
     payload = {
         "contents": [{"role": "user", "parts": [{"text": prompt}]}],
-        "generationConfig": {"temperature": 0.7, "maxOutputTokens": 1000},
+        # Gemma 4 emits hidden reasoning tokens before the answer, eating
+        # the output budget. Bump high enough that the answer survives.
+        "generationConfig": {"temperature": 0.7, "maxOutputTokens": 3000},
     }
     try:
-        r = requests.post(URL_TPL.format(key), json=payload, timeout=timeout)
+        r = requests.post(
+            URL_TPL.format(model=model, key=key), json=payload, timeout=timeout
+        )
     except requests.RequestException as e:
-        log.warning("Gemini call failed: %s", e)
+        log.warning("Gemini call failed (%s): %s", model, e)
         return None
     if r.status_code == 429:
-        log.warning("Gemini rate-limited; sleeping %ds", RATE_LIMIT_PAUSE)
+        log.warning("Gemini rate-limited (%s); sleeping %ds", model, RATE_LIMIT_PAUSE)
         time.sleep(RATE_LIMIT_PAUSE)
         return None
     if r.status_code != 200:
-        log.warning("Gemini HTTP %d: %s", r.status_code, r.text[:200])
+        log.warning("Gemini HTTP %d (%s): %s", r.status_code, model, r.text[:200])
         return None
     try:
         data = r.json()
@@ -98,7 +115,14 @@ def _call(prompt: str, key: str, timeout: int = DEFAULT_TIMEOUT) -> str | None:
     parts = cands[0].get("content", {}).get("parts") or []
     if not parts:
         return None
-    text = (parts[0].get("text") or "").strip()
+    # Gemma 4 returns reasoning in parts[*] with "thought": true and the
+    # actual answer in a separate part without that flag. Skip thought
+    # parts and join the rest. Older Gemma 3 models don't set the flag,
+    # so this still works for them.
+    answer_parts = [p.get("text", "") for p in parts if not p.get("thought")]
+    text = "\n".join(t for t in answer_parts if t).strip()
+    if not text:
+        text = (parts[-1].get("text") or "").strip()
     if text.startswith('"') and text.endswith('"'):
         text = text[1:-1]
     return text or None
@@ -131,7 +155,14 @@ def generate_unique_cs(
         return None
     builder = _build_prompt_series if is_series else _build_prompt_film
     prompt = builder(title, year, sources)
-    return _call(prompt, keys[0])
+    # Try each model in MODELS until one returns text. A 5xx or empty
+    # response on the primary used to silently fall back to raw TMDB EN
+    # — now we transparently retry with the next model first.
+    for model in MODELS:
+        text = _call(prompt, keys[0], model=model)
+        if text:
+            return text
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -148,7 +179,8 @@ build_prompt_series = _build_prompt_series
 load_keys = _load_keys
 
 
-def call_gemma(prompt: str, key: str, timeout: int = DEFAULT_TIMEOUT) -> str | None:
+def call_gemma(prompt: str, key: str, timeout: int = DEFAULT_TIMEOUT,
+               model: str | None = None) -> str | None:
     """Single Gemini call with a caller-supplied key.
 
     Returns the generated text, or None on:
@@ -157,5 +189,6 @@ def call_gemma(prompt: str, key: str, timeout: int = DEFAULT_TIMEOUT) -> str | N
       * HTTP != 200
       * network / JSON errors
 
-    The caller decides whether to retry — this function does not loop."""
-    return _call(prompt, key, timeout)
+    The caller decides whether to retry — this function does not loop.
+    `model` defaults to the primary entry of `MODELS`."""
+    return _call(prompt, key, timeout, model=model or MODEL)

--- a/scripts/auto_import/gemma_writer.py
+++ b/scripts/auto_import/gemma_writer.py
@@ -151,7 +151,8 @@ def generate_unique_cs(
         return None
     keys = _load_keys()
     if not keys:
-        log.warning("No GEMINI_API_KEY env var set — Gemma generation disabled")
+        log.warning("No GEMINI_API_KEY (or GEMINI_API_KEY_1..4) env var set "
+                    "— Gemma generation disabled")
         return None
     builder = _build_prompt_series if is_series else _build_prompt_film
     prompt = builder(title, year, sources)

--- a/scripts/backfill-raw-en-descriptions.py
+++ b/scripts/backfill-raw-en-descriptions.py
@@ -43,26 +43,43 @@ log = logging.getLogger("backfill-raw-en")
 
 # Same heuristic the user-facing audit query uses to count "suspect raw EN":
 # short description + no Czech diacritics + has a tmdb_id we can re-query.
-SUSPECT_SQL = """
-    SELECT id, title, year, tmdb_id
-      FROM films
-     WHERE description IS NOT NULL
-       AND LENGTH(description) < 200
-       AND description !~ '[ěščřžýáíéůúóďťň]'
-       AND tmdb_id IS NOT NULL
-"""
+# Use `~*` (case-insensitive) so a description starting with an uppercase
+# diacritic like "Český…" is correctly recognized as Czech text and skipped.
+SUSPECT_FILTER = (
+    "description IS NOT NULL "
+    "AND LENGTH(description) < 200 "
+    "AND description !~* '[ěščřžýáíéůúóďťň]'"
+)
+SUSPECT_SQL = (
+    "SELECT id, title, year, tmdb_id "
+    "FROM films "
+    f"WHERE {SUSPECT_FILTER} "
+    "AND tmdb_id IS NOT NULL"
+)
 
 
 def fetch_overview(http: requests.Session, key: str, tmdb_id: int,
                    lang: str) -> str | None:
-    r = http.get(
-        f"{TMDB_BASE}/movie/{tmdb_id}",
-        params={"api_key": key, "language": lang}, timeout=30,
-    )
+    """Fetch TMDB overview for one (movie, lang). Returns None on any
+    transient failure — caller treats it the same as "TMDB has nothing"
+    so a single bad request can't kill the whole backfill run."""
+    try:
+        r = http.get(
+            f"{TMDB_BASE}/movie/{tmdb_id}",
+            params={"api_key": key, "language": lang}, timeout=30,
+        )
+    except requests.RequestException as e:
+        log.warning("TMDB request failed tmdb=%d lang=%s: %s", tmdb_id, lang, e)
+        return None
     if r.status_code != 200:
         log.warning("TMDB %d for tmdb=%d lang=%s", r.status_code, tmdb_id, lang)
         return None
-    return (r.json().get("overview") or "").strip() or None
+    try:
+        body = r.json()
+    except ValueError as e:
+        log.warning("TMDB JSON decode failed tmdb=%d lang=%s: %s", tmdb_id, lang, e)
+        return None
+    return (body.get("overview") or "").strip() or None
 
 
 def main() -> int:
@@ -81,6 +98,18 @@ def main() -> int:
     tmdb_key = os.environ.get("TMDB_API_KEY", "").strip()
     if not (dsn and tmdb_key):
         log.error("DATABASE_URL and TMDB_API_KEY required")
+        return 2
+
+    # Validate Gemma key presence up front — without a working key every
+    # generate_unique_cs() call returns None and the whole run becomes a
+    # TMDB-pounding no-op. Same key sources `gemma_writer._load_keys` checks.
+    has_gemma_key = (os.environ.get("GEMINI_API_KEY", "").strip() or
+                     any(os.environ.get(f"GEMINI_API_KEY_{i}", "").strip()
+                         for i in range(1, 5)))
+    if not has_gemma_key:
+        log.error("GEMINI_API_KEY (or GEMINI_API_KEY_1..4) required — "
+                  "without it Gemma returns None for every film and the run "
+                  "would issue %d TMDB requests with nothing to update")
         return 2
 
     conn = psycopg2.connect(dsn)
@@ -134,15 +163,12 @@ def main() -> int:
 
         # Only overwrite if the row STILL matches the suspect pattern — guards
         # against an admin who edited the description manually between SELECT
-        # and UPDATE.
+        # and UPDATE. Same `SUSPECT_FILTER` (case-insensitive) the SELECT
+        # uses, so the two stay in sync if the heuristic ever changes.
         try:
             cur.execute(
-                """UPDATE films
-                      SET description = %s
-                    WHERE id = %s
-                      AND description IS NOT NULL
-                      AND LENGTH(description) < 200
-                      AND description !~ '[ěščřžýáíéůúóďťň]'""",
+                "UPDATE films SET description = %s "
+                f"WHERE id = %s AND {SUSPECT_FILTER}",
                 (generated, film_id),
             )
             if cur.rowcount == 0:

--- a/scripts/backfill-raw-en-descriptions.py
+++ b/scripts/backfill-raw-en-descriptions.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Re-generate Czech descriptions for films that ended up with raw English.
+
+The auto-import pipeline silently fell back to TMDB's English overview when
+Gemma 4 returned a 5xx (the `gemma-4-31b-it` model started erroring around
+2026-05-10). The fix in `gemma_writer.py` adds a model fallback chain so
+new imports don't regress, but ~58 historical films are still stuck with
+short English descriptions on a Czech-language site. This one-shot script
+re-runs Gemma for each of them.
+
+Filter: `description IS NOT NULL AND LENGTH(description) < 200 AND
+description !~ '[ěščřžýáíéůúóďťň]'` — short text without any Czech
+diacritic. The combination is a strong signal of "this is raw TMDB EN".
+
+Usage:
+  DATABASE_URL=...  TMDB_API_KEY=...  GEMINI_API_KEY=... \
+      python3 scripts/backfill-raw-en-descriptions.py [--dry-run] [--limit N]
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+
+import psycopg2
+import requests
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.auto_import.gemma_writer import generate_unique_cs  # noqa: E402
+
+TMDB_BASE = "https://api.themoviedb.org/3"
+TMDB_SLEEP = 0.25
+GEMMA_SLEEP = 0.5
+
+log = logging.getLogger("backfill-raw-en")
+
+# Same heuristic the user-facing audit query uses to count "suspect raw EN":
+# short description + no Czech diacritics + has a tmdb_id we can re-query.
+SUSPECT_SQL = """
+    SELECT id, title, year, tmdb_id
+      FROM films
+     WHERE description IS NOT NULL
+       AND LENGTH(description) < 200
+       AND description !~ '[ěščřžýáíéůúóďťň]'
+       AND tmdb_id IS NOT NULL
+"""
+
+
+def fetch_overview(http: requests.Session, key: str, tmdb_id: int,
+                   lang: str) -> str | None:
+    r = http.get(
+        f"{TMDB_BASE}/movie/{tmdb_id}",
+        params={"api_key": key, "language": lang}, timeout=30,
+    )
+    if r.status_code != 200:
+        log.warning("TMDB %d for tmdb=%d lang=%s", r.status_code, tmdb_id, lang)
+        return None
+    return (r.json().get("overview") or "").strip() or None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--limit", type=int)
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("-v", "--verbose", action="store_true")
+    args = ap.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+
+    dsn = os.environ.get("DATABASE_URL", "").strip()
+    tmdb_key = os.environ.get("TMDB_API_KEY", "").strip()
+    if not (dsn and tmdb_key):
+        log.error("DATABASE_URL and TMDB_API_KEY required")
+        return 2
+
+    conn = psycopg2.connect(dsn)
+    cur = conn.cursor()
+    sql = SUSPECT_SQL + " ORDER BY id"
+    if args.limit:
+        sql += f" LIMIT {int(args.limit)}"
+    cur.execute(sql)
+    films = cur.fetchall()
+    log.info("processing %d films", len(films))
+
+    http = requests.Session()
+    http.headers.update({"User-Agent": "ceskarepublika.wiki desc-backfill-raw-en"})
+
+    stats = {"updated_gemma": 0, "no_change": 0,
+             "skipped_no_overview": 0, "failed": 0}
+
+    for i, (film_id, title, year, tmdb_id) in enumerate(films, 1):
+        cs = fetch_overview(http, tmdb_key, tmdb_id, "cs-CZ")
+        time.sleep(TMDB_SLEEP)
+        en = fetch_overview(http, tmdb_key, tmdb_id, "en-US")
+        time.sleep(TMDB_SLEEP)
+
+        if not cs and not en:
+            stats["skipped_no_overview"] += 1
+            log.info("[%d/%d] film_id=%d %r — TMDB has no overview, skipping",
+                     i, len(films), film_id, title)
+            continue
+
+        sources = []
+        if cs: sources.append(("TMDB CS", cs))
+        if en: sources.append(("TMDB EN", en))
+
+        try:
+            generated = generate_unique_cs(title, year, sources, is_series=False)
+        except Exception as e:
+            log.warning("Gemma error film_id=%d: %s", film_id, e)
+            generated = None
+        time.sleep(GEMMA_SLEEP)
+
+        if not generated:
+            stats["failed"] += 1
+            log.info("[%d/%d] film_id=%d %r — Gemma returned None, leaving as-is",
+                     i, len(films), film_id, title)
+            continue
+
+        if args.dry_run:
+            log.info("[%d/%d] DRY film_id=%d %r → %s",
+                     i, len(films), film_id, title, generated[:120])
+            continue
+
+        # Only overwrite if the row STILL matches the suspect pattern — guards
+        # against an admin who edited the description manually between SELECT
+        # and UPDATE.
+        try:
+            cur.execute(
+                """UPDATE films
+                      SET description = %s
+                    WHERE id = %s
+                      AND description IS NOT NULL
+                      AND LENGTH(description) < 200
+                      AND description !~ '[ěščřžýáíéůúóďťň]'""",
+                (generated, film_id),
+            )
+            if cur.rowcount == 0:
+                stats["no_change"] += 1
+                log.info("[%d/%d] film_id=%d — no longer matches filter, skipping",
+                         i, len(films), film_id)
+            else:
+                stats["updated_gemma"] += 1
+                log.info("[%d/%d] film_id=%d %r ← gemma (%d chars)",
+                         i, len(films), film_id, title, len(generated))
+            conn.commit()
+        except Exception as e:
+            log.error("DB error film_id=%d: %s", film_id, e)
+            conn.rollback()
+            stats["failed"] += 1
+
+    log.info("done: %s", stats)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
<!-- claude-session: b54cb8cf-7fda-4006-b684-9957e548cbe8 -->

## Background

User reported https://ceskarepublika.wiki/filmy-online/adventures-in-dinosaur-city/ has only a 103-char raw English description instead of a Gemma-generated Czech one.

## Root cause

`gemma_writer.MODEL` was hardcoded to a single Gemma name. The production cron has been pinned to `gemma-3-27b-it` since April 20 — Google deprecated that name and `:generateContent` now returns HTTP 404. The local working tree had moved on to `gemma-4-31b-it`, but as of today that model returns HTTP 500 INTERNAL on every prompt (verified independently with all 4 production keys + a one-token "Řekni ahoj" payload).

In both cases `generate_unique_cs` returns `None` and the auto-import silently falls back to TMDB's English overview as-is, leaving Czech-language film pages with short, untranslated text.

| Model | HTTP today |
|---|---|
| `gemma-3-27b-it` | 404 (deprecated) |
| `gemma-4-31b-it` | 500 (Google outage) |
| `gemma-4-26b-a4b-it` | 200 ✓ |

## Changes

* `scripts/auto_import/gemma_writer.py` — replace single `MODEL` constant with an ordered `MODELS` list (primary `gemma-4-26b-a4b-it`, fallback `gemma-4-31b-it`). `generate_unique_cs` loops the chain on empty/error responses. `_call` / `call_gemma` accept explicit `model=` kwarg. The `MODEL` symbol is kept (`= MODELS[0]`) for callers that import it.

* `scripts/backfill-raw-en-descriptions.py` (new) — one-shot backfill targeting films matching the silent-fallback signature (description present, < 200 chars, zero Czech diacritics, has tmdb_id). Re-checks the row's description still matches the filter before UPDATE so manual edits between SELECT and UPDATE aren't overwritten.

## Test plan

- [x] Verified all three Gemma model HTTP statuses (curl)
- [x] Local Gemma generation via new MODELS chain succeeds for the user's film (`generate_unique_cs('Adventures in Dinosaur City', 1991, …) → 259 chars CS`)
- [x] Backfill dry-run on 3 films
- [x] Backfill live on prod: 58 films matched, 37 updated (CS 240–340 chars each), 20 skipped (TMDB has no overview at all), 1 network timeout
- [x] Playwright check at https://ceskarepublika.wiki/filmy-online/adventures-in-dinosaur-city/ — page renders 297-char Czech description
- [x] Prod `gemma_writer.py` already synced and shows new `MODELS = [...]` list — next 05:07 UTC cron will pick it up