### PR TITLE
feat(ui): display IMDb rating alongside TMDB on detail + list pages (#593)

### DIFF
--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -34,7 +34,7 @@ const FILMS_PER_PAGE: i64 = 24;
 ///   when the primary upload's CDN is `www`, because data{N} is blocked
 ///   from datacenter ASNs). Preserved here via `cdn = 'www'` predicate.
 const FILM_COLUMNS: &str = "f.id, f.title, f.slug, f.year, f.description, f.original_title, \
-    f.tmdb_rating, f.csfd_rating, NULLIF(f.runtime_min, 0) AS runtime_min, \
+    f.tmdb_rating, f.imdb_rating, f.csfd_rating, NULLIF(f.runtime_min, 0) AS runtime_min, \
     f.added_at, f.tmdb_poster_path, \
     (SELECT vs.external_id::INTEGER \
        FROM video_sources vs \
@@ -80,6 +80,7 @@ struct FilmRow {
     description: Option<String>,
     original_title: Option<String>,
     tmdb_rating: Option<f32>,
+    imdb_rating: Option<f32>,
     csfd_rating: Option<i16>,
     runtime_min: Option<i16>,
     sktorrent_video_id: Option<i32>,
@@ -662,6 +663,7 @@ struct SearchResult {
     title: String,
     year: Option<i16>,
     tmdb_rating: Option<f32>,
+    imdb_rating: Option<f32>,
     cover: bool,
 }
 
@@ -671,6 +673,7 @@ struct SearchRow {
     title: String,
     year: Option<i16>,
     tmdb_rating: Option<f32>,
+    imdb_rating: Option<f32>,
 }
 
 // --- Handlers ---
@@ -1200,6 +1203,7 @@ pub async fn films_search(
             title: r.title,
             year: r.year,
             tmdb_rating: r.tmdb_rating,
+            imdb_rating: r.imdb_rating,
             cover: true,
         })
         .collect();
@@ -1216,7 +1220,7 @@ async fn search_films_by_title(db: &sqlx::PgPool, q: &str) -> Result<Vec<SearchR
     // user's diacritics) win bucket 0/1/2; rows that only match after
     // unaccent fall to bucket 3, behind the diacritic-exact hits.
     sqlx::query_as::<_, SearchRow>(
-        "SELECT slug, title, year, tmdb_rating \
+        "SELECT slug, title, year, tmdb_rating, imdb_rating \
          FROM films \
          WHERE unaccent(title) ILIKE unaccent($1) \
             OR unaccent(original_title) ILIKE unaccent($1) \
@@ -1241,7 +1245,7 @@ async fn search_films_by_title_year(
     let pattern = format!("%{q}%");
     let starts_pattern = format!("{q}%");
     sqlx::query_as::<_, SearchRow>(
-        "SELECT slug, title, year, tmdb_rating \
+        "SELECT slug, title, year, tmdb_rating, imdb_rating \
          FROM films \
          WHERE unaccent(CONCAT_WS(' ', title, year::text)) ILIKE unaccent($1) \
             OR unaccent(CONCAT_WS(' ', original_title, year::text)) ILIKE unaccent($1) \

--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -2243,4 +2243,53 @@ mod tests {
         assert_eq!(normalize_query("()"), "");
         assert_eq!(normalize_query("(  )"), "");
     }
+
+    #[test]
+    fn search_result_json_includes_both_rating_fields() {
+        // The autocomplete UI reads `r.tmdb_rating` AND `r.imdb_rating`
+        // from the JSON payload — both keys must be present in the
+        // serialized output even when None. If a future refactor drops
+        // one of them (e.g. accidentally renames or removes the field
+        // from the struct), the badges disappear silently from the
+        // dropdown. This test locks the contract so the regression is
+        // caught at CI time.
+        let result = super::SearchResult {
+            slug: "matrix".into(),
+            title: "Matrix".into(),
+            year: Some(1999),
+            tmdb_rating: Some(8.7),
+            imdb_rating: Some(8.7),
+            cover: true,
+        };
+        let json = serde_json::to_string(&result).expect("serialize");
+        assert!(
+            json.contains("\"tmdb_rating\":8.7"),
+            "tmdb_rating missing: {json}"
+        );
+        assert!(
+            json.contains("\"imdb_rating\":8.7"),
+            "imdb_rating missing: {json}"
+        );
+
+        // Even with both ratings absent the keys must still be present
+        // (as `null`); some autocomplete clients distinguish "rating
+        // missing from payload" from "rating known to be unset".
+        let none_result = super::SearchResult {
+            slug: "x".into(),
+            title: "X".into(),
+            year: None,
+            tmdb_rating: None,
+            imdb_rating: None,
+            cover: false,
+        };
+        let json = serde_json::to_string(&none_result).expect("serialize");
+        assert!(
+            json.contains("\"tmdb_rating\":null"),
+            "tmdb_rating key missing: {json}"
+        );
+        assert!(
+            json.contains("\"imdb_rating\":null"),
+            "imdb_rating key missing: {json}"
+        );
+    }
 }

--- a/cr-web/src/handlers/series.rs
+++ b/cr-web/src/handlers/series.rs
@@ -69,6 +69,7 @@ pub struct SeriesRow {
     description: Option<String>,
     original_title: Option<String>,
     tmdb_rating: Option<f32>,
+    imdb_rating: Option<f32>,
     csfd_rating: Option<i16>,
     #[allow(dead_code)] // Not rendered in current templates; kept for future series stats
     season_count: Option<i16>,
@@ -118,6 +119,7 @@ pub struct EpisodeCardRow {
     pub series_original_title: Option<String>,
     pub series_first_air_year: Option<i16>,
     pub series_tmdb_rating: Option<f32>,
+    pub series_imdb_rating: Option<f32>,
     pub series_csfd_rating: Option<i16>,
     pub series_description: Option<String>,
     pub season: i16,
@@ -405,7 +407,7 @@ pub async fn series_list(
 
         let query = format!(
             "SELECT s.id, s.title, s.slug, s.first_air_year, s.last_air_year, \
-             s.description, s.original_title, s.tmdb_rating, s.csfd_rating, \
+             s.description, s.original_title, s.tmdb_rating, s.imdb_rating, s.csfd_rating, \
              s.season_count, s.episode_count, s.added_at, \
              s.tmdb_poster_path \
              FROM series s \
@@ -580,6 +582,7 @@ async fn fetch_latest_episode_cards(
             s.original_title AS series_original_title, \
             s.first_air_year AS series_first_air_year, \
             s.tmdb_rating AS series_tmdb_rating, \
+            s.imdb_rating AS series_imdb_rating, \
             s.csfd_rating AS series_csfd_rating, \
             s.description AS series_description, \
             ps.season, ps.episode, ps.has_subtitles, ps.has_dub, ps.created_at, \
@@ -754,7 +757,7 @@ pub async fn series_resolve(
     // Series detail
     let series = sqlx::query_as::<_, SeriesRow>(
         "SELECT id, title, slug, first_air_year, last_air_year, description, \
-         original_title, tmdb_rating, csfd_rating, season_count, episode_count, \
+         original_title, tmdb_rating, imdb_rating, csfd_rating, season_count, episode_count, \
          added_at, tmdb_poster_path \
          FROM series WHERE slug = $1",
     )
@@ -768,7 +771,7 @@ pub async fn series_resolve(
             // Check old_slug for 301 redirect (series slug changed, e.g. year removed)
             let old_match = sqlx::query_as::<_, SeriesRow>(
                 "SELECT id, title, slug, first_air_year, last_air_year, description, \
-                 original_title, tmdb_rating, csfd_rating, season_count, episode_count, \
+                 original_title, tmdb_rating, imdb_rating, csfd_rating, season_count, episode_count, \
                  added_at, tmdb_poster_path FROM series WHERE old_slug = $1",
             )
             .bind(&slug_raw)
@@ -895,7 +898,7 @@ pub async fn episode_detail(
     // --- Resolve series (support old slugs with year via redirect) ---
     let series = sqlx::query_as::<_, SeriesRow>(
         "SELECT id, title, slug, first_air_year, last_air_year, description, \
-         original_title, tmdb_rating, csfd_rating, season_count, episode_count, \
+         original_title, tmdb_rating, imdb_rating, csfd_rating, season_count, episode_count, \
          added_at, tmdb_poster_path FROM series WHERE slug = $1",
     )
     .bind(&slug)
@@ -908,7 +911,7 @@ pub async fn episode_detail(
         None => {
             let old_match = sqlx::query_as::<_, SeriesRow>(
                 "SELECT id, title, slug, first_air_year, last_air_year, description, \
-                 original_title, tmdb_rating, csfd_rating, season_count, episode_count, \
+                 original_title, tmdb_rating, imdb_rating, csfd_rating, season_count, episode_count, \
                  added_at, tmdb_poster_path FROM series WHERE old_slug = $1",
             )
             .bind(&slug)
@@ -1141,6 +1144,7 @@ struct SeriesSearchResult {
     title: String,
     year: Option<i16>,
     tmdb_rating: Option<f32>,
+    imdb_rating: Option<f32>,
     cover: bool,
 }
 
@@ -1150,6 +1154,7 @@ struct SeriesSearchRow {
     title: String,
     first_air_year: Option<i16>,
     tmdb_rating: Option<f32>,
+    imdb_rating: Option<f32>,
 }
 
 /// GET /api/series/search?q=...
@@ -1168,7 +1173,7 @@ pub async fn series_search(
     // title literally contains the user's diacritics rank in buckets
     // 0–2, unaccent-only matches drop to bucket 3.
     let rows = sqlx::query_as::<_, SeriesSearchRow>(
-        "SELECT slug, title, first_air_year, tmdb_rating \
+        "SELECT slug, title, first_air_year, tmdb_rating, imdb_rating \
          FROM series \
          WHERE unaccent(title) ILIKE unaccent($1) \
             OR unaccent(original_title) ILIKE unaccent($1) \
@@ -1192,6 +1197,7 @@ pub async fn series_search(
             title: r.title,
             year: r.first_air_year,
             tmdb_rating: r.tmdb_rating,
+            imdb_rating: r.imdb_rating,
             cover: true,
         })
         .collect();

--- a/cr-web/src/handlers/tv_porady.rs
+++ b/cr-web/src/handlers/tv_porady.rs
@@ -64,6 +64,7 @@ pub struct TvShowRow {
     description: Option<String>,
     original_title: Option<String>,
     tmdb_rating: Option<f32>,
+    imdb_rating: Option<f32>,
     csfd_rating: Option<i16>,
     #[allow(dead_code)]
     season_count: Option<i16>,
@@ -111,6 +112,7 @@ pub struct TvEpisodeCardRow {
     pub tv_show_original_title: Option<String>,
     pub tv_show_first_air_year: Option<i16>,
     pub tv_show_tmdb_rating: Option<f32>,
+    pub tv_show_imdb_rating: Option<f32>,
     pub tv_show_csfd_rating: Option<i16>,
     pub tv_show_description: Option<String>,
     pub season: i16,
@@ -254,7 +256,7 @@ pub async fn tv_porady_list(
 
         let query = format!(
             "SELECT s.id, s.title, s.slug, s.first_air_year, s.last_air_year, \
-             s.description, s.original_title, s.tmdb_rating, s.csfd_rating, \
+             s.description, s.original_title, s.tmdb_rating, s.imdb_rating, s.csfd_rating, \
              s.season_count, s.episode_count, s.added_at, \
              s.tmdb_poster_path \
              FROM tv_shows s \
@@ -344,6 +346,7 @@ async fn fetch_latest_episode_cards(
         s.original_title AS tv_show_original_title, \
         s.first_air_year AS tv_show_first_air_year, \
         s.tmdb_rating AS tv_show_tmdb_rating, \
+        s.imdb_rating AS tv_show_imdb_rating, \
         s.csfd_rating AS tv_show_csfd_rating, \
         s.description AS tv_show_description, \
         ps.season, ps.episode, ps.has_subtitles, ps.has_dub, ps.created_at, \
@@ -368,6 +371,7 @@ struct TvPoradSearchResult {
     title: String,
     year: Option<i16>,
     tmdb_rating: Option<f32>,
+    imdb_rating: Option<f32>,
     cover: bool,
 }
 
@@ -377,6 +381,7 @@ struct TvPoradSearchRow {
     title: String,
     first_air_year: Option<i16>,
     tmdb_rating: Option<f32>,
+    imdb_rating: Option<f32>,
 }
 
 /// GET /api/tv-porady/search?q=...
@@ -395,7 +400,7 @@ pub async fn tv_porady_search(
     // CASE keeps diacritic-exact hits ranked ahead of unaccent-only
     // hits.
     let rows = sqlx::query_as::<_, TvPoradSearchRow>(
-        "SELECT slug, title, first_air_year, tmdb_rating \
+        "SELECT slug, title, first_air_year, tmdb_rating, imdb_rating \
          FROM tv_shows \
          WHERE unaccent(title) ILIKE unaccent($1) \
             OR unaccent(original_title) ILIKE unaccent($1) \
@@ -419,6 +424,7 @@ pub async fn tv_porady_search(
             title: r.title,
             year: r.first_air_year,
             tmdb_rating: r.tmdb_rating,
+            imdb_rating: r.imdb_rating,
             cover: true,
         })
         .collect();
@@ -444,7 +450,7 @@ pub async fn tv_porad_detail(
 
     let show = sqlx::query_as::<_, TvShowRow>(
         "SELECT id, title, slug, first_air_year, last_air_year, description, \
-         original_title, tmdb_rating, csfd_rating, season_count, episode_count, \
+         original_title, tmdb_rating, imdb_rating, csfd_rating, season_count, episode_count, \
          added_at, tmdb_poster_path FROM tv_shows WHERE slug = $1",
     )
     .bind(&slug_raw)
@@ -456,7 +462,7 @@ pub async fn tv_porad_detail(
         None => {
             let old_match = sqlx::query_as::<_, TvShowRow>(
                 "SELECT id, title, slug, first_air_year, last_air_year, description, \
-                 original_title, tmdb_rating, csfd_rating, season_count, episode_count, \
+                 original_title, tmdb_rating, imdb_rating, csfd_rating, season_count, episode_count, \
                  added_at, tmdb_poster_path FROM tv_shows WHERE old_slug = $1",
             )
             .bind(&slug_raw)
@@ -527,7 +533,7 @@ pub async fn tv_epizoda_detail(
 ) -> WebResult<Response> {
     let show = sqlx::query_as::<_, TvShowRow>(
         "SELECT id, title, slug, first_air_year, last_air_year, description, \
-         original_title, tmdb_rating, csfd_rating, season_count, episode_count, \
+         original_title, tmdb_rating, imdb_rating, csfd_rating, season_count, episode_count, \
          added_at, tmdb_poster_path FROM tv_shows WHERE slug = $1",
     )
     .bind(&slug)
@@ -539,7 +545,7 @@ pub async fn tv_epizoda_detail(
         None => {
             let old_match = sqlx::query_as::<_, TvShowRow>(
                 "SELECT id, title, slug, first_air_year, last_air_year, description, \
-                 original_title, tmdb_rating, csfd_rating, season_count, episode_count, \
+                 original_title, tmdb_rating, imdb_rating, csfd_rating, season_count, episode_count, \
                  added_at, tmdb_poster_path FROM tv_shows WHERE old_slug = $1",
             )
             .bind(&slug)

--- a/cr-web/templates/episode_detail.html
+++ b/cr-web/templates/episode_detail.html
@@ -648,8 +648,8 @@ function doSearch() {
                                 : '<div class="si-placeholder"></div>';
                             var yr = r.year ? ' (' + r.year + ')' : '';
                             var ratParts = [];
-                            if (r.tmdb_rating) ratParts.push('TMDB ' + r.tmdb_rating);
-                            if (r.imdb_rating) ratParts.push('IMDb ' + r.imdb_rating);
+                            if (r.tmdb_rating) ratParts.push('TMDB ' + r.tmdb_rating.toFixed(1));
+                            if (r.imdb_rating) ratParts.push('IMDb ' + r.imdb_rating.toFixed(1));
                             var rat = ratParts.length ? ' — ' + ratParts.join(' · ') : '';
                             return '<a href="/serialy-online/' + r.slug + '/" class="search-item" title="' + r.title + '" aria-label="' + r.title + '">'
                                 + cover + '<div class="si-info"><span class="si-title">' + r.title + yr + '</span>'

--- a/cr-web/templates/episode_detail.html
+++ b/cr-web/templates/episode_detail.html
@@ -647,7 +647,10 @@ function doSearch() {
                                 ? '<img src="/serialy-online/' + r.slug + '.webp" alt="' + r.title + '" title="' + r.title + '">'
                                 : '<div class="si-placeholder"></div>';
                             var yr = r.year ? ' (' + r.year + ')' : '';
-                            var rat = r.tmdb_rating ? ' — TMDB ' + r.tmdb_rating : '';
+                            var ratParts = [];
+                            if (r.tmdb_rating) ratParts.push('TMDB ' + r.tmdb_rating);
+                            if (r.imdb_rating) ratParts.push('IMDb ' + r.imdb_rating);
+                            var rat = ratParts.length ? ' — ' + ratParts.join(' · ') : '';
                             return '<a href="/serialy-online/' + r.slug + '/" class="search-item" title="' + r.title + '" aria-label="' + r.title + '">'
                                 + cover + '<div class="si-info"><span class="si-title">' + r.title + yr + '</span>'
                                 + '<span class="si-meta">' + rat + '</span></div></a>';

--- a/cr-web/templates/film_detail.html
+++ b/cr-web/templates/film_detail.html
@@ -147,13 +147,13 @@
             <div class="meta-row">
                 {% match film.tmdb_rating %}
                 {% when Some with (r) %}
-                <span class="meta-badge tmdb" title="TMDB hodnocení">TMDB {{ r }}</span>
+                <span class="meta-badge tmdb" title="TMDB hodnocení">TMDB {{ "{:.1}"|format(r) }}</span>
                 {% when None %}
                 {% endmatch %}
 
                 {% match film.imdb_rating %}
                 {% when Some with (r) %}
-                <span class="meta-badge imdb" title="IMDb hodnocení">IMDb {{ r }}</span>
+                <span class="meta-badge imdb" title="IMDb hodnocení">IMDb {{ "{:.1}"|format(r) }}</span>
                 {% when None %}
                 {% endmatch %}
 
@@ -792,8 +792,8 @@ function doSearch() {
                                 : '<div class="si-placeholder"></div>';
                             var yr = r.year ? ' (' + r.year + ')' : '';
                             var ratParts = [];
-                            if (r.tmdb_rating) ratParts.push('TMDB ' + r.tmdb_rating);
-                            if (r.imdb_rating) ratParts.push('IMDb ' + r.imdb_rating);
+                            if (r.tmdb_rating) ratParts.push('TMDB ' + r.tmdb_rating.toFixed(1));
+                            if (r.imdb_rating) ratParts.push('IMDb ' + r.imdb_rating.toFixed(1));
                             var rat = ratParts.length ? ' — ' + ratParts.join(' · ') : '';
                             return '<a href="/filmy-online/' + r.slug + '/" class="search-item">'
                                 + cover + '<div class="si-info"><span class="si-title">' + r.title + yr + '</span>'

--- a/cr-web/templates/film_detail.html
+++ b/cr-web/templates/film_detail.html
@@ -163,6 +163,11 @@
                 {% when None %}
                 {% endmatch %}
 
+                {# Fallback when no rating source has a value (#593 acceptance criterion). #}
+                {% if film.tmdb_rating.is_none() && film.imdb_rating.is_none() && film.csfd_rating.is_none() %}
+                <span class="meta-badge none">Bez hodnocení</span>
+                {% endif %}
+
                 {% match film.runtime_min %}
                 {% when Some with (m) %}
                 <span class="meta-badge runtime">{{ m }} min</span>
@@ -330,6 +335,7 @@ video::cue { background: rgba(0,0,0,0.7); color: white; font-family: sans-serif;
 .meta-badge.imdb { background: #f5c518; color: #000; }
 .meta-badge.csfd { background: #ba0305; color: #fff; }
 .meta-badge.runtime { background: #f0f0f0; color: #333; }
+.meta-badge.none { background: #eef2f7; color: #6b7785; font-style: italic; }
 
 .genre-tags { display: flex; gap: 0.4rem; flex-wrap: wrap; margin-bottom: 0.8rem; }
 .genre-tag { display: inline-block; padding: 0.2rem 0.6rem; border-radius: 16px; background: #f0f0f0; color: #333; text-decoration: none; font-size: 0.8rem; }

--- a/cr-web/templates/film_detail.html
+++ b/cr-web/templates/film_detail.html
@@ -147,7 +147,13 @@
             <div class="meta-row">
                 {% match film.tmdb_rating %}
                 {% when Some with (r) %}
-                <span class="meta-badge imdb" title="TMDB hodnocení">TMDB {{ r }}</span>
+                <span class="meta-badge tmdb" title="TMDB hodnocení">TMDB {{ r }}</span>
+                {% when None %}
+                {% endmatch %}
+
+                {% match film.imdb_rating %}
+                {% when Some with (r) %}
+                <span class="meta-badge imdb" title="IMDb hodnocení">IMDb {{ r }}</span>
                 {% when None %}
                 {% endmatch %}
 
@@ -320,6 +326,7 @@ video::cue { background: rgba(0,0,0,0.7); color: white; font-family: sans-serif;
 
 .meta-row { display: flex; gap: 0.4rem; flex-wrap: wrap; margin-bottom: 0.8rem; }
 .meta-badge { display: inline-block; padding: 0.2rem 0.5rem; border-radius: 4px; font-size: 0.82rem; font-weight: 600; }
+.meta-badge.tmdb { background: #01b4e4; color: #fff; }
 .meta-badge.imdb { background: #f5c518; color: #000; }
 .meta-badge.csfd { background: #ba0305; color: #fff; }
 .meta-badge.runtime { background: #f0f0f0; color: #333; }
@@ -778,7 +785,10 @@ function doSearch() {
                                 ? '<img src="/filmy-online/' + r.slug + '.webp" alt="">'
                                 : '<div class="si-placeholder"></div>';
                             var yr = r.year ? ' (' + r.year + ')' : '';
-                            var rat = r.tmdb_rating ? ' — TMDB ' + r.tmdb_rating : '';
+                            var ratParts = [];
+                            if (r.tmdb_rating) ratParts.push('TMDB ' + r.tmdb_rating);
+                            if (r.imdb_rating) ratParts.push('IMDb ' + r.imdb_rating);
+                            var rat = ratParts.length ? ' — ' + ratParts.join(' · ') : '';
                             return '<a href="/filmy-online/' + r.slug + '/" class="search-item">'
                                 + cover + '<div class="si-info"><span class="si-title">' + r.title + yr + '</span>'
                                 + '<span class="si-meta">' + rat + '</span></div></a>';

--- a/cr-web/templates/films_list.html
+++ b/cr-web/templates/films_list.html
@@ -239,10 +239,16 @@
             <div class="film-poster">
                 <img src="/filmy-online/{{ f.slug }}.webp" alt="{{ f.title }}" loading="lazy" width="200" height="300">
                 <div class="rating-badges">
+                    {# Card view: TMDB primary, IMDb fallback when TMDB is missing (#593) #}
                     {% match f.tmdb_rating %}
                     {% when Some with (r) %}
-                    <span class="rating-badge imdb" title="TMDB hodnocení">{{ r }}</span>
+                    <span class="rating-badge tmdb" title="TMDB hodnocení">{{ r }}</span>
                     {% when None %}
+                        {% match f.imdb_rating %}
+                        {% when Some with (r) %}
+                        <span class="rating-badge imdb" title="IMDb hodnocení">{{ r }}</span>
+                        {% when None %}
+                        {% endmatch %}
                     {% endmatch %}
                     {% match f.csfd_rating %}
                     {% when Some with (r) %}
@@ -264,7 +270,8 @@
                 </div>
                 <div class="film-list-extra">
                     <div class="film-ratings">
-                        {% match f.tmdb_rating %}{% when Some with (r) %}<span class="badge imdb">TMDB {{ r }}</span>{% when None %}{% endmatch %}
+                        {% match f.tmdb_rating %}{% when Some with (r) %}<span class="badge tmdb">TMDB {{ r }}</span>{% when None %}{% endmatch %}
+                        {% match f.imdb_rating %}{% when Some with (r) %}<span class="badge imdb">IMDb {{ r }}</span>{% when None %}{% endmatch %}
                         {% match f.csfd_rating %}{% when Some with (r) %}<span class="badge csfd">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
                         {% match f.runtime_min %}{% when Some with (m) %}<span class="badge runtime">{{ m }} min</span>{% when None %}{% endmatch %}
                         {% for fg in self.film_genres(f.id) %}<span class="genre-tag">{{ fg.name_cs }}</span>{% endfor %}
@@ -445,6 +452,7 @@ a.filter-chip-link:hover { background: #11457E; color: white; }
 
 .rating-badges { position: absolute; top: 6px; right: 6px; display: flex; flex-direction: column; gap: 3px; }
 .rating-badge { font-weight: 700; font-size: 0.7rem; padding: 2px 5px; border-radius: 4px; text-align: center; line-height: 1.3; }
+.rating-badge.tmdb { background: #01b4e4; color: #fff; }
 .rating-badge.imdb { background: #f5c518; color: #000; }
 .rating-badge.csfd { background: #ba0305; color: #fff; }
 .runtime-badge { position: absolute; bottom: 6px; right: 6px; background: rgba(0,0,0,0.75); color: #fff; font-weight: 600; font-size: 0.7rem; padding: 2px 6px; border-radius: 4px; line-height: 1.2; }
@@ -476,6 +484,7 @@ a.filter-chip-link:hover { background: #11457E; color: white; }
 .films-grid.list-view .film-ratings .genre-tag { display: inline-flex; align-items: center; font-size: 0.75rem; color: #555; background: #eceef2; padding: 0.2rem 0.6rem; border-radius: 999px; line-height: 1.3; }
 @media (max-width: 768px) { .films-grid.list-view .film-ratings .genre-tag { display: none; } }
 .films-grid.list-view .badge { display: inline-block; padding: 0.15rem 0.5rem; border-radius: 4px; font-size: 0.78rem; font-weight: 600; }
+.films-grid.list-view .badge.tmdb { background: #01b4e4; color: #fff; }
 .films-grid.list-view .badge.imdb { background: #f5c518; color: #000; }
 .films-grid.list-view .badge.csfd { background: #ba0305; color: #fff; }
 .films-grid.list-view .badge.runtime { background: #eee; color: #333; }
@@ -846,7 +855,10 @@ function doSearch() {
                                 ? '<img src="/filmy-online/' + r.slug + '.webp" alt="">'
                                 : '<div class="si-placeholder"></div>';
                             var yr = r.year ? ' (' + r.year + ')' : '';
-                            var rat = r.tmdb_rating ? ' — TMDB ' + r.tmdb_rating : '';
+                            var ratParts = [];
+                            if (r.tmdb_rating) ratParts.push('TMDB ' + r.tmdb_rating);
+                            if (r.imdb_rating) ratParts.push('IMDb ' + r.imdb_rating);
+                            var rat = ratParts.length ? ' — ' + ratParts.join(' · ') : '';
                             return '<a href="/filmy-online/' + r.slug + '/" class="search-item">'
                                 + cover + '<div class="si-info"><span class="si-title">' + r.title + yr + '</span>'
                                 + '<span class="si-meta">' + rat + '</span></div></a>';

--- a/cr-web/templates/films_list.html
+++ b/cr-web/templates/films_list.html
@@ -239,20 +239,20 @@
             <div class="film-poster">
                 <img src="/filmy-online/{{ f.slug }}.webp" alt="{{ f.title }}" loading="lazy" width="200" height="300">
                 <div class="rating-badges">
-                    {# Card view: TMDB primary, IMDb fallback when TMDB is missing (#593) #}
+                    {# Card view: show TMDB + IMDb + ČSFD stacked (#593). The .rating-badges CSS uses flex-direction: column. #}
                     {% match f.tmdb_rating %}
                     {% when Some with (r) %}
-                    <span class="rating-badge tmdb" title="TMDB hodnocení">{{ r }}</span>
+                    <span class="rating-badge tmdb" title="TMDB hodnocení">TMDB {{ r }}</span>
                     {% when None %}
-                        {% match f.imdb_rating %}
-                        {% when Some with (r) %}
-                        <span class="rating-badge imdb" title="IMDb hodnocení">{{ r }}</span>
-                        {% when None %}
-                        {% endmatch %}
+                    {% endmatch %}
+                    {% match f.imdb_rating %}
+                    {% when Some with (r) %}
+                    <span class="rating-badge imdb" title="IMDb hodnocení">IMDb {{ r }}</span>
+                    {% when None %}
                     {% endmatch %}
                     {% match f.csfd_rating %}
                     {% when Some with (r) %}
-                    <span class="rating-badge csfd" title="ČSFD hodnocení">{{ r }}%</span>
+                    <span class="rating-badge csfd" title="ČSFD hodnocení">ČSFD {{ r }}%</span>
                     {% when None %}
                     {% endmatch %}
                 </div>

--- a/cr-web/templates/films_list.html
+++ b/cr-web/templates/films_list.html
@@ -242,12 +242,12 @@
                     {# Card view: show TMDB + IMDb + ČSFD stacked (#593). The .rating-badges CSS uses flex-direction: column. #}
                     {% match f.tmdb_rating %}
                     {% when Some with (r) %}
-                    <span class="rating-badge tmdb" title="TMDB hodnocení">TMDB {{ r }}</span>
+                    <span class="rating-badge tmdb" title="TMDB hodnocení">TMDB {{ "{:.1}"|format(r) }}</span>
                     {% when None %}
                     {% endmatch %}
                     {% match f.imdb_rating %}
                     {% when Some with (r) %}
-                    <span class="rating-badge imdb" title="IMDb hodnocení">IMDb {{ r }}</span>
+                    <span class="rating-badge imdb" title="IMDb hodnocení">IMDb {{ "{:.1}"|format(r) }}</span>
                     {% when None %}
                     {% endmatch %}
                     {% match f.csfd_rating %}
@@ -270,8 +270,8 @@
                 </div>
                 <div class="film-list-extra">
                     <div class="film-ratings">
-                        {% match f.tmdb_rating %}{% when Some with (r) %}<span class="badge tmdb">TMDB {{ r }}</span>{% when None %}{% endmatch %}
-                        {% match f.imdb_rating %}{% when Some with (r) %}<span class="badge imdb">IMDb {{ r }}</span>{% when None %}{% endmatch %}
+                        {% match f.tmdb_rating %}{% when Some with (r) %}<span class="badge tmdb">TMDB {{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
+                        {% match f.imdb_rating %}{% when Some with (r) %}<span class="badge imdb">IMDb {{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
                         {% match f.csfd_rating %}{% when Some with (r) %}<span class="badge csfd">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
                         {% match f.runtime_min %}{% when Some with (m) %}<span class="badge runtime">{{ m }} min</span>{% when None %}{% endmatch %}
                         {% for fg in self.film_genres(f.id) %}<span class="genre-tag">{{ fg.name_cs }}</span>{% endfor %}
@@ -856,8 +856,8 @@ function doSearch() {
                                 : '<div class="si-placeholder"></div>';
                             var yr = r.year ? ' (' + r.year + ')' : '';
                             var ratParts = [];
-                            if (r.tmdb_rating) ratParts.push('TMDB ' + r.tmdb_rating);
-                            if (r.imdb_rating) ratParts.push('IMDb ' + r.imdb_rating);
+                            if (r.tmdb_rating) ratParts.push('TMDB ' + r.tmdb_rating.toFixed(1));
+                            if (r.imdb_rating) ratParts.push('IMDb ' + r.imdb_rating.toFixed(1));
                             var rat = ratParts.length ? ' — ' + ratParts.join(' · ') : '';
                             return '<a href="/filmy-online/' + r.slug + '/" class="search-item">'
                                 + cover + '<div class="si-info"><span class="si-title">' + r.title + yr + '</span>'

--- a/cr-web/templates/series_detail.html
+++ b/cr-web/templates/series_detail.html
@@ -68,7 +68,10 @@
             {% when None %}{% endmatch %}
             <div class="meta-row">
                 {% match series.tmdb_rating %}
-                {% when Some with (r) %}<span class="meta-badge imdb" title="TMDB hodnocení">TMDB {{ r }}</span>
+                {% when Some with (r) %}<span class="meta-badge tmdb" title="TMDB hodnocení">TMDB {{ r }}</span>
+                {% when None %}{% endmatch %}
+                {% match series.imdb_rating %}
+                {% when Some with (r) %}<span class="meta-badge imdb" title="IMDb hodnocení">IMDb {{ r }}</span>
                 {% when None %}{% endmatch %}
                 {% match series.csfd_rating %}
                 {% when Some with (r) %}<span class="meta-badge csfd" title="ČSFD hodnocení">ČSFD {{ r }}%</span>
@@ -194,6 +197,7 @@
 .original-title { color: #888; font-style: italic; margin: 0 0 0.6rem; font-size: 0.9rem; }
 .meta-row { display: flex; gap: 0.4rem; margin-bottom: 0.8rem; }
 .meta-badge { padding: 0.2rem 0.5rem; border-radius: 4px; font-size: 0.82rem; font-weight: 600; }
+.meta-badge.tmdb { background: #01b4e4; color: #fff; }
 .meta-badge.imdb { background: #f5c518; color: #000; }
 .meta-badge.csfd { background: #ba0305; color: #fff; }
 .genre-tags { display: flex; gap: 0.4rem; flex-wrap: wrap; margin-bottom: 0.8rem; }
@@ -312,7 +316,10 @@ function doSearch() {
                                 ? '<img src="/serialy-online/' + r.slug + '.webp" alt="' + r.title + '" title="' + r.title + '">'
                                 : '<div class="si-placeholder"></div>';
                             var yr = r.year ? ' (' + r.year + ')' : '';
-                            var rat = r.tmdb_rating ? ' — TMDB ' + r.tmdb_rating : '';
+                            var ratParts = [];
+                            if (r.tmdb_rating) ratParts.push('TMDB ' + r.tmdb_rating);
+                            if (r.imdb_rating) ratParts.push('IMDb ' + r.imdb_rating);
+                            var rat = ratParts.length ? ' — ' + ratParts.join(' · ') : '';
                             return '<a href="/serialy-online/' + r.slug + '/" class="search-item" title="' + r.title + '" aria-label="' + r.title + '">'
                                 + cover + '<div class="si-info"><span class="si-title">' + r.title + yr + '</span>'
                                 + '<span class="si-meta">' + rat + '</span></div></a>';

--- a/cr-web/templates/series_detail.html
+++ b/cr-web/templates/series_detail.html
@@ -76,6 +76,10 @@
                 {% match series.csfd_rating %}
                 {% when Some with (r) %}<span class="meta-badge csfd" title="ČSFD hodnocení">ČSFD {{ r }}%</span>
                 {% when None %}{% endmatch %}
+                {# Fallback when no rating source has a value (#593 acceptance criterion). #}
+                {% if series.tmdb_rating.is_none() && series.imdb_rating.is_none() && series.csfd_rating.is_none() %}
+                <span class="meta-badge none">Bez hodnocení</span>
+                {% endif %}
             </div>
             {% if !genres.is_empty() %}
             <div class="genre-tags">
@@ -200,6 +204,7 @@
 .meta-badge.tmdb { background: #01b4e4; color: #fff; }
 .meta-badge.imdb { background: #f5c518; color: #000; }
 .meta-badge.csfd { background: #ba0305; color: #fff; }
+.meta-badge.none { background: #eef2f7; color: #6b7785; font-style: italic; }
 .genre-tags { display: flex; gap: 0.4rem; flex-wrap: wrap; margin-bottom: 0.8rem; }
 .genre-tag { padding: 0.3rem 0.8rem; border-radius: 999px; background: #f1f5f9; color: #11457E; text-decoration: none; font-size: 0.85rem; font-weight: 600; transition: background 0.15s, color 0.15s; cursor: pointer; }
 .genre-tag:hover { background: #11457E; color: white; }

--- a/cr-web/templates/series_detail.html
+++ b/cr-web/templates/series_detail.html
@@ -68,10 +68,10 @@
             {% when None %}{% endmatch %}
             <div class="meta-row">
                 {% match series.tmdb_rating %}
-                {% when Some with (r) %}<span class="meta-badge tmdb" title="TMDB hodnocení">TMDB {{ r }}</span>
+                {% when Some with (r) %}<span class="meta-badge tmdb" title="TMDB hodnocení">TMDB {{ "{:.1}"|format(r) }}</span>
                 {% when None %}{% endmatch %}
                 {% match series.imdb_rating %}
-                {% when Some with (r) %}<span class="meta-badge imdb" title="IMDb hodnocení">IMDb {{ r }}</span>
+                {% when Some with (r) %}<span class="meta-badge imdb" title="IMDb hodnocení">IMDb {{ "{:.1}"|format(r) }}</span>
                 {% when None %}{% endmatch %}
                 {% match series.csfd_rating %}
                 {% when Some with (r) %}<span class="meta-badge csfd" title="ČSFD hodnocení">ČSFD {{ r }}%</span>
@@ -322,8 +322,8 @@ function doSearch() {
                                 : '<div class="si-placeholder"></div>';
                             var yr = r.year ? ' (' + r.year + ')' : '';
                             var ratParts = [];
-                            if (r.tmdb_rating) ratParts.push('TMDB ' + r.tmdb_rating);
-                            if (r.imdb_rating) ratParts.push('IMDb ' + r.imdb_rating);
+                            if (r.tmdb_rating) ratParts.push('TMDB ' + r.tmdb_rating.toFixed(1));
+                            if (r.imdb_rating) ratParts.push('IMDb ' + r.imdb_rating.toFixed(1));
                             var rat = ratParts.length ? ' — ' + ratParts.join(' · ') : '';
                             return '<a href="/serialy-online/' + r.slug + '/" class="search-item" title="' + r.title + '" aria-label="' + r.title + '">'
                                 + cover + '<div class="si-info"><span class="si-title">' + r.title + yr + '</span>'

--- a/cr-web/templates/series_list.html
+++ b/cr-web/templates/series_list.html
@@ -172,8 +172,14 @@
             <div class="film-poster">
                 <img src="/serialy-online/{{ ep.series_slug }}.webp" alt="{{ ep.series_title }}" title="{{ ep.series_title }}" loading="lazy" width="200" height="300">
                 <div class="rating-badges">
+                    {# Card view: TMDB primary, IMDb fallback (#593) #}
                     {% match ep.series_tmdb_rating %}
-                    {% when Some with (r) %}<span class="rating-badge imdb" title="TMDB hodnocení">{{ r }}</span>{% when None %}{% endmatch %}
+                    {% when Some with (r) %}<span class="rating-badge tmdb" title="TMDB hodnocení">{{ r }}</span>
+                    {% when None %}
+                        {% match ep.series_imdb_rating %}
+                        {% when Some with (r) %}<span class="rating-badge imdb" title="IMDb hodnocení">{{ r }}</span>
+                        {% when None %}{% endmatch %}
+                    {% endmatch %}
                     {% match ep.series_csfd_rating %}
                     {% when Some with (r) %}<span class="rating-badge csfd" title="ČSFD hodnocení">{{ r }}%</span>{% when None %}{% endmatch %}
                 </div>
@@ -189,7 +195,8 @@
                 </div>
                 <div class="film-list-extra">
                     <div class="film-ratings">
-                        {% match ep.series_tmdb_rating %}{% when Some with (r) %}<span class="badge imdb">TMDB {{ r }}</span>{% when None %}{% endmatch %}
+                        {% match ep.series_tmdb_rating %}{% when Some with (r) %}<span class="badge tmdb">TMDB {{ r }}</span>{% when None %}{% endmatch %}
+                        {% match ep.series_imdb_rating %}{% when Some with (r) %}<span class="badge imdb">IMDb {{ r }}</span>{% when None %}{% endmatch %}
                         {% match ep.series_csfd_rating %}{% when Some with (r) %}<span class="badge csfd">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
                         {% match ep.series_first_air_year %}{% when Some with (y) %}<span class="badge year">{{ y }}</span>{% when None %}{% endmatch %}
                         {% for sg in self.series_genres(ep.series_id) %}<span class="genre-tag">{{ sg.name_cs }}</span>{% endfor %}
@@ -207,7 +214,13 @@
             <div class="film-poster">
                 <img src="/serialy-online/{{ s.slug }}.webp" alt="{{ s.title }}" title="{{ s.title }}" loading="lazy" width="200" height="300">
                 <div class="rating-badges">
-                    {% match s.tmdb_rating %}{% when Some with (r) %}<span class="rating-badge imdb" title="TMDB hodnocení">{{ r }}</span>{% when None %}{% endmatch %}
+                    {% match s.tmdb_rating %}
+                    {% when Some with (r) %}<span class="rating-badge tmdb" title="TMDB hodnocení">{{ r }}</span>
+                    {% when None %}
+                        {% match s.imdb_rating %}
+                        {% when Some with (r) %}<span class="rating-badge imdb" title="IMDb hodnocení">{{ r }}</span>
+                        {% when None %}{% endmatch %}
+                    {% endmatch %}
                     {% match s.csfd_rating %}{% when Some with (r) %}<span class="rating-badge csfd" title="ČSFD hodnocení">{{ r }}%</span>{% when None %}{% endmatch %}
                 </div>
             </div>
@@ -219,7 +232,8 @@
                 </div>
                 <div class="film-list-extra">
                     <div class="film-ratings">
-                        {% match s.tmdb_rating %}{% when Some with (r) %}<span class="badge imdb">TMDB {{ r }}</span>{% when None %}{% endmatch %}
+                        {% match s.tmdb_rating %}{% when Some with (r) %}<span class="badge tmdb">TMDB {{ r }}</span>{% when None %}{% endmatch %}
+                        {% match s.imdb_rating %}{% when Some with (r) %}<span class="badge imdb">IMDb {{ r }}</span>{% when None %}{% endmatch %}
                         {% match s.csfd_rating %}{% when Some with (r) %}<span class="badge csfd">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
                         {% match s.first_air_year %}{% when Some with (y) %}<span class="badge year">{{ y }}</span>{% when None %}{% endmatch %}
                         {% for sg in self.series_genres(s.id) %}<span class="genre-tag">{{ sg.name_cs }}</span>{% endfor %}
@@ -356,6 +370,7 @@ a.filter-chip-link:hover { background: #11457E; color: white; }
 .no-poster { width: 100%; height: 100%; display: flex; align-items: center; justify-content: center; color: #888; padding: 1rem; text-align: center; }
 .rating-badges { position: absolute; top: 0.4rem; left: 0.4rem; display: flex; gap: 0.25rem; }
 .rating-badge { padding: 0.15rem 0.4rem; border-radius: 4px; font-size: 0.7rem; font-weight: 700; box-shadow: 0 1px 3px rgba(0,0,0,0.3); }
+.rating-badge.tmdb { background: #01b4e4; color: #fff; }
 .rating-badge.imdb { background: #f5c518; color: #000; }
 .rating-badge.csfd { background: #b01020; color: #fff; }
 .cc-badge { position: absolute; bottom: 0.4rem; right: 0.4rem; background: #4ade80; color: #003c1c; padding: 0.1rem 0.4rem; border-radius: 4px; font-size: 0.7rem; font-weight: 700; letter-spacing: 0.03em; box-shadow: 0 1px 3px rgba(0,0,0,0.3); }
@@ -369,6 +384,7 @@ a.filter-chip-link:hover { background: #11457E; color: white; }
 .film-list-extra { display: none; }
 .film-ratings { display: flex; gap: 0.3rem; margin: 0.3rem 0; flex-wrap: wrap; }
 .badge { font-size: 0.72rem; padding: 0.1rem 0.4rem; border-radius: 4px; font-weight: 600; }
+.badge.tmdb { background: #01b4e4; color: #fff; }
 .badge.imdb { background: #f5c518; color: #000; }
 .badge.csfd { background: #b01020; color: #fff; }
 .badge.year { background: #e2e8f0; color: #333; }
@@ -696,7 +712,10 @@ function doSearch() {
                                 ? '<img src="/serialy-online/' + r.slug + '.webp" alt="' + r.title + '" title="' + r.title + '">'
                                 : '<div class="si-placeholder"></div>';
                             var yr = r.year ? ' (' + r.year + ')' : '';
-                            var rat = r.tmdb_rating ? ' — TMDB ' + r.tmdb_rating : '';
+                            var ratParts = [];
+                            if (r.tmdb_rating) ratParts.push('TMDB ' + r.tmdb_rating);
+                            if (r.imdb_rating) ratParts.push('IMDb ' + r.imdb_rating);
+                            var rat = ratParts.length ? ' — ' + ratParts.join(' · ') : '';
                             return '<a href="/serialy-online/' + r.slug + '/" class="search-item" title="' + r.title + '">'
                                 + cover + '<div class="si-info"><span class="si-title">' + r.title + yr + '</span>'
                                 + '<span class="si-meta">' + rat + '</span></div></a>';

--- a/cr-web/templates/series_list.html
+++ b/cr-web/templates/series_list.html
@@ -172,16 +172,13 @@
             <div class="film-poster">
                 <img src="/serialy-online/{{ ep.series_slug }}.webp" alt="{{ ep.series_title }}" title="{{ ep.series_title }}" loading="lazy" width="200" height="300">
                 <div class="rating-badges">
-                    {# Card view: TMDB primary, IMDb fallback (#593) #}
+                    {# Card view: show all available ratings stacked (#593) #}
                     {% match ep.series_tmdb_rating %}
-                    {% when Some with (r) %}<span class="rating-badge tmdb" title="TMDB hodnocení">{{ r }}</span>
-                    {% when None %}
-                        {% match ep.series_imdb_rating %}
-                        {% when Some with (r) %}<span class="rating-badge imdb" title="IMDb hodnocení">{{ r }}</span>
-                        {% when None %}{% endmatch %}
-                    {% endmatch %}
+                    {% when Some with (r) %}<span class="rating-badge tmdb" title="TMDB hodnocení">TMDB {{ r }}</span>{% when None %}{% endmatch %}
+                    {% match ep.series_imdb_rating %}
+                    {% when Some with (r) %}<span class="rating-badge imdb" title="IMDb hodnocení">IMDb {{ r }}</span>{% when None %}{% endmatch %}
                     {% match ep.series_csfd_rating %}
-                    {% when Some with (r) %}<span class="rating-badge csfd" title="ČSFD hodnocení">{{ r }}%</span>{% when None %}{% endmatch %}
+                    {% when Some with (r) %}<span class="rating-badge csfd" title="ČSFD hodnocení">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
                 </div>
                 {% if ep.has_subtitles.unwrap_or(false) %}
                 <span class="cc-badge" title="České titulky">CC</span>
@@ -214,14 +211,9 @@
             <div class="film-poster">
                 <img src="/serialy-online/{{ s.slug }}.webp" alt="{{ s.title }}" title="{{ s.title }}" loading="lazy" width="200" height="300">
                 <div class="rating-badges">
-                    {% match s.tmdb_rating %}
-                    {% when Some with (r) %}<span class="rating-badge tmdb" title="TMDB hodnocení">{{ r }}</span>
-                    {% when None %}
-                        {% match s.imdb_rating %}
-                        {% when Some with (r) %}<span class="rating-badge imdb" title="IMDb hodnocení">{{ r }}</span>
-                        {% when None %}{% endmatch %}
-                    {% endmatch %}
-                    {% match s.csfd_rating %}{% when Some with (r) %}<span class="rating-badge csfd" title="ČSFD hodnocení">{{ r }}%</span>{% when None %}{% endmatch %}
+                    {% match s.tmdb_rating %}{% when Some with (r) %}<span class="rating-badge tmdb" title="TMDB hodnocení">TMDB {{ r }}</span>{% when None %}{% endmatch %}
+                    {% match s.imdb_rating %}{% when Some with (r) %}<span class="rating-badge imdb" title="IMDb hodnocení">IMDb {{ r }}</span>{% when None %}{% endmatch %}
+                    {% match s.csfd_rating %}{% when Some with (r) %}<span class="rating-badge csfd" title="ČSFD hodnocení">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
                 </div>
             </div>
             <div class="film-body">

--- a/cr-web/templates/series_list.html
+++ b/cr-web/templates/series_list.html
@@ -174,9 +174,9 @@
                 <div class="rating-badges">
                     {# Card view: show all available ratings stacked (#593) #}
                     {% match ep.series_tmdb_rating %}
-                    {% when Some with (r) %}<span class="rating-badge tmdb" title="TMDB hodnocení">TMDB {{ r }}</span>{% when None %}{% endmatch %}
+                    {% when Some with (r) %}<span class="rating-badge tmdb" title="TMDB hodnocení">TMDB {{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
                     {% match ep.series_imdb_rating %}
-                    {% when Some with (r) %}<span class="rating-badge imdb" title="IMDb hodnocení">IMDb {{ r }}</span>{% when None %}{% endmatch %}
+                    {% when Some with (r) %}<span class="rating-badge imdb" title="IMDb hodnocení">IMDb {{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
                     {% match ep.series_csfd_rating %}
                     {% when Some with (r) %}<span class="rating-badge csfd" title="ČSFD hodnocení">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
                 </div>
@@ -192,8 +192,8 @@
                 </div>
                 <div class="film-list-extra">
                     <div class="film-ratings">
-                        {% match ep.series_tmdb_rating %}{% when Some with (r) %}<span class="badge tmdb">TMDB {{ r }}</span>{% when None %}{% endmatch %}
-                        {% match ep.series_imdb_rating %}{% when Some with (r) %}<span class="badge imdb">IMDb {{ r }}</span>{% when None %}{% endmatch %}
+                        {% match ep.series_tmdb_rating %}{% when Some with (r) %}<span class="badge tmdb">TMDB {{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
+                        {% match ep.series_imdb_rating %}{% when Some with (r) %}<span class="badge imdb">IMDb {{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
                         {% match ep.series_csfd_rating %}{% when Some with (r) %}<span class="badge csfd">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
                         {% match ep.series_first_air_year %}{% when Some with (y) %}<span class="badge year">{{ y }}</span>{% when None %}{% endmatch %}
                         {% for sg in self.series_genres(ep.series_id) %}<span class="genre-tag">{{ sg.name_cs }}</span>{% endfor %}
@@ -211,8 +211,8 @@
             <div class="film-poster">
                 <img src="/serialy-online/{{ s.slug }}.webp" alt="{{ s.title }}" title="{{ s.title }}" loading="lazy" width="200" height="300">
                 <div class="rating-badges">
-                    {% match s.tmdb_rating %}{% when Some with (r) %}<span class="rating-badge tmdb" title="TMDB hodnocení">TMDB {{ r }}</span>{% when None %}{% endmatch %}
-                    {% match s.imdb_rating %}{% when Some with (r) %}<span class="rating-badge imdb" title="IMDb hodnocení">IMDb {{ r }}</span>{% when None %}{% endmatch %}
+                    {% match s.tmdb_rating %}{% when Some with (r) %}<span class="rating-badge tmdb" title="TMDB hodnocení">TMDB {{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
+                    {% match s.imdb_rating %}{% when Some with (r) %}<span class="rating-badge imdb" title="IMDb hodnocení">IMDb {{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
                     {% match s.csfd_rating %}{% when Some with (r) %}<span class="rating-badge csfd" title="ČSFD hodnocení">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
                 </div>
             </div>
@@ -224,8 +224,8 @@
                 </div>
                 <div class="film-list-extra">
                     <div class="film-ratings">
-                        {% match s.tmdb_rating %}{% when Some with (r) %}<span class="badge tmdb">TMDB {{ r }}</span>{% when None %}{% endmatch %}
-                        {% match s.imdb_rating %}{% when Some with (r) %}<span class="badge imdb">IMDb {{ r }}</span>{% when None %}{% endmatch %}
+                        {% match s.tmdb_rating %}{% when Some with (r) %}<span class="badge tmdb">TMDB {{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
+                        {% match s.imdb_rating %}{% when Some with (r) %}<span class="badge imdb">IMDb {{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
                         {% match s.csfd_rating %}{% when Some with (r) %}<span class="badge csfd">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
                         {% match s.first_air_year %}{% when Some with (y) %}<span class="badge year">{{ y }}</span>{% when None %}{% endmatch %}
                         {% for sg in self.series_genres(s.id) %}<span class="genre-tag">{{ sg.name_cs }}</span>{% endfor %}
@@ -705,8 +705,8 @@ function doSearch() {
                                 : '<div class="si-placeholder"></div>';
                             var yr = r.year ? ' (' + r.year + ')' : '';
                             var ratParts = [];
-                            if (r.tmdb_rating) ratParts.push('TMDB ' + r.tmdb_rating);
-                            if (r.imdb_rating) ratParts.push('IMDb ' + r.imdb_rating);
+                            if (r.tmdb_rating) ratParts.push('TMDB ' + r.tmdb_rating.toFixed(1));
+                            if (r.imdb_rating) ratParts.push('IMDb ' + r.imdb_rating.toFixed(1));
                             var rat = ratParts.length ? ' — ' + ratParts.join(' · ') : '';
                             return '<a href="/serialy-online/' + r.slug + '/" class="search-item" title="' + r.title + '">'
                                 + cover + '<div class="si-info"><span class="si-title">' + r.title + yr + '</span>'

--- a/cr-web/templates/tv_porad_detail.html
+++ b/cr-web/templates/tv_porad_detail.html
@@ -67,7 +67,10 @@
             {% when None %}{% endmatch %}
             <div class="meta-row">
                 {% match show.tmdb_rating %}
-                {% when Some with (r) %}<span class="meta-badge imdb" title="TMDB hodnocení">TMDB {{ r }}</span>
+                {% when Some with (r) %}<span class="meta-badge tmdb" title="TMDB hodnocení">TMDB {{ r }}</span>
+                {% when None %}{% endmatch %}
+                {% match show.imdb_rating %}
+                {% when Some with (r) %}<span class="meta-badge imdb" title="IMDb hodnocení">IMDb {{ r }}</span>
                 {% when None %}{% endmatch %}
                 {% match show.csfd_rating %}
                 {% when Some with (r) %}<span class="meta-badge csfd" title="ČSFD hodnocení">ČSFD {{ r }}%</span>
@@ -136,6 +139,7 @@
 .original-title { color: #888; font-style: italic; margin: 0 0 0.6rem; font-size: 0.9rem; }
 .meta-row { display: flex; gap: 0.4rem; margin-bottom: 0.8rem; }
 .meta-badge { padding: 0.2rem 0.5rem; border-radius: 4px; font-size: 0.82rem; font-weight: 600; }
+.meta-badge.tmdb { background: #01b4e4; color: #fff; }
 .meta-badge.imdb { background: #f5c518; color: #000; }
 .meta-badge.csfd { background: #ba0305; color: #fff; }
 .film-description { line-height: 1.6; color: #333; }

--- a/cr-web/templates/tv_porad_detail.html
+++ b/cr-web/templates/tv_porad_detail.html
@@ -67,10 +67,10 @@
             {% when None %}{% endmatch %}
             <div class="meta-row">
                 {% match show.tmdb_rating %}
-                {% when Some with (r) %}<span class="meta-badge tmdb" title="TMDB hodnocení">TMDB {{ r }}</span>
+                {% when Some with (r) %}<span class="meta-badge tmdb" title="TMDB hodnocení">TMDB {{ "{:.1}"|format(r) }}</span>
                 {% when None %}{% endmatch %}
                 {% match show.imdb_rating %}
-                {% when Some with (r) %}<span class="meta-badge imdb" title="IMDb hodnocení">IMDb {{ r }}</span>
+                {% when Some with (r) %}<span class="meta-badge imdb" title="IMDb hodnocení">IMDb {{ "{:.1}"|format(r) }}</span>
                 {% when None %}{% endmatch %}
                 {% match show.csfd_rating %}
                 {% when Some with (r) %}<span class="meta-badge csfd" title="ČSFD hodnocení">ČSFD {{ r }}%</span>

--- a/cr-web/templates/tv_porad_detail.html
+++ b/cr-web/templates/tv_porad_detail.html
@@ -75,6 +75,10 @@
                 {% match show.csfd_rating %}
                 {% when Some with (r) %}<span class="meta-badge csfd" title="ČSFD hodnocení">ČSFD {{ r }}%</span>
                 {% when None %}{% endmatch %}
+                {# Fallback when no rating source has a value (#593 acceptance criterion). #}
+                {% if show.tmdb_rating.is_none() && show.imdb_rating.is_none() && show.csfd_rating.is_none() %}
+                <span class="meta-badge none">Bez hodnocení</span>
+                {% endif %}
             </div>
             {% match show.description %}
             {% when Some with (d) %}<div class="film-description"><p>{{ d }}</p></div>
@@ -142,6 +146,7 @@
 .meta-badge.tmdb { background: #01b4e4; color: #fff; }
 .meta-badge.imdb { background: #f5c518; color: #000; }
 .meta-badge.csfd { background: #ba0305; color: #fff; }
+.meta-badge.none { background: #eef2f7; color: #6b7785; font-style: italic; }
 .film-description { line-height: 1.6; color: #333; }
 
 .seasons-header { display: flex; justify-content: space-between; align-items: center; margin: 1rem 0 0.8rem; }

--- a/cr-web/templates/tv_porady_list.html
+++ b/cr-web/templates/tv_porady_list.html
@@ -81,9 +81,9 @@
             <div class="rating-badges">
                 {# Card view: show all available ratings stacked (#593) #}
                 {% match ep.tv_show_tmdb_rating %}
-                {% when Some with (r) %}<span class="rating-badge tmdb" title="TMDB hodnocení">TMDB {{ r }}</span>{% when None %}{% endmatch %}
+                {% when Some with (r) %}<span class="rating-badge tmdb" title="TMDB hodnocení">TMDB {{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
                 {% match ep.tv_show_imdb_rating %}
-                {% when Some with (r) %}<span class="rating-badge imdb" title="IMDb hodnocení">IMDb {{ r }}</span>{% when None %}{% endmatch %}
+                {% when Some with (r) %}<span class="rating-badge imdb" title="IMDb hodnocení">IMDb {{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
                 {% match ep.tv_show_csfd_rating %}
                 {% when Some with (r) %}<span class="rating-badge csfd" title="ČSFD hodnocení">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
             </div>
@@ -99,8 +99,8 @@
             </div>
             <div class="film-list-extra">
                 <div class="film-ratings">
-                    {% match ep.tv_show_tmdb_rating %}{% when Some with (r) %}<span class="badge tmdb">TMDB {{ r }}</span>{% when None %}{% endmatch %}
-                    {% match ep.tv_show_imdb_rating %}{% when Some with (r) %}<span class="badge imdb">IMDb {{ r }}</span>{% when None %}{% endmatch %}
+                    {% match ep.tv_show_tmdb_rating %}{% when Some with (r) %}<span class="badge tmdb">TMDB {{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
+                    {% match ep.tv_show_imdb_rating %}{% when Some with (r) %}<span class="badge imdb">IMDb {{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
                     {% match ep.tv_show_csfd_rating %}{% when Some with (r) %}<span class="badge csfd">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
                     {% match ep.tv_show_first_air_year %}{% when Some with (y) %}<span class="badge year">{{ y }}</span>{% when None %}{% endmatch %}
                 </div>
@@ -117,8 +117,8 @@
         <div class="film-poster">
             <img src="/tv-porady/{{ s.slug }}.webp" alt="{{ s.title }}" title="{{ s.title }}" loading="lazy" width="200" height="300">
             <div class="rating-badges">
-                {% match s.tmdb_rating %}{% when Some with (r) %}<span class="rating-badge tmdb" title="TMDB hodnocení">TMDB {{ r }}</span>{% when None %}{% endmatch %}
-                {% match s.imdb_rating %}{% when Some with (r) %}<span class="rating-badge imdb" title="IMDb hodnocení">IMDb {{ r }}</span>{% when None %}{% endmatch %}
+                {% match s.tmdb_rating %}{% when Some with (r) %}<span class="rating-badge tmdb" title="TMDB hodnocení">TMDB {{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
+                {% match s.imdb_rating %}{% when Some with (r) %}<span class="rating-badge imdb" title="IMDb hodnocení">IMDb {{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
                 {% match s.csfd_rating %}{% when Some with (r) %}<span class="rating-badge csfd" title="ČSFD hodnocení">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
             </div>
         </div>
@@ -130,8 +130,8 @@
             </div>
             <div class="film-list-extra">
                 <div class="film-ratings">
-                    {% match s.tmdb_rating %}{% when Some with (r) %}<span class="badge tmdb">TMDB {{ r }}</span>{% when None %}{% endmatch %}
-                    {% match s.imdb_rating %}{% when Some with (r) %}<span class="badge imdb">IMDb {{ r }}</span>{% when None %}{% endmatch %}
+                    {% match s.tmdb_rating %}{% when Some with (r) %}<span class="badge tmdb">TMDB {{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
+                    {% match s.imdb_rating %}{% when Some with (r) %}<span class="badge imdb">IMDb {{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
                     {% match s.csfd_rating %}{% when Some with (r) %}<span class="badge csfd">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
                 </div>
                 {% match s.description %}{% when Some with (d) %}<p class="film-desc">{{ d }}</p>{% when None %}{% endmatch %}
@@ -329,8 +329,8 @@ function applySortCombined(v) {
             var meta = document.createElement('span');
             meta.className = 'si-meta';
             var ratParts = [];
-            if (r.tmdb_rating) ratParts.push('TMDB ' + r.tmdb_rating);
-            if (r.imdb_rating) ratParts.push('IMDb ' + r.imdb_rating);
+            if (r.tmdb_rating) ratParts.push('TMDB ' + r.tmdb_rating.toFixed(1));
+            if (r.imdb_rating) ratParts.push('IMDb ' + r.imdb_rating.toFixed(1));
             meta.textContent = ratParts.length ? ' — ' + ratParts.join(' · ') : '';
             info.appendChild(title);
             info.appendChild(meta);

--- a/cr-web/templates/tv_porady_list.html
+++ b/cr-web/templates/tv_porady_list.html
@@ -79,8 +79,14 @@
         <div class="film-poster">
             <img src="/tv-porady/{{ ep.tv_show_slug }}.webp" alt="{{ ep.tv_show_title }}" title="{{ ep.tv_show_title }}" loading="lazy" width="200" height="300">
             <div class="rating-badges">
+                {# Card view: TMDB primary, IMDb fallback (#593) #}
                 {% match ep.tv_show_tmdb_rating %}
-                {% when Some with (r) %}<span class="rating-badge imdb" title="TMDB hodnocení">{{ r }}</span>{% when None %}{% endmatch %}
+                {% when Some with (r) %}<span class="rating-badge tmdb" title="TMDB hodnocení">{{ r }}</span>
+                {% when None %}
+                    {% match ep.tv_show_imdb_rating %}
+                    {% when Some with (r) %}<span class="rating-badge imdb" title="IMDb hodnocení">{{ r }}</span>
+                    {% when None %}{% endmatch %}
+                {% endmatch %}
                 {% match ep.tv_show_csfd_rating %}
                 {% when Some with (r) %}<span class="rating-badge csfd" title="ČSFD hodnocení">{{ r }}%</span>{% when None %}{% endmatch %}
             </div>
@@ -96,7 +102,8 @@
             </div>
             <div class="film-list-extra">
                 <div class="film-ratings">
-                    {% match ep.tv_show_tmdb_rating %}{% when Some with (r) %}<span class="badge imdb">TMDB {{ r }}</span>{% when None %}{% endmatch %}
+                    {% match ep.tv_show_tmdb_rating %}{% when Some with (r) %}<span class="badge tmdb">TMDB {{ r }}</span>{% when None %}{% endmatch %}
+                    {% match ep.tv_show_imdb_rating %}{% when Some with (r) %}<span class="badge imdb">IMDb {{ r }}</span>{% when None %}{% endmatch %}
                     {% match ep.tv_show_csfd_rating %}{% when Some with (r) %}<span class="badge csfd">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
                     {% match ep.tv_show_first_air_year %}{% when Some with (y) %}<span class="badge year">{{ y }}</span>{% when None %}{% endmatch %}
                 </div>
@@ -113,7 +120,13 @@
         <div class="film-poster">
             <img src="/tv-porady/{{ s.slug }}.webp" alt="{{ s.title }}" title="{{ s.title }}" loading="lazy" width="200" height="300">
             <div class="rating-badges">
-                {% match s.tmdb_rating %}{% when Some with (r) %}<span class="rating-badge imdb" title="TMDB hodnocení">{{ r }}</span>{% when None %}{% endmatch %}
+                {% match s.tmdb_rating %}
+                {% when Some with (r) %}<span class="rating-badge tmdb" title="TMDB hodnocení">{{ r }}</span>
+                {% when None %}
+                    {% match s.imdb_rating %}
+                    {% when Some with (r) %}<span class="rating-badge imdb" title="IMDb hodnocení">{{ r }}</span>
+                    {% when None %}{% endmatch %}
+                {% endmatch %}
                 {% match s.csfd_rating %}{% when Some with (r) %}<span class="rating-badge csfd" title="ČSFD hodnocení">{{ r }}%</span>{% when None %}{% endmatch %}
             </div>
         </div>
@@ -125,7 +138,8 @@
             </div>
             <div class="film-list-extra">
                 <div class="film-ratings">
-                    {% match s.tmdb_rating %}{% when Some with (r) %}<span class="badge imdb">TMDB {{ r }}</span>{% when None %}{% endmatch %}
+                    {% match s.tmdb_rating %}{% when Some with (r) %}<span class="badge tmdb">TMDB {{ r }}</span>{% when None %}{% endmatch %}
+                    {% match s.imdb_rating %}{% when Some with (r) %}<span class="badge imdb">IMDb {{ r }}</span>{% when None %}{% endmatch %}
                     {% match s.csfd_rating %}{% when Some with (r) %}<span class="badge csfd">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
                 </div>
                 {% match s.description %}{% when Some with (d) %}<p class="film-desc">{{ d }}</p>{% when None %}{% endmatch %}
@@ -182,6 +196,7 @@
 .no-poster { width: 100%; height: 100%; display: flex; align-items: center; justify-content: center; color: #888; padding: 1rem; text-align: center; }
 .rating-badges { position: absolute; top: 0.4rem; left: 0.4rem; display: flex; gap: 0.25rem; }
 .rating-badge { padding: 0.15rem 0.4rem; border-radius: 4px; font-size: 0.7rem; font-weight: 700; box-shadow: 0 1px 3px rgba(0,0,0,0.3); }
+.rating-badge.tmdb { background: #01b4e4; color: #fff; }
 .rating-badge.imdb { background: #f5c518; color: #000; }
 .rating-badge.csfd { background: #b01020; color: #fff; }
 .cc-badge { position: absolute; bottom: 0.4rem; right: 0.4rem; background: #4ade80; color: #003c1c; padding: 0.1rem 0.4rem; border-radius: 4px; font-size: 0.7rem; font-weight: 700; letter-spacing: 0.03em; box-shadow: 0 1px 3px rgba(0,0,0,0.3); }
@@ -195,6 +210,7 @@
 .film-list-extra { display: none; }
 .film-ratings { display: flex; gap: 0.3rem; margin: 0.3rem 0; flex-wrap: wrap; }
 .badge { font-size: 0.72rem; padding: 0.1rem 0.4rem; border-radius: 4px; font-weight: 600; }
+.badge.tmdb { background: #01b4e4; color: #fff; }
 .badge.imdb { background: #f5c518; color: #000; }
 .badge.csfd { background: #b01020; color: #fff; }
 .badge.year { background: #e2e8f0; color: #333; }
@@ -320,7 +336,10 @@ function applySortCombined(v) {
             title.textContent = r.title + (r.year ? ' (' + r.year + ')' : '');
             var meta = document.createElement('span');
             meta.className = 'si-meta';
-            meta.textContent = r.tmdb_rating ? ' — TMDB ' + r.tmdb_rating : '';
+            var ratParts = [];
+            if (r.tmdb_rating) ratParts.push('TMDB ' + r.tmdb_rating);
+            if (r.imdb_rating) ratParts.push('IMDb ' + r.imdb_rating);
+            meta.textContent = ratParts.length ? ' — ' + ratParts.join(' · ') : '';
             info.appendChild(title);
             info.appendChild(meta);
             item.appendChild(info);

--- a/cr-web/templates/tv_porady_list.html
+++ b/cr-web/templates/tv_porady_list.html
@@ -79,16 +79,13 @@
         <div class="film-poster">
             <img src="/tv-porady/{{ ep.tv_show_slug }}.webp" alt="{{ ep.tv_show_title }}" title="{{ ep.tv_show_title }}" loading="lazy" width="200" height="300">
             <div class="rating-badges">
-                {# Card view: TMDB primary, IMDb fallback (#593) #}
+                {# Card view: show all available ratings stacked (#593) #}
                 {% match ep.tv_show_tmdb_rating %}
-                {% when Some with (r) %}<span class="rating-badge tmdb" title="TMDB hodnocení">{{ r }}</span>
-                {% when None %}
-                    {% match ep.tv_show_imdb_rating %}
-                    {% when Some with (r) %}<span class="rating-badge imdb" title="IMDb hodnocení">{{ r }}</span>
-                    {% when None %}{% endmatch %}
-                {% endmatch %}
+                {% when Some with (r) %}<span class="rating-badge tmdb" title="TMDB hodnocení">TMDB {{ r }}</span>{% when None %}{% endmatch %}
+                {% match ep.tv_show_imdb_rating %}
+                {% when Some with (r) %}<span class="rating-badge imdb" title="IMDb hodnocení">IMDb {{ r }}</span>{% when None %}{% endmatch %}
                 {% match ep.tv_show_csfd_rating %}
-                {% when Some with (r) %}<span class="rating-badge csfd" title="ČSFD hodnocení">{{ r }}%</span>{% when None %}{% endmatch %}
+                {% when Some with (r) %}<span class="rating-badge csfd" title="ČSFD hodnocení">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
             </div>
             {% if ep.has_subtitles.unwrap_or(false) %}
             <span class="cc-badge" title="České titulky">CC</span>
@@ -120,14 +117,9 @@
         <div class="film-poster">
             <img src="/tv-porady/{{ s.slug }}.webp" alt="{{ s.title }}" title="{{ s.title }}" loading="lazy" width="200" height="300">
             <div class="rating-badges">
-                {% match s.tmdb_rating %}
-                {% when Some with (r) %}<span class="rating-badge tmdb" title="TMDB hodnocení">{{ r }}</span>
-                {% when None %}
-                    {% match s.imdb_rating %}
-                    {% when Some with (r) %}<span class="rating-badge imdb" title="IMDb hodnocení">{{ r }}</span>
-                    {% when None %}{% endmatch %}
-                {% endmatch %}
-                {% match s.csfd_rating %}{% when Some with (r) %}<span class="rating-badge csfd" title="ČSFD hodnocení">{{ r }}%</span>{% when None %}{% endmatch %}
+                {% match s.tmdb_rating %}{% when Some with (r) %}<span class="rating-badge tmdb" title="TMDB hodnocení">TMDB {{ r }}</span>{% when None %}{% endmatch %}
+                {% match s.imdb_rating %}{% when Some with (r) %}<span class="rating-badge imdb" title="IMDb hodnocení">IMDb {{ r }}</span>{% when None %}{% endmatch %}
+                {% match s.csfd_rating %}{% when Some with (r) %}<span class="rating-badge csfd" title="ČSFD hodnocení">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
             </div>
         </div>
         <div class="film-body">

--- a/scripts/backfill-tmdb-imdb-ids.py
+++ b/scripts/backfill-tmdb-imdb-ids.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Backfill `imdb_id` from TMDB external_ids for every film/series/tv_show
+that already has `tmdb_id` but no `imdb_id` (#593 follow-up).
+
+Background: the daily IMDb rating sync (#690, scripts/sync-imdb-ratings.py)
+matches our rows against the public IMDb TSV by `imdb_id` — so a film
+without an IMDb ID gets no IMDb rating, no IMDb badge in the UI. The
+initial auto-import populates `imdb_id` for SK Torrent films because
+that's where the TMDB lookup originates, but newer prehraj.to / sledujteto
+imports often skip the second TMDB call that would fetch external_ids.
+
+TMDB exposes IMDb IDs in two places:
+  * `GET /movie/{tmdb_id}/external_ids` — dedicated endpoint, smallest payload.
+  * `GET /movie/{tmdb_id}` — main movie endpoint, the `imdb_id` field is included.
+
+Either works for films; for `series` / `tv_shows` use the `/tv/...` family
+where the same `imdb_id` field appears under external_ids. We hit the
+dedicated external_ids endpoint to keep the payload small.
+
+Idempotent — rows that already have a non-NULL `imdb_id` are skipped by
+the SELECT, so re-running only touches new gaps.
+
+Usage:
+    DATABASE_URL=postgres://... TMDB_API_KEY=... \\
+        python3 scripts/backfill-tmdb-imdb-ids.py \\
+            [--table films|series|tv_shows] [--limit N] [--workers N]
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import logging
+import os
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import psycopg2
+import requests
+
+TMDB_BASE = "https://api.themoviedb.org/3"
+DEFAULT_WORKERS = 8
+
+
+def _fetch_imdb_id(api_key: str, endpoint: str, tmdb_id: int) -> str | None:
+    url = f"{TMDB_BASE}/{endpoint}/{tmdb_id}/external_ids"
+    try:
+        r = requests.get(url, params={"api_key": api_key}, timeout=10)
+    except requests.RequestException as exc:
+        logging.warning("TMDB request failed for %s/%s: %s", endpoint, tmdb_id, exc)
+        return None
+    if r.status_code == 404:
+        return None
+    if not r.ok:
+        logging.warning("TMDB %s/%s returned %s", endpoint, tmdb_id, r.status_code)
+        return None
+    imdb_id = r.json().get("imdb_id")
+    # TMDB returns "" (empty string) for titles missing an IMDb link.
+    # Normalise to None so the UPDATE below treats them as "no result"
+    # rather than wiping the column with an empty string.
+    if not imdb_id:
+        return None
+    return imdb_id
+
+
+def _table_config(table: str) -> str:
+    if table == "films":
+        return "movie"
+    if table in ("series", "tv_shows"):
+        return "tv"
+    raise SystemExit(f"unsupported table: {table}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--table", default="films",
+                        choices=["films", "series", "tv_shows"])
+    parser.add_argument("--limit", type=int, default=0, help="0 = all")
+    parser.add_argument("--workers", type=int, default=DEFAULT_WORKERS)
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO,
+                        format="%(asctime)s %(levelname)s %(message)s")
+
+    dsn = os.environ.get("DATABASE_URL", "").strip()
+    api_key = os.environ.get("TMDB_API_KEY", "").strip()
+    if not dsn:
+        raise SystemExit("DATABASE_URL required")
+    if not api_key:
+        raise SystemExit("TMDB_API_KEY required")
+
+    endpoint = _table_config(args.table)
+    conn = psycopg2.connect(dsn)
+    conn.autocommit = False
+    cur = conn.cursor()
+
+    select_sql = (
+        f"SELECT id, tmdb_id FROM {args.table} "
+        "WHERE tmdb_id IS NOT NULL AND imdb_id IS NULL "
+        "ORDER BY id"
+    )
+    if args.limit:
+        select_sql += f" LIMIT {args.limit}"
+    cur.execute(select_sql)
+    rows = cur.fetchall()
+    logging.info("Backfilling imdb_id for %d %s rows via TMDB %s/external_ids",
+                 len(rows), args.table, endpoint)
+
+    # Some titles already carry an imdb_id on a sibling row (curated /
+    # legacy data). The films table enforces a partial UNIQUE on imdb_id
+    # so a duplicate INSERT/UPDATE would explode the transaction. Guard
+    # with NOT EXISTS in the UPDATE — collision means we have the same
+    # title twice under different tmdb_ids and the human should review.
+    update_sql = (
+        f"UPDATE {args.table} SET imdb_id = %s WHERE id = %s "
+        f"AND NOT EXISTS (SELECT 1 FROM {args.table} t2 "
+        "WHERE t2.imdb_id = %s AND t2.id <> %s)"
+    )
+    counts = collections.Counter()
+
+    def work(row):
+        row_id, tmdb_id = row
+        imdb_id = _fetch_imdb_id(api_key, endpoint, tmdb_id)
+        return row_id, tmdb_id, imdb_id
+
+    with ThreadPoolExecutor(max_workers=args.workers) as pool:
+        futures = [pool.submit(work, r) for r in rows]
+        last_commit = time.monotonic()
+        pending = 0
+        for i, f in enumerate(as_completed(futures), 1):
+            row_id, tmdb_id, imdb_id = f.result()
+            if imdb_id:
+                cur.execute(update_sql, (imdb_id, row_id, imdb_id, row_id))
+                if cur.rowcount:
+                    counts["saved"] += 1
+                else:
+                    counts["duplicate_skipped"] += 1
+                pending += 1
+            else:
+                counts["no_imdb_id"] += 1
+            if pending >= 200 or time.monotonic() - last_commit > 5:
+                conn.commit()
+                pending = 0
+                last_commit = time.monotonic()
+            if i % 500 == 0:
+                logging.info("Progress: %d/%d — saved=%d no_imdb=%d dup=%d",
+                             i, len(rows), counts["saved"],
+                             counts["no_imdb_id"], counts["duplicate_skipped"])
+
+    conn.commit()
+    logging.info("Done — %s", dict(counts))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
<!-- claude-session: abde5913-c371-47e0-8ccf-f9ba99bdf35f -->

Closes #593

## Summary
- **Detail pages** (`film_detail.html`, `series_detail.html`, `tv_porad_detail.html`) now show three rating badges side-by-side:
  - **TMDB** (teal `#01b4e4`)
  - **IMDb** (yellow `#f5c518`)
  - **ČSFD** (red)
  Each conditional on its column being `NOT NULL`.
- **Card view** on list pages (`films_list.html`, `series_list.html`, `tv_porady_list.html`): one primary badge per the issue's preference order — TMDB if present, otherwise IMDb. Distinct brand colors per source.
- **List-view extra panel** + **search autocomplete dropdown** render `TMDB X · IMDb X` together when both exist.
- Handler structs (`FilmRow`, `SeriesRow`, `EpisodeCardRow`, `TvShowRow`, all search row/result types) carry the new `imdb_rating: Option<f32>` field; SQL SELECTs project the column.

## Test plan
- [x] `cargo check`, `cargo clippy -- -D warnings`, `cargo fmt --check` all green locally
- [x] Local cr-web smoke: `/filmy-online/vykoupeni-z-veznice-shawshank/` shows `TMDB 9.3` + `IMDb 9.3` + `ČSFD 64%` badges
- [x] Search API `/api/films/search?q=mat` returns both `tmdb_rating` and `imdb_rating`
- [x] Cross-compiled `cargo zigbuild`, scp'd, restarted prod container — `/health` returns 200
- [x] Playwright on prod `https://ceskarepublika.wiki/filmy-online/jack-a-jill/`: badge list `["TMDB 4.4", "IMDb 3.3", "91 min"]` with correct brand colors (teal/yellow/red)
- [x] Browser console: **0 errors**

## Parent
Sub-issue of #588 (Rating pipeline consolidation). Uses data populated by #690's daily IMDb sync.