### PR TITLE
feat(homepage): add /prevod-textu-na-hlas/ link to portal nav

### DIFF
--- a/cr-web/templates/homepage.html
+++ b/cr-web/templates/homepage.html
@@ -36,6 +36,10 @@
         <span class="portal-category-icon">📡</span>
         <span>TV pořady</span>
     </a>
+    <a href="/prevod-textu-na-hlas/" class="portal-category-link">
+        <span class="portal-category-icon">🎙️</span>
+        <span>Převod textu na hlas</span>
+    </a>
 </nav>
 
 <section class="active-hub">


### PR DESCRIPTION
<!-- claude-session: abde5913-c371-47e0-8ccf-f9ba99bdf35f -->

## Summary

Adds `/prevod-textu-na-hlas/` as the 9th tile in the homepage portal-categories nav (after TV pořady), with a microphone icon 🎙️. Lets users discover the ChatterBox-vs-OmniVoice TTS comparison demo directly from the landing page.

## Test plan

- [x] `cargo check -p cr-web` green
- [x] Cross-compile + scp + restart
- [x] Production HTML contains `<a href="/prevod-textu-na-hlas/"`
- [x] Playwright on https://ceskarepublika.wiki/ — link found, visible, text "Převod textu na hlas" with 🎙️ icon
- [x] Playwright click on the tile navigated to /prevod-textu-na-hlas/ correctly
- [x] Zero console errors on either page