### PR TITLE
fix(scripts): prehraj.to discover now stamps ratings + uploads cover to R2

### DIFF
--- a/scripts/auto_import/tmdb_resolver.py
+++ b/scripts/auto_import/tmdb_resolver.py
@@ -383,10 +383,16 @@ def _build_tv_resolution(session: requests.Session, candidate: dict, score: floa
         # TMDB returns vote_average=0 for TV shows with no votes yet —
         # treat that as None so we don't pollute `series.tmdb_rating`
         # with a spurious 0.0 (same rule as the films resolver above).
+        # Resolve from src first, fall back to src_en — and crucially
+        # coerce BEFORE the float() call so a None from one side doesn't
+        # crash the other side's lookup. Previously this expression
+        # called `float(src.get("vote_average"))` even when src lacked
+        # the key but src_en had it, raising TypeError, and silently
+        # stored 0.0 when src had 0 but src_en had a real rating.
         vote_average=(
-            float(src.get("vote_average"))
-            if (src.get("vote_average") or src_en.get("vote_average"))
-            else None
+            (lambda va: float(va) if va else None)(
+                src.get("vote_average") or src_en.get("vote_average")
+            )
         ),
         popularity=float(candidate.get("popularity") or 0.0),
         raw_search_score=score,

--- a/scripts/auto_import/tmdb_resolver.py
+++ b/scripts/auto_import/tmdb_resolver.py
@@ -138,6 +138,11 @@ class TvResolution:
     episode_count: int | None
     poster_path: str | None
     genre_ids: list[int]
+    # TMDB's 0–10 average. Persisted into `series.tmdb_rating` (migration
+    # 069). None for brand-new shows with no votes yet — same convention
+    # as the films resolver: TMDB returns vote_average=0 to mean "no
+    # votes," not "zero stars," so we coerce that to None.
+    vote_average: float | None = None
     popularity: float = 0.0
     raw_search_score: float = 0.0
 
@@ -375,6 +380,14 @@ def _build_tv_resolution(session: requests.Session, candidate: dict, score: floa
         episode_count=src.get("number_of_episodes"),
         poster_path=src.get("poster_path") or src_en.get("poster_path"),
         genre_ids=[g["id"] for g in (src.get("genres") or src_en.get("genres") or []) if g.get("id")],
+        # TMDB returns vote_average=0 for TV shows with no votes yet —
+        # treat that as None so we don't pollute `series.tmdb_rating`
+        # with a spurious 0.0 (same rule as the films resolver above).
+        vote_average=(
+            float(src.get("vote_average"))
+            if (src.get("vote_average") or src_en.get("vote_average"))
+            else None
+        ),
         popularity=float(candidate.get("popularity") or 0.0),
         raw_search_score=score,
     )

--- a/scripts/import-prehrajto-series.py
+++ b/scripts/import-prehrajto-series.py
@@ -519,8 +519,15 @@ def _stamp_ratings(cur, series_id: int, tv,
 
     Idempotent + non-clobbering — `COALESCE(col, %s)` keeps any value
     that's already there (the daily IMDB sync cron, manual fixes, an
-    earlier discover run). Stamps `tmdb_rating_synced_at` to now() so
-    freshness audits work the same way as `sync-imdb-ratings.py`.
+    earlier discover run).
+
+    Both `tmdb_rating_synced_at` and `imdb_rating_synced_at` are
+    stamped to now() in the same UPDATE — without the IMDb timestamp
+    a re-run of migration 069 would re-clear our freshly-stamped
+    `imdb_rating` because that migration's WHERE filter is
+    `imdb_rating_synced_at IS NULL` (the column is treated as
+    "definitely-not-synced" until proven otherwise). Same freshness
+    convention as `sync-imdb-ratings.py`.
     """
     tmdb_rating = tv.vote_average
     imdb_rating: float | None = None
@@ -539,9 +546,15 @@ def _stamp_ratings(cur, series_id: int, tv,
                   ELSE tmdb_rating_synced_at
               END,
               imdb_rating           = COALESCE(imdb_rating, %s),
-              imdb_votes            = COALESCE(imdb_votes, %s)
+              imdb_votes            = COALESCE(imdb_votes, %s),
+              imdb_rating_synced_at = CASE
+                  WHEN imdb_rating IS NULL AND %s IS NOT NULL THEN now()
+                  ELSE imdb_rating_synced_at
+              END
            WHERE id = %s""",
-        (tmdb_rating, tmdb_rating, imdb_rating, imdb_votes, series_id),
+        (tmdb_rating, tmdb_rating,
+         imdb_rating, imdb_votes, imdb_rating,
+         series_id),
     )
 
 # Sitemap XML regexes (vendored from import-prehrajto-new-films.py so

--- a/scripts/import-prehrajto-series.py
+++ b/scripts/import-prehrajto-series.py
@@ -455,6 +455,95 @@ def enrich_one_series(
 #   10764 Reality, 10767 Talk, 10763 News, 10762 Kids
 TV_SHOWS_GENRES: frozenset[int] = frozenset({10764, 10767, 10763, 10762})
 
+
+# IMDB ratings index — loaded once per run from the cached TSV that
+# `sync-imdb-ratings.py` keeps fresh via a daily cron. The TSV is
+# ~10 MB compressed, ~1.5 M rows; loading it into a {imdb_id:
+# (rating, votes)} dict takes ~3 s and ~150 MB RAM — cheap compared
+# to the alternative of an OMDb / IMDb-API call per cluster. The
+# index is a process-global cache so multiple `discover_one_cluster`
+# invocations share it.
+DEFAULT_IMDB_CACHE = Path("/opt/cr/data/imdb-cache/title.ratings.tsv.gz")
+_IMDB_INDEX: dict[str, tuple[float, int]] | None = None
+
+
+def _load_imdb_ratings(cache_path: Path = DEFAULT_IMDB_CACHE
+                       ) -> dict[str, tuple[float, int]]:
+    """Parse `title.ratings.tsv.gz` into a {tconst: (rating, votes)} map.
+
+    Schema (tab-separated, header on row 0):
+        tconst    averageRating    numVotes
+        tt0000001 5.7              2104
+        tt0000002 5.6              287
+        ...
+
+    Cached at module scope: subsequent calls return the same dict.
+    Returns an empty dict (and logs a warning) when the TSV is
+    missing — Phase B can still create series, they'll just lack
+    IMDB ratings until the next `sync-imdb-ratings.py` cron tick.
+    """
+    global _IMDB_INDEX
+    if _IMDB_INDEX is not None:
+        return _IMDB_INDEX
+    if not cache_path.exists():
+        log.warning("IMDB ratings TSV not found at %s — new series will "
+                    "have imdb_rating=NULL until the daily sync cron "
+                    "fills them in", cache_path)
+        _IMDB_INDEX = {}
+        return _IMDB_INDEX
+    import gzip
+    index: dict[str, tuple[float, int]] = {}
+    t0 = time.time()
+    with gzip.open(cache_path, "rt", encoding="utf-8") as fh:
+        next(fh, None)  # header row
+        for line in fh:
+            parts = line.rstrip("\n").split("\t")
+            if len(parts) < 3:
+                continue
+            tconst, avg, votes = parts[0], parts[1], parts[2]
+            if not tconst.startswith("tt"):
+                continue
+            try:
+                index[tconst] = (float(avg), int(votes))
+            except ValueError:
+                continue
+    log.info("Loaded %d IMDB ratings from %s in %.1fs",
+             len(index), cache_path, time.time() - t0)
+    _IMDB_INDEX = index
+    return index
+
+
+def _stamp_ratings(cur, series_id: int, tv,
+                   imdb_index: dict[str, tuple[float, int]]) -> None:
+    """Fill `series.tmdb_rating` / `.imdb_rating` / `.imdb_votes` if NULL.
+
+    Idempotent + non-clobbering — `COALESCE(col, %s)` keeps any value
+    that's already there (the daily IMDB sync cron, manual fixes, an
+    earlier discover run). Stamps `tmdb_rating_synced_at` to now() so
+    freshness audits work the same way as `sync-imdb-ratings.py`.
+    """
+    tmdb_rating = tv.vote_average
+    imdb_rating: float | None = None
+    imdb_votes: int | None = None
+    if getattr(tv, "imdb_id", None):
+        hit = imdb_index.get(tv.imdb_id)
+        if hit is not None:
+            imdb_rating, imdb_votes = hit
+    if tmdb_rating is None and imdb_rating is None:
+        return  # nothing to write
+    cur.execute(
+        """UPDATE series SET
+              tmdb_rating           = COALESCE(tmdb_rating, %s),
+              tmdb_rating_synced_at = CASE
+                  WHEN tmdb_rating IS NULL AND %s IS NOT NULL THEN now()
+                  ELSE tmdb_rating_synced_at
+              END,
+              imdb_rating           = COALESCE(imdb_rating, %s),
+              imdb_votes            = COALESCE(imdb_votes, %s)
+           WHERE id = %s""",
+        (tmdb_rating, tmdb_rating, imdb_rating, imdb_votes, series_id),
+    )
+
 # Sitemap XML regexes (vendored from import-prehrajto-new-films.py so
 # Phase B doesn't have to import a sibling script just for these).
 _SITEMAP_LOC_RE = re.compile(r"<loc>([^<]+)</loc>")
@@ -836,6 +925,27 @@ def discover_one_cluster(
              series_id, stats.tmdb_name, tv.tmdb_id,
              "CREATED" if was_created else "existed")
 
+    # Stamp TMDB + IMDB ratings on the series row. Runs for BOTH the
+    # newly-created and the existed branches because legacy series
+    # rows often have NULL ratings the daily IMDB sync cron hasn't
+    # yet filled in. `_stamp_ratings` uses COALESCE so an existing
+    # non-NULL value is never clobbered.
+    try:
+        _stamp_ratings(conn.cursor(), series_id, tv, _load_imdb_ratings())
+    except Exception:  # noqa: BLE001
+        log.exception("    rating stamp failed for series id=%d "
+                      "(continuing — sources still get attached)",
+                      series_id)
+    if was_created:
+        # ensure_series writes cover bytes to the local cover_dir but
+        # NEVER touches R2. The Rust handler at
+        # `/serialy-online/{slug}.webp` reads from R2 directly via
+        # `series/{id}/cover.webp` — so without this upload the new
+        # series page would serve the 1×1 placeholder. We push it
+        # right after series creation so the cover lands at the same
+        # time as the series row commits in step 5.
+        _push_cover_to_r2(series_id, cover_dir)
+
     # 4. Per-upload attach: ensure episode row, attach video_sources.
     cur = conn.cursor()
     cur.execute(
@@ -962,6 +1072,59 @@ def discover_one_cluster(
 def _lang_from_title(title: str) -> str:
     from scripts.auto_import.prehrajto_search import detect_lang
     return detect_lang(title)
+
+
+def _push_cover_to_r2(series_id: int, cover_dir: str) -> None:
+    """Upload `cover_dir/{id}/cover{,-large}.webp` to R2 via rclone.
+
+    R2 layout matches what `cr-web/src/handlers/series.rs::series_cover`
+    reads: `cr-images/series/{id}/cover.webp` (200×300) and
+    `cr-images/series/{id}/cover-large.webp` (780×1170). Without this
+    push the new series page would serve the 1×1 placeholder since the
+    Rust handler reads from R2, not from local disk.
+
+    `--s3-no-check-bucket` skips a ListBuckets call our R2 token isn't
+    authorised for — without that flag every copyto prints an "Access
+    Denied" notice despite the PUT itself succeeding. Best-effort: a
+    failure here leaves the cover only locally; surrounding cluster
+    work continues regardless.
+    """
+    import shutil
+    import subprocess
+    if not shutil.which("rclone"):
+        log.warning("    rclone not in PATH — series id=%d cover stays "
+                    "local only; user sees placeholder until manual "
+                    "sync", series_id)
+        return
+    cover_root = Path(cover_dir) / str(series_id)
+    small = cover_root / "cover.webp"
+    large = cover_root / "cover-large.webp"
+    if not small.exists():
+        log.warning("    series id=%d: local cover.webp missing — "
+                    "ensure_series did not download a poster", series_id)
+        return
+    for path, variant in ((small, "cover.webp"),
+                          (large, "cover-large.webp")):
+        if not path.exists():
+            continue
+        dest = f"cr-r2:cr-images/series/{series_id}/{variant}"
+        try:
+            r = subprocess.run(
+                ["rclone", "copyto", "--s3-no-check-bucket",
+                 str(path), dest],
+                capture_output=True, text=True, timeout=60,
+            )
+            if r.returncode != 0:
+                tail = ((r.stderr or r.stdout or "").strip()
+                        .splitlines()[-3:])
+                log.warning("    rclone push failed for %s: %s",
+                            dest, " | ".join(tail))
+            else:
+                log.info("    pushed %s to R2", dest)
+        except subprocess.TimeoutExpired:
+            log.warning("    rclone push timed out for %s", dest)
+        except Exception as e:  # noqa: BLE001
+            log.warning("    rclone push raised for %s: %s", dest, e)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- claude-session: e5713c88-75a7-4380-8c08-7327c983587b -->

Follow-up to #688 (Phase B — prehraj.to series discover, #686). Two fixes surfaced by a 30-cluster prod run that created 10 new series — none of them had a visible cover and all had NULL TMDB / IMDb ratings until the daily IMDb sync cron caught up.

## (1) Cover R2 push

`ensure_series` writes the WebP bytes locally under `cover_dir/{id}/cover{,-large}.webp`, but the Rust handler at `/serialy-online/{slug}.webp` (`series_cover` / `series_cover_large` in `cr-web/src/handlers/series.rs`) fetches from R2 at `cr-images/series/{id}/cover{,-large}.webp` — local files are never consulted. Without a push, every newly-created series page served the 1×1 placeholder.

New `_push_cover_to_r2()` runs `rclone copyto --s3-no-check-bucket` after a successful `ensure_series(was_created=True)`. The `--s3-no-check-bucket` flag is mandatory: our R2 token doesn't grant ListBuckets, so every PUT prints "Access Denied" if it's missing — even though the PUT itself succeeds. Best-effort: a failed rclone leaves the cover only locally and surrounding cluster work continues.

## (2) TMDB + IMDb ratings at create time

`ensure_series` did not stamp `series.tmdb_rating` / `.imdb_rating` — new rows had NULL on both until the daily `sync-imdb-ratings.py` cron filled them in. Now `_stamp_ratings()` runs immediately after `ensure_series` and fills:
* `tmdb_rating` from a new `vote_average` field on `TvResolution` (TMDB's `/tv/{id}.vote_average`, coerced to None when 0 — same "no votes yet" convention as the films resolver).
* `imdb_rating` + `imdb_votes` from the cached `/opt/cr/data/imdb-cache/title.ratings.tsv.gz` (~1.5 M rows, loaded once per run into a {tconst: (rating, votes)} dict at ~150 MB RAM — much cheaper than an OMDb call per cluster).

COALESCE-based UPDATE so a non-NULL value already on the row (manual fix, prior sync) is never clobbered. Runs for BOTH the newly-created and the existed branches, so a legacy series with NULL ratings the daily sync hasn't yet filled in also picks them up.

## Test plan

### Local
- [x] `python -m py_compile scripts/import-prehrajto-series.py scripts/auto_import/tmdb_resolver.py` clean.

### Prod
- [x] After the discover --limit 30 run (10 new series 1048–1058), backfilled R2 covers + ratings via these helpers; every new series now has 2 files on R2 (`cr-r2:cr-images/series/{id}/{cover,cover-large}.webp`) and non-NULL `tmdb_rating` / `imdb_rating` / `imdb_votes`.

### Playwright (from local PC)
- [x] `/serialy-online/brooklyn-99/` → cover loads (23 160 bytes content-length, image/webp), rating row shows `TMDB 8.2` + `IMDb 8.4` badges.
- [x] Every other new slug (`andromeda`, `star-trek-hluboky-vesmir-devet`, `hvezdna-brana-atlantida`, `star-trek-enterprise`, `cerna-listina`, `chicago-fire`, `carodejky`, `24-hodin`, `star-trek-voyager`) serves a real cover (10–23 KB).

## Notes

* The IMDb TSV cache is populated by an existing daily cron (`sync-imdb-ratings.py`, #690). If the file is missing at `/opt/cr/data/imdb-cache/title.ratings.tsv.gz`, `_load_imdb_ratings` logs a warning and returns an empty dict — new series get NULL IMDb fields until the next cron tick.
* The TMDB rating comes from the already-existing `resolve_tv` HTTP call — no extra API call per cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)