### PR TITLE
fix(ratings): drop TMDB/IMDb text prefix in image-form rating badges

### DIFF
--- a/cr-web/templates/episode_detail.html
+++ b/cr-web/templates/episode_detail.html
@@ -645,17 +645,26 @@ function doSearch() {
                 .then(function(results) {
                     if (!results.length) { dd.innerHTML = '<div style="padding:0.8rem;color:#888;text-align:center">Nic nenalezeno</div>'; }
                     else {
+                        var esc = function(s) { return String(s).replace(/[&<>"']/g, function(c) { return ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'})[c]; }); };
                         dd.innerHTML = results.map(function(r) {
+                            var slug = esc(r.slug);
+                            var title = esc(r.title);
                             var cover = r.cover
-                                ? '<img src="/serialy-online/' + r.slug + '.webp" alt="' + r.title + '" title="' + r.title + '">'
+                                ? '<img src="/serialy-online/' + slug + '.webp" alt="' + title + '" title="' + title + '">'
                                 : '<div class="si-placeholder"></div>';
                             var yr = r.year ? ' (' + r.year + ')' : '';
                             var ratParts = [];
-                            if (r.tmdb_rating) ratParts.push('<span class="si-rating tmdb">' + r.tmdb_rating.toFixed(1) + '</span>');
-                            if (r.imdb_rating) ratParts.push('<span class="si-rating imdb">' + r.imdb_rating.toFixed(1) + '</span>');
-                            var rat = ratParts.length ? ' ' + ratParts.join('') : '';
-                            return '<a href="/serialy-online/' + r.slug + '/" class="search-item" title="' + r.title + '" aria-label="' + r.title + '">'
-                                + cover + '<div class="si-info"><span class="si-title">' + r.title + yr + '</span>'
+                            if (r.tmdb_rating) {
+                                var t = r.tmdb_rating.toFixed(1);
+                                ratParts.push('<span class="si-rating tmdb" title="TMDB hodnocení" aria-label="TMDB hodnocení ' + t + '">' + t + '</span>');
+                            }
+                            if (r.imdb_rating) {
+                                var i = r.imdb_rating.toFixed(1);
+                                ratParts.push('<span class="si-rating imdb" title="IMDb hodnocení" aria-label="IMDb hodnocení ' + i + '">' + i + '</span>');
+                            }
+                            var rat = ratParts.join('');
+                            return '<a href="/serialy-online/' + slug + '/" class="search-item" title="' + title + '" aria-label="' + title + '">'
+                                + cover + '<div class="si-info"><span class="si-title">' + title + yr + '</span>'
                                 + '<span class="si-meta">' + rat + '</span></div></a>';
                         }).join('');
                     }

--- a/cr-web/templates/episode_detail.html
+++ b/cr-web/templates/episode_detail.html
@@ -134,7 +134,10 @@
 .search-item .si-placeholder { width: 40px; height: 60px; background: #eee; border-radius: 4px; }
 .search-item .si-info { flex: 1; min-width: 0; }
 .search-item .si-title { font-weight: 500; display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.search-item .si-meta { font-size: 0.8rem; color: #888; }
+.search-item .si-meta { font-size: 0.8rem; color: #888; display: flex; gap: 0.25rem; align-items: center; }
+.search-item .si-rating { display: inline-block; padding: 0.05rem 0.35rem; border-radius: 3px; font-size: 0.72rem; font-weight: 700; }
+.search-item .si-rating.tmdb { background: #01b4e4; color: #fff; }
+.search-item .si-rating.imdb { background: #f5c518; color: #000; }
 
 /* Player */
 .player-section { margin-bottom: 1.5rem; }
@@ -648,9 +651,9 @@ function doSearch() {
                                 : '<div class="si-placeholder"></div>';
                             var yr = r.year ? ' (' + r.year + ')' : '';
                             var ratParts = [];
-                            if (r.tmdb_rating) ratParts.push('TMDB ' + r.tmdb_rating.toFixed(1));
-                            if (r.imdb_rating) ratParts.push('IMDb ' + r.imdb_rating.toFixed(1));
-                            var rat = ratParts.length ? ' — ' + ratParts.join(' · ') : '';
+                            if (r.tmdb_rating) ratParts.push('<span class="si-rating tmdb">' + r.tmdb_rating.toFixed(1) + '</span>');
+                            if (r.imdb_rating) ratParts.push('<span class="si-rating imdb">' + r.imdb_rating.toFixed(1) + '</span>');
+                            var rat = ratParts.length ? ' ' + ratParts.join('') : '';
                             return '<a href="/serialy-online/' + r.slug + '/" class="search-item" title="' + r.title + '" aria-label="' + r.title + '">'
                                 + cover + '<div class="si-info"><span class="si-title">' + r.title + yr + '</span>'
                                 + '<span class="si-meta">' + rat + '</span></div></a>';

--- a/cr-web/templates/film_detail.html
+++ b/cr-web/templates/film_detail.html
@@ -789,17 +789,26 @@ function doSearch() {
                     if (!results.length) {
                         dd.innerHTML = '<div style="padding:0.8rem;color:#888;text-align:center">Nic nenalezeno</div>';
                     } else {
+                        var esc = function(s) { return String(s).replace(/[&<>"']/g, function(c) { return ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'})[c]; }); };
                         dd.innerHTML = results.map(function(r) {
+                            var slug = esc(r.slug);
+                            var title = esc(r.title);
                             var cover = r.cover
-                                ? '<img src="/filmy-online/' + r.slug + '.webp" alt="">'
+                                ? '<img src="/filmy-online/' + slug + '.webp" alt="">'
                                 : '<div class="si-placeholder"></div>';
                             var yr = r.year ? ' (' + r.year + ')' : '';
                             var ratParts = [];
-                            if (r.tmdb_rating) ratParts.push('<span class="si-rating tmdb">' + r.tmdb_rating.toFixed(1) + '</span>');
-                            if (r.imdb_rating) ratParts.push('<span class="si-rating imdb">' + r.imdb_rating.toFixed(1) + '</span>');
-                            var rat = ratParts.length ? ' ' + ratParts.join('') : '';
-                            return '<a href="/filmy-online/' + r.slug + '/" class="search-item">'
-                                + cover + '<div class="si-info"><span class="si-title">' + r.title + yr + '</span>'
+                            if (r.tmdb_rating) {
+                                var t = r.tmdb_rating.toFixed(1);
+                                ratParts.push('<span class="si-rating tmdb" title="TMDB hodnocení" aria-label="TMDB hodnocení ' + t + '">' + t + '</span>');
+                            }
+                            if (r.imdb_rating) {
+                                var i = r.imdb_rating.toFixed(1);
+                                ratParts.push('<span class="si-rating imdb" title="IMDb hodnocení" aria-label="IMDb hodnocení ' + i + '">' + i + '</span>');
+                            }
+                            var rat = ratParts.join('');
+                            return '<a href="/filmy-online/' + slug + '/" class="search-item">'
+                                + cover + '<div class="si-info"><span class="si-title">' + title + yr + '</span>'
                                 + '<span class="si-meta">' + rat + '</span></div></a>';
                         }).join('');
                     }

--- a/cr-web/templates/film_detail.html
+++ b/cr-web/templates/film_detail.html
@@ -262,7 +262,10 @@
 .search-item .si-placeholder { width: 40px; height: 60px; background: #eee; border-radius: 4px; flex-shrink: 0; }
 .search-item .si-info { flex: 1; min-width: 0; }
 .search-item .si-title { font-weight: 500; display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.search-item .si-meta { font-size: 0.8rem; color: #888; }
+.search-item .si-meta { font-size: 0.8rem; color: #888; display: flex; gap: 0.25rem; align-items: center; }
+.search-item .si-rating { display: inline-block; padding: 0.05rem 0.35rem; border-radius: 3px; font-size: 0.72rem; font-weight: 700; }
+.search-item .si-rating.tmdb { background: #01b4e4; color: #fff; }
+.search-item .si-rating.imdb { background: #f5c518; color: #000; }
 
 /* Breadcrumb */
 .breadcrumb { font-size: 0.85rem; color: #888; margin-bottom: 1.2rem; }
@@ -792,9 +795,9 @@ function doSearch() {
                                 : '<div class="si-placeholder"></div>';
                             var yr = r.year ? ' (' + r.year + ')' : '';
                             var ratParts = [];
-                            if (r.tmdb_rating) ratParts.push('TMDB ' + r.tmdb_rating.toFixed(1));
-                            if (r.imdb_rating) ratParts.push('IMDb ' + r.imdb_rating.toFixed(1));
-                            var rat = ratParts.length ? ' — ' + ratParts.join(' · ') : '';
+                            if (r.tmdb_rating) ratParts.push('<span class="si-rating tmdb">' + r.tmdb_rating.toFixed(1) + '</span>');
+                            if (r.imdb_rating) ratParts.push('<span class="si-rating imdb">' + r.imdb_rating.toFixed(1) + '</span>');
+                            var rat = ratParts.length ? ' ' + ratParts.join('') : '';
                             return '<a href="/filmy-online/' + r.slug + '/" class="search-item">'
                                 + cover + '<div class="si-info"><span class="si-title">' + r.title + yr + '</span>'
                                 + '<span class="si-meta">' + rat + '</span></div></a>';

--- a/cr-web/templates/films_list.html
+++ b/cr-web/templates/films_list.html
@@ -242,12 +242,12 @@
                     {# Card view: show TMDB + IMDb + ČSFD stacked (#593). The .rating-badges CSS uses flex-direction: column. #}
                     {% match f.tmdb_rating %}
                     {% when Some with (r) %}
-                    <span class="rating-badge tmdb" title="TMDB hodnocení">TMDB {{ "{:.1}"|format(r) }}</span>
+                    <span class="rating-badge tmdb" title="TMDB hodnocení">{{ "{:.1}"|format(r) }}</span>
                     {% when None %}
                     {% endmatch %}
                     {% match f.imdb_rating %}
                     {% when Some with (r) %}
-                    <span class="rating-badge imdb" title="IMDb hodnocení">IMDb {{ "{:.1}"|format(r) }}</span>
+                    <span class="rating-badge imdb" title="IMDb hodnocení">{{ "{:.1}"|format(r) }}</span>
                     {% when None %}
                     {% endmatch %}
                     {% match f.csfd_rating %}
@@ -330,7 +330,10 @@
 .search-item .si-placeholder { width: 40px; height: 60px; background: #eee; border-radius: 4px; flex-shrink: 0; }
 .search-item .si-info { flex: 1; min-width: 0; }
 .search-item .si-title { font-weight: 500; display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.search-item .si-meta { font-size: 0.8rem; color: #888; }
+.search-item .si-meta { font-size: 0.8rem; color: #888; display: flex; gap: 0.25rem; align-items: center; }
+.search-item .si-rating { display: inline-block; padding: 0.05rem 0.35rem; border-radius: 3px; font-size: 0.72rem; font-weight: 700; }
+.search-item .si-rating.tmdb { background: #01b4e4; color: #fff; }
+.search-item .si-rating.imdb { background: #f5c518; color: #000; }
 
 /* --- Header + toolbar --- */
 .films-header { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 0.8rem; }
@@ -856,9 +859,9 @@ function doSearch() {
                                 : '<div class="si-placeholder"></div>';
                             var yr = r.year ? ' (' + r.year + ')' : '';
                             var ratParts = [];
-                            if (r.tmdb_rating) ratParts.push('TMDB ' + r.tmdb_rating.toFixed(1));
-                            if (r.imdb_rating) ratParts.push('IMDb ' + r.imdb_rating.toFixed(1));
-                            var rat = ratParts.length ? ' — ' + ratParts.join(' · ') : '';
+                            if (r.tmdb_rating) ratParts.push('<span class="si-rating tmdb">' + r.tmdb_rating.toFixed(1) + '</span>');
+                            if (r.imdb_rating) ratParts.push('<span class="si-rating imdb">' + r.imdb_rating.toFixed(1) + '</span>');
+                            var rat = ratParts.length ? ' ' + ratParts.join('') : '';
                             return '<a href="/filmy-online/' + r.slug + '/" class="search-item">'
                                 + cover + '<div class="si-info"><span class="si-title">' + r.title + yr + '</span>'
                                 + '<span class="si-meta">' + rat + '</span></div></a>';

--- a/cr-web/templates/films_list.html
+++ b/cr-web/templates/films_list.html
@@ -242,12 +242,12 @@
                     {# Card view: show TMDB + IMDb + ČSFD stacked (#593). The .rating-badges CSS uses flex-direction: column. #}
                     {% match f.tmdb_rating %}
                     {% when Some with (r) %}
-                    <span class="rating-badge tmdb" title="TMDB hodnocení">{{ "{:.1}"|format(r) }}</span>
+                    <span class="rating-badge tmdb" title="TMDB hodnocení" aria-label="TMDB hodnocení {{ "{:.1}"|format(r) }}">{{ "{:.1}"|format(r) }}</span>
                     {% when None %}
                     {% endmatch %}
                     {% match f.imdb_rating %}
                     {% when Some with (r) %}
-                    <span class="rating-badge imdb" title="IMDb hodnocení">{{ "{:.1}"|format(r) }}</span>
+                    <span class="rating-badge imdb" title="IMDb hodnocení" aria-label="IMDb hodnocení {{ "{:.1}"|format(r) }}">{{ "{:.1}"|format(r) }}</span>
                     {% when None %}
                     {% endmatch %}
                     {% match f.csfd_rating %}
@@ -853,17 +853,31 @@ function doSearch() {
                     if (!results.length) {
                         dd.innerHTML = '<div style="padding:0.8rem;color:#888;text-align:center">Nic nenalezeno</div>';
                     } else {
+                        // Escape HTML-special chars from user-visible fields so a title
+                        // like `<script>` or `It's "fine"` can't break out of the
+                        // attribute / text context we splice it into below.
+                        var esc = function(s) { return String(s).replace(/[&<>"']/g, function(c) { return ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'})[c]; }); };
                         dd.innerHTML = results.map(function(r) {
+                            var slug = esc(r.slug);
+                            var title = esc(r.title);
                             var cover = r.cover
-                                ? '<img src="/filmy-online/' + r.slug + '.webp" alt="">'
+                                ? '<img src="/filmy-online/' + slug + '.webp" alt="">'
                                 : '<div class="si-placeholder"></div>';
                             var yr = r.year ? ' (' + r.year + ')' : '';
                             var ratParts = [];
-                            if (r.tmdb_rating) ratParts.push('<span class="si-rating tmdb">' + r.tmdb_rating.toFixed(1) + '</span>');
-                            if (r.imdb_rating) ratParts.push('<span class="si-rating imdb">' + r.imdb_rating.toFixed(1) + '</span>');
-                            var rat = ratParts.length ? ' ' + ratParts.join('') : '';
-                            return '<a href="/filmy-online/' + r.slug + '/" class="search-item">'
-                                + cover + '<div class="si-info"><span class="si-title">' + r.title + yr + '</span>'
+                            if (r.tmdb_rating) {
+                                var t = r.tmdb_rating.toFixed(1);
+                                ratParts.push('<span class="si-rating tmdb" title="TMDB hodnocení" aria-label="TMDB hodnocení ' + t + '">' + t + '</span>');
+                            }
+                            if (r.imdb_rating) {
+                                var i = r.imdb_rating.toFixed(1);
+                                ratParts.push('<span class="si-rating imdb" title="IMDb hodnocení" aria-label="IMDb hodnocení ' + i + '">' + i + '</span>');
+                            }
+                            // No leading space — .si-meta is display:flex with gap, so
+                            // a stray text node would render as an extra flex child.
+                            var rat = ratParts.join('');
+                            return '<a href="/filmy-online/' + slug + '/" class="search-item">'
+                                + cover + '<div class="si-info"><span class="si-title">' + title + yr + '</span>'
                                 + '<span class="si-meta">' + rat + '</span></div></a>';
                         }).join('');
                     }

--- a/cr-web/templates/series_detail.html
+++ b/cr-web/templates/series_detail.html
@@ -319,17 +319,26 @@ function doSearch() {
                 .then(function(results) {
                     if (!results.length) { dd.innerHTML = '<div style="padding:0.8rem;color:#888;text-align:center">Nic nenalezeno</div>'; }
                     else {
+                        var esc = function(s) { return String(s).replace(/[&<>"']/g, function(c) { return ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'})[c]; }); };
                         dd.innerHTML = results.map(function(r) {
+                            var slug = esc(r.slug);
+                            var title = esc(r.title);
                             var cover = r.cover
-                                ? '<img src="/serialy-online/' + r.slug + '.webp" alt="' + r.title + '" title="' + r.title + '">'
+                                ? '<img src="/serialy-online/' + slug + '.webp" alt="' + title + '" title="' + title + '">'
                                 : '<div class="si-placeholder"></div>';
                             var yr = r.year ? ' (' + r.year + ')' : '';
                             var ratParts = [];
-                            if (r.tmdb_rating) ratParts.push('<span class="si-rating tmdb">' + r.tmdb_rating.toFixed(1) + '</span>');
-                            if (r.imdb_rating) ratParts.push('<span class="si-rating imdb">' + r.imdb_rating.toFixed(1) + '</span>');
-                            var rat = ratParts.length ? ' ' + ratParts.join('') : '';
-                            return '<a href="/serialy-online/' + r.slug + '/" class="search-item" title="' + r.title + '" aria-label="' + r.title + '">'
-                                + cover + '<div class="si-info"><span class="si-title">' + r.title + yr + '</span>'
+                            if (r.tmdb_rating) {
+                                var t = r.tmdb_rating.toFixed(1);
+                                ratParts.push('<span class="si-rating tmdb" title="TMDB hodnocení" aria-label="TMDB hodnocení ' + t + '">' + t + '</span>');
+                            }
+                            if (r.imdb_rating) {
+                                var i = r.imdb_rating.toFixed(1);
+                                ratParts.push('<span class="si-rating imdb" title="IMDb hodnocení" aria-label="IMDb hodnocení ' + i + '">' + i + '</span>');
+                            }
+                            var rat = ratParts.join('');
+                            return '<a href="/serialy-online/' + slug + '/" class="search-item" title="' + title + '" aria-label="' + title + '">'
+                                + cover + '<div class="si-info"><span class="si-title">' + title + yr + '</span>'
                                 + '<span class="si-meta">' + rat + '</span></div></a>';
                         }).join('');
                     }

--- a/cr-web/templates/series_detail.html
+++ b/cr-web/templates/series_detail.html
@@ -188,7 +188,10 @@
 .search-item .si-placeholder { width: 40px; height: 60px; background: #eee; border-radius: 4px; }
 .search-item .si-info { flex: 1; min-width: 0; }
 .search-item .si-title { font-weight: 500; display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.search-item .si-meta { font-size: 0.8rem; color: #888; }
+.search-item .si-meta { font-size: 0.8rem; color: #888; display: flex; gap: 0.25rem; align-items: center; }
+.search-item .si-rating { display: inline-block; padding: 0.05rem 0.35rem; border-radius: 3px; font-size: 0.72rem; font-weight: 700; }
+.search-item .si-rating.tmdb { background: #01b4e4; color: #fff; }
+.search-item .si-rating.imdb { background: #f5c518; color: #000; }
 
 .film-hero { display: flex; gap: 1.5rem; margin-bottom: 1.5rem; }
 @media (max-width: 600px) { .film-hero { flex-direction: column; align-items: center; } }
@@ -322,9 +325,9 @@ function doSearch() {
                                 : '<div class="si-placeholder"></div>';
                             var yr = r.year ? ' (' + r.year + ')' : '';
                             var ratParts = [];
-                            if (r.tmdb_rating) ratParts.push('TMDB ' + r.tmdb_rating.toFixed(1));
-                            if (r.imdb_rating) ratParts.push('IMDb ' + r.imdb_rating.toFixed(1));
-                            var rat = ratParts.length ? ' — ' + ratParts.join(' · ') : '';
+                            if (r.tmdb_rating) ratParts.push('<span class="si-rating tmdb">' + r.tmdb_rating.toFixed(1) + '</span>');
+                            if (r.imdb_rating) ratParts.push('<span class="si-rating imdb">' + r.imdb_rating.toFixed(1) + '</span>');
+                            var rat = ratParts.length ? ' ' + ratParts.join('') : '';
                             return '<a href="/serialy-online/' + r.slug + '/" class="search-item" title="' + r.title + '" aria-label="' + r.title + '">'
                                 + cover + '<div class="si-info"><span class="si-title">' + r.title + yr + '</span>'
                                 + '<span class="si-meta">' + rat + '</span></div></a>';

--- a/cr-web/templates/series_list.html
+++ b/cr-web/templates/series_list.html
@@ -174,9 +174,9 @@
                 <div class="rating-badges">
                     {# Card view: show all available ratings stacked (#593) #}
                     {% match ep.series_tmdb_rating %}
-                    {% when Some with (r) %}<span class="rating-badge tmdb" title="TMDB hodnocení">TMDB {{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
+                    {% when Some with (r) %}<span class="rating-badge tmdb" title="TMDB hodnocení">{{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
                     {% match ep.series_imdb_rating %}
-                    {% when Some with (r) %}<span class="rating-badge imdb" title="IMDb hodnocení">IMDb {{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
+                    {% when Some with (r) %}<span class="rating-badge imdb" title="IMDb hodnocení">{{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
                     {% match ep.series_csfd_rating %}
                     {% when Some with (r) %}<span class="rating-badge csfd" title="ČSFD hodnocení">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
                 </div>
@@ -211,8 +211,8 @@
             <div class="film-poster">
                 <img src="/serialy-online/{{ s.slug }}.webp" alt="{{ s.title }}" title="{{ s.title }}" loading="lazy" width="200" height="300">
                 <div class="rating-badges">
-                    {% match s.tmdb_rating %}{% when Some with (r) %}<span class="rating-badge tmdb" title="TMDB hodnocení">TMDB {{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
-                    {% match s.imdb_rating %}{% when Some with (r) %}<span class="rating-badge imdb" title="IMDb hodnocení">IMDb {{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
+                    {% match s.tmdb_rating %}{% when Some with (r) %}<span class="rating-badge tmdb" title="TMDB hodnocení">{{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
+                    {% match s.imdb_rating %}{% when Some with (r) %}<span class="rating-badge imdb" title="IMDb hodnocení">{{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
                     {% match s.csfd_rating %}{% when Some with (r) %}<span class="rating-badge csfd" title="ČSFD hodnocení">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
                 </div>
             </div>
@@ -276,7 +276,10 @@
 .search-item .si-placeholder { width: 40px; height: 60px; background: #eee; border-radius: 4px; flex-shrink: 0; }
 .search-item .si-info { flex: 1; min-width: 0; }
 .search-item .si-title { font-weight: 500; display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.search-item .si-meta { font-size: 0.8rem; color: #888; }
+.search-item .si-meta { font-size: 0.8rem; color: #888; display: flex; gap: 0.25rem; align-items: center; }
+.search-item .si-rating { display: inline-block; padding: 0.05rem 0.35rem; border-radius: 3px; font-size: 0.72rem; font-weight: 700; }
+.search-item .si-rating.tmdb { background: #01b4e4; color: #fff; }
+.search-item .si-rating.imdb { background: #f5c518; color: #000; }
 
 /* --- Header + toolbar --- */
 .films-header { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 0.8rem; }
@@ -705,9 +708,9 @@ function doSearch() {
                                 : '<div class="si-placeholder"></div>';
                             var yr = r.year ? ' (' + r.year + ')' : '';
                             var ratParts = [];
-                            if (r.tmdb_rating) ratParts.push('TMDB ' + r.tmdb_rating.toFixed(1));
-                            if (r.imdb_rating) ratParts.push('IMDb ' + r.imdb_rating.toFixed(1));
-                            var rat = ratParts.length ? ' — ' + ratParts.join(' · ') : '';
+                            if (r.tmdb_rating) ratParts.push('<span class="si-rating tmdb">' + r.tmdb_rating.toFixed(1) + '</span>');
+                            if (r.imdb_rating) ratParts.push('<span class="si-rating imdb">' + r.imdb_rating.toFixed(1) + '</span>');
+                            var rat = ratParts.length ? ' ' + ratParts.join('') : '';
                             return '<a href="/serialy-online/' + r.slug + '/" class="search-item" title="' + r.title + '">'
                                 + cover + '<div class="si-info"><span class="si-title">' + r.title + yr + '</span>'
                                 + '<span class="si-meta">' + rat + '</span></div></a>';

--- a/cr-web/templates/series_list.html
+++ b/cr-web/templates/series_list.html
@@ -174,9 +174,9 @@
                 <div class="rating-badges">
                     {# Card view: show all available ratings stacked (#593) #}
                     {% match ep.series_tmdb_rating %}
-                    {% when Some with (r) %}<span class="rating-badge tmdb" title="TMDB hodnocení">{{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
+                    {% when Some with (r) %}<span class="rating-badge tmdb" title="TMDB hodnocení" aria-label="TMDB hodnocení {{ "{:.1}"|format(r) }}">{{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
                     {% match ep.series_imdb_rating %}
-                    {% when Some with (r) %}<span class="rating-badge imdb" title="IMDb hodnocení">{{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
+                    {% when Some with (r) %}<span class="rating-badge imdb" title="IMDb hodnocení" aria-label="IMDb hodnocení {{ "{:.1}"|format(r) }}">{{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
                     {% match ep.series_csfd_rating %}
                     {% when Some with (r) %}<span class="rating-badge csfd" title="ČSFD hodnocení">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
                 </div>
@@ -211,8 +211,8 @@
             <div class="film-poster">
                 <img src="/serialy-online/{{ s.slug }}.webp" alt="{{ s.title }}" title="{{ s.title }}" loading="lazy" width="200" height="300">
                 <div class="rating-badges">
-                    {% match s.tmdb_rating %}{% when Some with (r) %}<span class="rating-badge tmdb" title="TMDB hodnocení">{{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
-                    {% match s.imdb_rating %}{% when Some with (r) %}<span class="rating-badge imdb" title="IMDb hodnocení">{{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
+                    {% match s.tmdb_rating %}{% when Some with (r) %}<span class="rating-badge tmdb" title="TMDB hodnocení" aria-label="TMDB hodnocení {{ "{:.1}"|format(r) }}">{{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
+                    {% match s.imdb_rating %}{% when Some with (r) %}<span class="rating-badge imdb" title="IMDb hodnocení" aria-label="IMDb hodnocení {{ "{:.1}"|format(r) }}">{{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
                     {% match s.csfd_rating %}{% when Some with (r) %}<span class="rating-badge csfd" title="ČSFD hodnocení">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
                 </div>
             </div>
@@ -702,17 +702,26 @@ function doSearch() {
                     if (!results.length) {
                         dd.innerHTML = '<div style="padding:0.8rem;color:#888;text-align:center">Nic nenalezeno</div>';
                     } else {
+                        var esc = function(s) { return String(s).replace(/[&<>"']/g, function(c) { return ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'})[c]; }); };
                         dd.innerHTML = results.map(function(r) {
+                            var slug = esc(r.slug);
+                            var title = esc(r.title);
                             var cover = r.cover
-                                ? '<img src="/serialy-online/' + r.slug + '.webp" alt="' + r.title + '" title="' + r.title + '">'
+                                ? '<img src="/serialy-online/' + slug + '.webp" alt="' + title + '" title="' + title + '">'
                                 : '<div class="si-placeholder"></div>';
                             var yr = r.year ? ' (' + r.year + ')' : '';
                             var ratParts = [];
-                            if (r.tmdb_rating) ratParts.push('<span class="si-rating tmdb">' + r.tmdb_rating.toFixed(1) + '</span>');
-                            if (r.imdb_rating) ratParts.push('<span class="si-rating imdb">' + r.imdb_rating.toFixed(1) + '</span>');
-                            var rat = ratParts.length ? ' ' + ratParts.join('') : '';
-                            return '<a href="/serialy-online/' + r.slug + '/" class="search-item" title="' + r.title + '">'
-                                + cover + '<div class="si-info"><span class="si-title">' + r.title + yr + '</span>'
+                            if (r.tmdb_rating) {
+                                var t = r.tmdb_rating.toFixed(1);
+                                ratParts.push('<span class="si-rating tmdb" title="TMDB hodnocení" aria-label="TMDB hodnocení ' + t + '">' + t + '</span>');
+                            }
+                            if (r.imdb_rating) {
+                                var i = r.imdb_rating.toFixed(1);
+                                ratParts.push('<span class="si-rating imdb" title="IMDb hodnocení" aria-label="IMDb hodnocení ' + i + '">' + i + '</span>');
+                            }
+                            var rat = ratParts.join('');
+                            return '<a href="/serialy-online/' + slug + '/" class="search-item" title="' + title + '">'
+                                + cover + '<div class="si-info"><span class="si-title">' + title + yr + '</span>'
                                 + '<span class="si-meta">' + rat + '</span></div></a>';
                         }).join('');
                     }

--- a/cr-web/templates/tv_porady_list.html
+++ b/cr-web/templates/tv_porady_list.html
@@ -81,9 +81,9 @@
             <div class="rating-badges">
                 {# Card view: show all available ratings stacked (#593) #}
                 {% match ep.tv_show_tmdb_rating %}
-                {% when Some with (r) %}<span class="rating-badge tmdb" title="TMDB hodnocení">{{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
+                {% when Some with (r) %}<span class="rating-badge tmdb" title="TMDB hodnocení" aria-label="TMDB hodnocení {{ "{:.1}"|format(r) }}">{{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
                 {% match ep.tv_show_imdb_rating %}
-                {% when Some with (r) %}<span class="rating-badge imdb" title="IMDb hodnocení">{{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
+                {% when Some with (r) %}<span class="rating-badge imdb" title="IMDb hodnocení" aria-label="IMDb hodnocení {{ "{:.1}"|format(r) }}">{{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
                 {% match ep.tv_show_csfd_rating %}
                 {% when Some with (r) %}<span class="rating-badge csfd" title="ČSFD hodnocení">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
             </div>
@@ -117,8 +117,8 @@
         <div class="film-poster">
             <img src="/tv-porady/{{ s.slug }}.webp" alt="{{ s.title }}" title="{{ s.title }}" loading="lazy" width="200" height="300">
             <div class="rating-badges">
-                {% match s.tmdb_rating %}{% when Some with (r) %}<span class="rating-badge tmdb" title="TMDB hodnocení">{{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
-                {% match s.imdb_rating %}{% when Some with (r) %}<span class="rating-badge imdb" title="IMDb hodnocení">{{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
+                {% match s.tmdb_rating %}{% when Some with (r) %}<span class="rating-badge tmdb" title="TMDB hodnocení" aria-label="TMDB hodnocení {{ "{:.1}"|format(r) }}">{{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
+                {% match s.imdb_rating %}{% when Some with (r) %}<span class="rating-badge imdb" title="IMDb hodnocení" aria-label="IMDb hodnocení {{ "{:.1}"|format(r) }}">{{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
                 {% match s.csfd_rating %}{% when Some with (r) %}<span class="rating-badge csfd" title="ČSFD hodnocení">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
             </div>
         </div>
@@ -332,16 +332,21 @@ function applySortCombined(v) {
             var meta = document.createElement('span');
             meta.className = 'si-meta';
             // Build colored badges (image-form display — no TMDB/IMDb text prefix, color does the talking).
+            // `aria-label` carries the source name so screen readers still get "TMDB hodnocení 6.2" / "IMDb hodnocení 7.0".
             if (r.tmdb_rating) {
                 var t = document.createElement('span');
                 t.className = 'si-rating tmdb';
+                t.title = 'TMDB hodnocení';
                 t.textContent = r.tmdb_rating.toFixed(1);
+                t.setAttribute('aria-label', 'TMDB hodnocení ' + r.tmdb_rating.toFixed(1));
                 meta.appendChild(t);
             }
             if (r.imdb_rating) {
                 var i2 = document.createElement('span');
                 i2.className = 'si-rating imdb';
+                i2.title = 'IMDb hodnocení';
                 i2.textContent = r.imdb_rating.toFixed(1);
+                i2.setAttribute('aria-label', 'IMDb hodnocení ' + r.imdb_rating.toFixed(1));
                 meta.appendChild(i2);
             }
             info.appendChild(title);

--- a/cr-web/templates/tv_porady_list.html
+++ b/cr-web/templates/tv_porady_list.html
@@ -81,9 +81,9 @@
             <div class="rating-badges">
                 {# Card view: show all available ratings stacked (#593) #}
                 {% match ep.tv_show_tmdb_rating %}
-                {% when Some with (r) %}<span class="rating-badge tmdb" title="TMDB hodnocení">TMDB {{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
+                {% when Some with (r) %}<span class="rating-badge tmdb" title="TMDB hodnocení">{{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
                 {% match ep.tv_show_imdb_rating %}
-                {% when Some with (r) %}<span class="rating-badge imdb" title="IMDb hodnocení">IMDb {{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
+                {% when Some with (r) %}<span class="rating-badge imdb" title="IMDb hodnocení">{{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
                 {% match ep.tv_show_csfd_rating %}
                 {% when Some with (r) %}<span class="rating-badge csfd" title="ČSFD hodnocení">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
             </div>
@@ -117,8 +117,8 @@
         <div class="film-poster">
             <img src="/tv-porady/{{ s.slug }}.webp" alt="{{ s.title }}" title="{{ s.title }}" loading="lazy" width="200" height="300">
             <div class="rating-badges">
-                {% match s.tmdb_rating %}{% when Some with (r) %}<span class="rating-badge tmdb" title="TMDB hodnocení">TMDB {{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
-                {% match s.imdb_rating %}{% when Some with (r) %}<span class="rating-badge imdb" title="IMDb hodnocení">IMDb {{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
+                {% match s.tmdb_rating %}{% when Some with (r) %}<span class="rating-badge tmdb" title="TMDB hodnocení">{{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
+                {% match s.imdb_rating %}{% when Some with (r) %}<span class="rating-badge imdb" title="IMDb hodnocení">{{ "{:.1}"|format(r) }}</span>{% when None %}{% endmatch %}
                 {% match s.csfd_rating %}{% when Some with (r) %}<span class="rating-badge csfd" title="ČSFD hodnocení">ČSFD {{ r }}%</span>{% when None %}{% endmatch %}
             </div>
         </div>
@@ -229,7 +229,10 @@
 .search-item .si-placeholder { width: 40px; height: 60px; background: #eee; border-radius: 4px; flex-shrink: 0; }
 .search-item .si-info { flex: 1; min-width: 0; }
 .search-item .si-title { font-weight: 500; display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.search-item .si-meta { font-size: 0.8rem; color: #888; }
+.search-item .si-meta { font-size: 0.8rem; color: #888; display: flex; gap: 0.25rem; align-items: center; }
+.search-item .si-rating { display: inline-block; padding: 0.05rem 0.35rem; border-radius: 3px; font-size: 0.72rem; font-weight: 700; }
+.search-item .si-rating.tmdb { background: #01b4e4; color: #fff; }
+.search-item .si-rating.imdb { background: #f5c518; color: #000; }
 </style>
 
 <script>
@@ -328,10 +331,19 @@ function applySortCombined(v) {
             title.textContent = r.title + (r.year ? ' (' + r.year + ')' : '');
             var meta = document.createElement('span');
             meta.className = 'si-meta';
-            var ratParts = [];
-            if (r.tmdb_rating) ratParts.push('TMDB ' + r.tmdb_rating.toFixed(1));
-            if (r.imdb_rating) ratParts.push('IMDb ' + r.imdb_rating.toFixed(1));
-            meta.textContent = ratParts.length ? ' — ' + ratParts.join(' · ') : '';
+            // Build colored badges (image-form display — no TMDB/IMDb text prefix, color does the talking).
+            if (r.tmdb_rating) {
+                var t = document.createElement('span');
+                t.className = 'si-rating tmdb';
+                t.textContent = r.tmdb_rating.toFixed(1);
+                meta.appendChild(t);
+            }
+            if (r.imdb_rating) {
+                var i2 = document.createElement('span');
+                i2.className = 'si-rating imdb';
+                i2.textContent = r.imdb_rating.toFixed(1);
+                meta.appendChild(i2);
+            }
             info.appendChild(title);
             info.appendChild(meta);
             item.appendChild(info);


### PR DESCRIPTION
<!-- claude-session: abde5913-c371-47e0-8ccf-f9ba99bdf35f -->

Follow-up to #693 / #593 — user requested that the image-form rating displays (grid card overlay + search autocomplete dropdown) show just the colored rectangles without the \"TMDB\"/\"IMDb\" text prefix. Keep the full labels on row-list view + detail pages.

## Summary
- **`.rating-badges` (grid overlay on poster)**: now renders just the number (e.g. `6.2` / `7.0`). Brand color + `title="…hodnocení"` tooltip still identify the source.
- **`.si-meta` (search autocomplete dropdown)**: inline colored badges instead of `— TMDB 6.2 · IMDb 7.0` text. Five templates use `innerHTML` strings; `tv_porady_list.html` builds DOM nodes (its autocomplete uses `textContent`).
- New CSS class `.search-item .si-rating` for the dropdown badges (compact ~12px font).
- List-view extra panel (`.film-ratings .badge`) and detail-page meta-row (`.meta-badge`) keep the full `TMDB X` / `IMDb X` labels.

## Test plan
- [x] `cargo check` + `cargo zigbuild --release` green locally
- [x] Deployed to prod, restarted container, `/health` returns 200
- [x] Playwright on prod `/filmy-online/?strana=5`: grid card badges are `["6.2", "5.4"]` / `["6.6", "7.0"]` etc. — no \"TMDB\"/\"IMDb\" text in image form
- [x] Playwright search autocomplete on \"matrix\": dropdown shows colored `.si-rating.tmdb` (blue) + `.si-rating.imdb` (yellow) badges, no text prefix
- [x] Browser console: 0 errors