### PR TITLE
feat(admin): IMDb + TMDB rating sync tiles on /admin/ (#696)

### DIFF
--- a/cr-infra/migrations/20260610_070_rating_sync_runs.sql
+++ b/cr-infra/migrations/20260610_070_rating_sync_runs.sql
@@ -21,9 +21,14 @@ CREATE TABLE rating_sync_runs (
     films_refreshed     INT NOT NULL DEFAULT 0,
     series_refreshed    INT NOT NULL DEFAULT 0,
     tv_shows_refreshed  INT NOT NULL DEFAULT 0,
-    -- TMDB only — rows that returned 404 or had no votes. IMDb sync
-    -- doesn't track per-row failures (the TSV either parses cleanly or
-    -- the whole run errors).
+    -- TMDB only — rows that returned HTTP 404 (stale tmdb_id) or had a
+    -- transient fetch failure (network / 5xx / unparseable JSON).
+    -- Titles with vote_count=0 ("TMDB knows the title, nobody rated it
+    -- yet") are NOT counted here: that's a normal steady state, not a
+    -- problem worth flagging on the admin tile. The Python sync script
+    -- still logs them as a separate `_no_votes` bucket for diagnostics.
+    -- IMDb sync doesn't track per-row failures (the TSV either parses
+    -- cleanly or the whole run errors at the top level).
     failed_count        INT NOT NULL DEFAULT 0,
     error_message       TEXT
 );

--- a/cr-infra/migrations/20260610_070_rating_sync_runs.sql
+++ b/cr-infra/migrations/20260610_070_rating_sync_runs.sql
@@ -1,0 +1,35 @@
+-- Run history for the nightly IMDb (04:30 UTC) and TMDB (04:45 UTC)
+-- rating sync jobs (#591, #696). Each script writes one row per run:
+-- INSERT at start with status='running', UPDATE at finish with the
+-- final counters + status. Admin dashboard reads the latest row per
+-- kind to render the IMDb/TMDB tiles, same pattern as `import_runs` +
+-- `backup_runs`.
+--
+-- Volume: 2 rows/day → 730 rows/year. Even after a decade the table is
+-- under 2 MB, so no retention/archiving is needed.
+
+CREATE TABLE rating_sync_runs (
+    id                  SERIAL PRIMARY KEY,
+    kind                TEXT NOT NULL
+        CHECK (kind IN ('imdb', 'tmdb')),
+    started_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    finished_at         TIMESTAMPTZ,
+    status              TEXT NOT NULL DEFAULT 'running'
+        CHECK (status IN ('running', 'ok', 'error', 'partial')),
+    -- Per-table refresh counters. INT (not SMALLINT): IMDb daily TSV
+    -- can refresh ~30 000 films at once, well past SMALLINT's ceiling.
+    films_refreshed     INT NOT NULL DEFAULT 0,
+    series_refreshed    INT NOT NULL DEFAULT 0,
+    tv_shows_refreshed  INT NOT NULL DEFAULT 0,
+    -- TMDB only — rows that returned 404 or had no votes. IMDb sync
+    -- doesn't track per-row failures (the TSV either parses cleanly or
+    -- the whole run errors).
+    failed_count        INT NOT NULL DEFAULT 0,
+    error_message       TEXT
+);
+
+-- Admin dashboard query: `SELECT … FROM rating_sync_runs WHERE kind=$1
+-- ORDER BY started_at DESC LIMIT 1`. Composite index keeps the lookup
+-- O(1) regardless of how the table grows.
+CREATE INDEX idx_rating_sync_runs_kind_started_at
+    ON rating_sync_runs (kind, started_at DESC);

--- a/cr-web/src/handlers/admin_dashboard.rs
+++ b/cr-web/src/handlers/admin_dashboard.rs
@@ -209,11 +209,12 @@ async fn fetch_rating_tile(state: &AppState, kind: &'static str) -> LastRunTile 
         series_refreshed: i32,
         tv_shows_refreshed: i32,
         failed_count: i32,
+        error_message: Option<String>,
     }
 
     let row = match sqlx::query_as::<_, LastRatingSync>(
         "SELECT started_at, status, films_refreshed, series_refreshed, \
-         tv_shows_refreshed, failed_count \
+         tv_shows_refreshed, failed_count, error_message \
          FROM rating_sync_runs WHERE kind = $1 \
          ORDER BY started_at DESC LIMIT 1",
     )
@@ -223,9 +224,22 @@ async fn fetch_rating_tile(state: &AppState, kind: &'static str) -> LastRunTile 
     {
         Ok(r) => r,
         Err(e) => {
-            tracing::error!(
-                "admin dashboard: rating_sync_runs query failed for kind={kind}: {e}"
-            );
+            // Special-case "table does not exist" (Postgres SQLSTATE 42P01).
+            // The Python sync scripts tolerate migration 070 not yet being
+            // applied; if the dashboard treated that as a red incident the
+            // first deploy of this feature on an older instance would scream
+            // false alarms in journald and on /admin/. Real DB errors
+            // (auth, connection, schema-mismatch in *other* columns) still
+            // surface as `error` and get logged loudly.
+            if let sqlx::Error::Database(db_err) = &e
+                && db_err.code().as_deref() == Some("42P01")
+            {
+                return LastRunTile {
+                    status: "none",
+                    message: "Migrace 070 ještě není aplikována.".to_string(),
+                };
+            }
+            tracing::error!("admin dashboard: rating_sync_runs query failed for kind={kind}: {e}");
             return LastRunTile {
                 status: "error",
                 message: "Chyba DB (rating_sync_runs) — viz journald.".to_string(),
@@ -250,6 +264,28 @@ async fn fetch_rating_tile(state: &AppState, kind: &'static str) -> LastRunTile 
             let total = r.films_refreshed + r.series_refreshed + r.tv_shows_refreshed;
             let summary = if r.status == "running" {
                 "právě běží".to_string()
+            } else if r.status == "error" {
+                // error_message is trimmed by the Python scripts to 500
+                // chars; cap further here so a multi-line traceback
+                // doesn't blow up the tile. The full text is still in
+                // journald — link the operator there mentally via the
+                // "viz journald" trailer.
+                let detail = r
+                    .error_message
+                    .as_deref()
+                    .map(|s| s.trim())
+                    .filter(|s| !s.is_empty())
+                    .map(|s| {
+                        let max = 120;
+                        if s.chars().count() > max {
+                            let truncated: String = s.chars().take(max).collect();
+                            format!("{truncated}…")
+                        } else {
+                            s.to_string()
+                        }
+                    })
+                    .unwrap_or_else(|| "bez detailu".to_string());
+                format!("{detail} — viz journald")
             } else if total == 0 && r.failed_count == 0 && r.status == "ok" {
                 // IMDb sync returns a status=ok / counts=0 row when the
                 // upstream TSV's Last-Modified is unchanged from the

--- a/cr-web/src/handlers/admin_dashboard.rs
+++ b/cr-web/src/handlers/admin_dashboard.rs
@@ -3,6 +3,8 @@
 //! Zobrazuje dlaždice:
 //!   - Auto-import (SK Torrent → films/series/tv_shows)
 //!   - Zálohy DB (pg_dump → Cloudflare R2)
+//!   - IMDb hodnocení (datasets.imdbws.com TSV → films/series/tv_shows)
+//!   - TMDB hodnocení (/movie/changes + /tv/changes → films/series/tv_shows)
 //!
 //! Každá dlaždice ukazuje stav poslední akce, aby admin ráno věděl, jestli
 //! noční pipeline proběhla v pořádku.
@@ -45,6 +47,8 @@ struct AdminDashboardTemplate {
     import_tile: LastRunTile,
     backup_tile: LastRunTile,
     cache_tile: LastRunTile,
+    imdb_tile: LastRunTile,
+    tmdb_tile: LastRunTile,
 }
 
 fn noindex(html: String) -> Response {
@@ -193,16 +197,102 @@ fn cache_tile(state: &AppState) -> LastRunTile {
     }
 }
 
+/// Read the latest `rating_sync_runs` row for the given kind ('imdb' / 'tmdb')
+/// and render it as a dashboard tile. Same error-vs-empty distinction as
+/// the other tiles — DB error stays loud, empty table is calm.
+async fn fetch_rating_tile(state: &AppState, kind: &'static str) -> LastRunTile {
+    #[derive(sqlx::FromRow)]
+    struct LastRatingSync {
+        started_at: chrono::DateTime<chrono::Utc>,
+        status: String,
+        films_refreshed: i32,
+        series_refreshed: i32,
+        tv_shows_refreshed: i32,
+        failed_count: i32,
+    }
+
+    let row = match sqlx::query_as::<_, LastRatingSync>(
+        "SELECT started_at, status, films_refreshed, series_refreshed, \
+         tv_shows_refreshed, failed_count \
+         FROM rating_sync_runs WHERE kind = $1 \
+         ORDER BY started_at DESC LIMIT 1",
+    )
+    .bind(kind)
+    .fetch_optional(&state.db)
+    .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!(
+                "admin dashboard: rating_sync_runs query failed for kind={kind}: {e}"
+            );
+            return LastRunTile {
+                status: "error",
+                message: "Chyba DB (rating_sync_runs) — viz journald.".to_string(),
+            };
+        }
+    };
+
+    match row {
+        None => LastRunTile {
+            status: "none",
+            message: "Zatím žádný běh — sync nikdy neproběhl.".to_string(),
+        },
+        Some(r) => {
+            let h = hours_ago(r.started_at);
+            let status: &'static str = match r.status.as_str() {
+                "ok" => "ok",
+                "partial" => "partial",
+                "error" => "error",
+                "running" => "running",
+                _ => "none",
+            };
+            let total = r.films_refreshed + r.series_refreshed + r.tv_shows_refreshed;
+            let summary = if r.status == "running" {
+                "právě běží".to_string()
+            } else if total == 0 && r.failed_count == 0 && r.status == "ok" {
+                // IMDb sync returns a status=ok / counts=0 row when the
+                // upstream TSV's Last-Modified is unchanged from the
+                // previous run — nothing to refresh, but the pipeline DID
+                // execute (and we want the tile to reflect that, not look
+                // like a missing run). "TMDB /changes empty" hits the same
+                // branch; both meanings are accurate here.
+                "beze změny zdroje".to_string()
+            } else {
+                let base = format!(
+                    "{total} ↻ ({}f / {}s / {}tv)",
+                    r.films_refreshed, r.series_refreshed, r.tv_shows_refreshed,
+                );
+                if r.failed_count > 0 {
+                    format!("{base} / ⚠ {} selhalo", r.failed_count)
+                } else {
+                    base
+                }
+            };
+            LastRunTile {
+                status,
+                message: format!("Před {h}h — {} ({summary})", r.status),
+            }
+        }
+    }
+}
+
 /// GET /admin/ — landing page with per-section status tiles.
 pub async fn admin_dashboard(State(state): State<AppState>) -> WebResult<Response> {
-    let (import_tile, backup_tile) =
-        tokio::join!(fetch_import_tile(&state), fetch_backup_tile(&state));
+    let (import_tile, backup_tile, imdb_tile, tmdb_tile) = tokio::join!(
+        fetch_import_tile(&state),
+        fetch_backup_tile(&state),
+        fetch_rating_tile(&state, "imdb"),
+        fetch_rating_tile(&state, "tmdb"),
+    );
 
     let tmpl = AdminDashboardTemplate {
         img: state.image_base_url.clone(),
         import_tile,
         backup_tile,
         cache_tile: cache_tile(&state),
+        imdb_tile,
+        tmdb_tile,
     };
     Ok(noindex(tmpl.render()?))
 }

--- a/cr-web/templates/admin_dashboard.html
+++ b/cr-web/templates/admin_dashboard.html
@@ -46,6 +46,20 @@
             <p class="tile-status">{{ cache_tile.message }}</p>
         </a>
 
+        <div class="tile {{ imdb_tile.css_class() }}" title="Noční IMDb rating sync z datasets.imdbws.com">
+            <div class="tile-icon">⭐</div>
+            <h3>IMDb hodnocení</h3>
+            <p class="tile-sub">datasets.imdbws.com TSV → films / series / tv_shows (04:30 UTC)</p>
+            <p class="tile-status">{{ imdb_tile.message }}</p>
+        </div>
+
+        <div class="tile {{ tmdb_tile.css_class() }}" title="Noční TMDB rating sync přes /movie/changes + /tv/changes">
+            <div class="tile-icon">🎯</div>
+            <h3>TMDB hodnocení</h3>
+            <p class="tile-sub">/movie/changes + /tv/changes → films / series / tv_shows (04:45 UTC)</p>
+            <p class="tile-status">{{ tmdb_tile.message }}</p>
+        </div>
+
         <a href="/admin/test-sledujteto/" class="tile" title="Diagnostika sledujteto.cz integrace">
             <div class="tile-icon">🎞️</div>
             <h3>Test sledujteto.cz</h3>

--- a/scripts/sync-imdb-ratings.py
+++ b/scripts/sync-imdb-ratings.py
@@ -52,6 +52,68 @@ TSV_FILE_NAME = "title.ratings.tsv.gz"
 TABLES = ("films", "series", "tv_shows")
 
 
+def _insert_run(conn, kind: str) -> int | None:
+    """Open a new `rating_sync_runs` row and return its id.
+
+    Failure here MUST NOT abort the sync — the admin tile is a
+    nice-to-have; the real work is the UPDATEs to films/series/tv_shows.
+    Migration 070 may not be applied yet on legacy environments, so we
+    swallow the error, log it, and fall through to a syncless run.
+    """
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO rating_sync_runs (kind, status) VALUES (%s, 'running') RETURNING id",
+                (kind,),
+            )
+            run_id = cur.fetchone()[0]
+        conn.commit()
+        return run_id
+    except psycopg2.Error as e:
+        conn.rollback()
+        logging.warning("rating_sync_runs INSERT failed (migration 070?): %s", e)
+        return None
+
+
+def _finalize_run(
+    conn,
+    run_id: int | None,
+    status: str,
+    counts: dict[str, int],
+    error_message: str | None,
+) -> None:
+    """Close out the run row started by `_insert_run`. Safe to call with
+    run_id=None — turns into a no-op for environments without the table."""
+    if run_id is None:
+        return
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE rating_sync_runs
+                   SET finished_at = now(),
+                       status = %s,
+                       films_refreshed = %s,
+                       series_refreshed = %s,
+                       tv_shows_refreshed = %s,
+                       error_message = %s
+                 WHERE id = %s
+                """,
+                (
+                    status,
+                    counts.get("films", 0),
+                    counts.get("series", 0),
+                    counts.get("tv_shows", 0),
+                    error_message,
+                    run_id,
+                ),
+            )
+        conn.commit()
+    except psycopg2.Error as e:
+        conn.rollback()
+        logging.warning("rating_sync_runs UPDATE failed: %s", e)
+
+
 def _load_our_imdb_ids(cur) -> dict[str, str]:
     """Return imdb_id → table for every row we may want to update.
 
@@ -236,9 +298,26 @@ def main() -> int:
         raise SystemExit("DATABASE_URL required")
 
     conn = psycopg2.connect(dsn)
+    # On dry-run we skip the run-row entirely — admin dashboard should
+    # only track real production syncs, not ad-hoc parses.
+    run_id = None if args.dry_run else _insert_run(conn, "imdb")
+    status = "ok"
+    error_message: str | None = None
+    counts: dict[str, int] = {t: 0 for t in TABLES}
     try:
-        sync(conn, Path(args.cache_dir), args.dry_run, args.force)
+        counts = sync(conn, Path(args.cache_dir), args.dry_run, args.force)
+    except Exception as e:
+        status = "error"
+        # Trim to first 500 chars — full traceback already lives in journald.
+        error_message = (str(e) or repr(e))[:500]
+        _finalize_run(conn, run_id, status, counts, error_message)
+        conn.close()
+        raise
     finally:
+        # Successful path: write the OK summary before closing the conn.
+        # The except branch above already finalized + re-raised.
+        if status == "ok":
+            _finalize_run(conn, run_id, status, counts, error_message)
         conn.close()
     return 0
 

--- a/scripts/sync-tmdb-ratings.py
+++ b/scripts/sync-tmdb-ratings.py
@@ -70,6 +70,80 @@ TABLE_KIND = {
 }
 
 
+def _insert_run(conn, kind: str) -> int | None:
+    """Open a new `rating_sync_runs` row and return its id.
+
+    Failure here MUST NOT abort the sync — the admin tile is a
+    nice-to-have; the real work is the UPDATEs to films/series/tv_shows.
+    Migration 070 may not be applied yet on legacy environments, so we
+    swallow the error, log it, and fall through to a syncless run.
+    """
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO rating_sync_runs (kind, status) VALUES (%s, 'running') RETURNING id",
+                (kind,),
+            )
+            run_id = cur.fetchone()[0]
+        conn.commit()
+        return run_id
+    except psycopg2.Error as e:
+        conn.rollback()
+        logging.warning("rating_sync_runs INSERT failed (migration 070?): %s", e)
+        return None
+
+
+def _finalize_run(
+    conn,
+    run_id: int | None,
+    status: str,
+    counts: dict[str, int],
+    error_message: str | None,
+) -> None:
+    """Close out the run row started by `_insert_run`. Safe to call with
+    run_id=None — turns into a no-op for environments without the table.
+
+    `counts` is the Counter returned by `sync()` with keys like
+    `{table}_refreshed`, `{table}_failed`, … We aggregate `failed_count`
+    as the sum of every non-OK bucket so the admin tile shows "0 selhalo"
+    when everything was fine and "N selhalo" otherwise.
+    """
+    if run_id is None:
+        return
+    failed_count = sum(
+        v for k, v in counts.items()
+        if k.endswith("_failed") or k.endswith("_not_found")
+    )
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE rating_sync_runs
+                   SET finished_at = now(),
+                       status = %s,
+                       films_refreshed = %s,
+                       series_refreshed = %s,
+                       tv_shows_refreshed = %s,
+                       failed_count = %s,
+                       error_message = %s
+                 WHERE id = %s
+                """,
+                (
+                    status,
+                    counts.get("films_refreshed", 0),
+                    counts.get("series_refreshed", 0),
+                    counts.get("tv_shows_refreshed", 0),
+                    failed_count,
+                    error_message,
+                    run_id,
+                ),
+            )
+        conn.commit()
+    except psycopg2.Error as e:
+        conn.rollback()
+        logging.warning("rating_sync_runs UPDATE failed: %s", e)
+
+
 def _load_our_tmdb_ids(cur) -> dict[tuple[int, str], list[str]]:
     """Return (tmdb_id, kind) → list-of-tables mapping. `kind` is "movie"
     or "tv" so the film/tv namespaces don't collide, but `series` and
@@ -382,9 +456,22 @@ def main() -> int:
         raise SystemExit("TMDB_API_KEY required")
 
     conn = psycopg2.connect(dsn)
+    run_id = _insert_run(conn, "tmdb")
+    status = "ok"
+    error_message: str | None = None
+    counts: dict[str, int] = {}
     try:
-        sync(conn, api_key, args.days, args.workers, Path(args.state_dir))
+        counts = sync(conn, api_key, args.days, args.workers, Path(args.state_dir))
+    except Exception as e:
+        status = "error"
+        # Trim to 500 chars — full traceback already lives in journald.
+        error_message = (str(e) or repr(e))[:500]
+        _finalize_run(conn, run_id, status, counts, error_message)
+        conn.close()
+        raise
     finally:
+        if status == "ok":
+            _finalize_run(conn, run_id, status, counts, error_message)
         conn.close()
     return 0
 

--- a/scripts/sync-tmdb-ratings.py
+++ b/scripts/sync-tmdb-ratings.py
@@ -104,9 +104,14 @@ def _finalize_run(
     run_id=None — turns into a no-op for environments without the table.
 
     `counts` is the Counter returned by `sync()` with keys like
-    `{table}_refreshed`, `{table}_failed`, … We aggregate `failed_count`
-    as the sum of every non-OK bucket so the admin tile shows "0 selhalo"
-    when everything was fine and "N selhalo" otherwise.
+    `{table}_refreshed`, `{table}_failed`, `{table}_not_found`,
+    `{table}_no_votes`. `failed_count` aggregates ONLY the buckets that
+    represent a real problem worth surfacing on the admin tile:
+      - `_failed`     — transient network / 5xx / unparseable JSON
+      - `_not_found`  — HTTP 404 from TMDB (our tmdb_id is stale)
+    `_no_votes` is intentionally NOT included: it's a normal state
+    (TMDB has the title but nobody rated it yet) and stays as an
+    informational counter in the logs, not a failure.
     """
     if run_id is None:
         return


### PR DESCRIPTION
<!-- claude-session: abde5913-c371-47e0-8ccf-f9ba99bdf35f -->

Closes #696. Sub-issue of #588.

## Summary
- New migration `20260610_070` adds `rating_sync_runs` table — 2 rows/day, ~150 KB/year, no retention needed.
- `scripts/sync-imdb-ratings.py` + `scripts/sync-tmdb-ratings.py` open a row at start (status='running'), update on finish with per-table refresh counts + status. Failure to write the run row never aborts the real sync.
- Two new `/admin/` tiles ("IMDb hodnocení" ⭐ + "TMDB hodnocení" 🎯) reading the latest row per kind, same status/color convention as the existing Auto-import + Backup tiles.
- "0 refreshed + status=ok" collapses to *"beze změny zdroje"* so an IMDb 304 / TMDB empty-/changes day doesn't look like a missing run.

## Test plan
- [x] cargo check + cargo build local — green
- [x] Migration applied locally via `cr-web` auto-migrate
- [x] `sync-imdb-ratings.py` real run on dev: row `{kind=imdb, status=ok, films_refreshed=25399, series_refreshed=832}`
- [x] `sync-tmdb-ratings.py` real run on dev: row `{kind=tmdb, status=ok, films_refreshed=1335, series_refreshed=163, failed_count=1}`
- [x] Cross-compile + scp + restart on prod — health 200
- [x] Migration auto-applied on prod (verified `_sqlx_migrations` + `\d rating_sync_runs`)
- [x] `systemctl start cr-imdb-rating-sync.service` + `cr-tmdb-rating-sync.service` on prod — both finished, rows written: `imdb: 0/0/0` (TSV unchanged), `tmdb: 1408f/195s/3tv`
- [x] Playwright on https://ceskarepublika.wiki/admin/ — both tiles render correctly, IMDb shows "beze změny zdroje", TMDB shows "1606 ↻ (1408f / 195s / 3tv)"
- [x] 0 console errors / warnings on /admin/