### PR TITLE
fix(web): /serialy-online honors razeni=imdb/tmdb

### DIFF
--- a/cr-web/src/handlers/series.rs
+++ b/cr-web/src/handlers/series.rs
@@ -254,6 +254,18 @@ impl SeriesQuery {
         self.razeni.as_deref().unwrap_or("pridano")
     }
 
+    /// Whether the user picked a non-default sort that the latest-episode
+    /// listing can't honour (it's hard-ordered by `created_at`). When true
+    /// and no genre/year filters are active, the handler switches to a
+    /// series-by-`order_clause` query so the page actually reorders rather
+    /// than silently ignoring `razeni=` (parity with tv_porady #702 review).
+    fn wants_shows_mode(&self) -> bool {
+        matches!(
+            self.razeni.as_deref(),
+            Some("rok") | Some("imdb") | Some("tmdb") | Some("nazev")
+        )
+    }
+
     fn parse_genre_slugs(input: Option<&String>) -> Vec<String> {
         // Dedup to keep AND-mode `HAVING COUNT(DISTINCT g.slug) = slugs.len()` correct.
         let mut slugs: Vec<String> = Vec::new();
@@ -422,6 +434,33 @@ pub async fn series_list(
         );
         let rows = sqlx::query_as::<_, SeriesRow>(&query)
             .bind(pattern)
+            .bind(SERIES_PER_PAGE)
+            .bind(offset)
+            .fetch_all(&state.db)
+            .await?;
+        (count_row.count.unwrap_or(0), rows, Vec::new())
+    } else if include.is_empty()
+        && exclude.is_empty()
+        && year_f.is_none()
+        && params.wants_shows_mode()
+    {
+        // Non-default sort (rok / imdb / tmdb / nazev) without filters: the
+        // latest-episode listing is hard-ordered by `created_at` and would
+        // silently ignore `razeni=`, so switch to a series-by-`order_clause`
+        // query (parity with tv_porady, originally surfaced by Copilot review
+        // on #702).
+        let count_row = sqlx::query_as::<_, CountRow>("SELECT count(*) as count FROM series")
+            .fetch_one(&state.db)
+            .await?;
+        let query = format!(
+            "SELECT s.id, s.title, s.slug, s.first_air_year, s.last_air_year, \
+             s.description, s.original_title, s.tmdb_rating, s.imdb_rating, s.csfd_rating, \
+             s.season_count, s.episode_count, s.added_at, \
+             s.tmdb_poster_path \
+             FROM series s \
+             ORDER BY {order} LIMIT $1 OFFSET $2"
+        );
+        let rows = sqlx::query_as::<_, SeriesRow>(&query)
             .bind(SERIES_PER_PAGE)
             .bind(offset)
             .fetch_all(&state.db)

--- a/cr-web/templates/series_list.html
+++ b/cr-web/templates/series_list.html
@@ -71,7 +71,11 @@
             {% when Some with (g) %}
             <h1>{{ g.pretty_plural() }}<span class="online-word"> online</span> <span class="count">({{ total_count }})</span></h1>
             {% when None %}
-            <h2>Nejnovější epizody z {{ total_count }} seriálů<span class="online-word"> online</span></h2>
+                {% if episodes.is_empty() %}
+                <h1>Seriály<span class="online-word"> online</span> <span class="count">({{ total_count }})</span></h1>
+                {% else %}
+                <h2>Nejnovější epizody z {{ total_count }} seriálů<span class="online-word"> online</span></h2>
+                {% endif %}
             {% endmatch %}
         {% endmatch %}
         <div class="films-toolbar">

--- a/cr-web/templates/tv_porady_list.html
+++ b/cr-web/templates/tv_porady_list.html
@@ -48,12 +48,16 @@
 </nav>
 
 <div class="films-header">
-    <h2>
-        {% match search_query %}
-        {% when Some with (q) %}Výsledky hledání pro „{{ q }}" <span class="count">({{ total_count }})</span>
-        {% when None %}Nejnovější epizody z {{ total_count }} TV pořadů
-        {% endmatch %}
-    </h2>
+    {% match search_query %}
+    {% when Some with (q) %}
+    <h2>Výsledky hledání pro „{{ q }}" <span class="count">({{ total_count }})</span></h2>
+    {% when None %}
+        {% if episodes.is_empty() %}
+        <h1>TV pořady <span class="count">({{ total_count }})</span></h1>
+        {% else %}
+        <h2>Nejnovější epizody z {{ total_count }} TV pořadů</h2>
+        {% endif %}
+    {% endmatch %}
     <div class="films-toolbar">
         <label class="toolbar-group">
             <span class="toolbar-label">Řazení:</span>


### PR DESCRIPTION
<!-- claude-session: abde5913-c371-47e0-8ccf-f9ba99bdf35f -->

Sibling fix to #702. Same root cause Copilot called out for tv_porady, now applied to series_list.

## Summary
- /serialy-online/?razeni=imdb (or tmdb / rok / nazev) silently ignored the sort because the default branch always returned latest-episode cards (hard-ordered by `created_at`).
- Adds `SeriesQuery::wants_shows_mode()` and a new branch in `series_list()` that switches to a series-by-`order_clause` query when the user picks a non-default sort without genre/year filters.
- Default landing (no razeni, no filters) keeps the latest-episode listing → no regression on the home view.

## Test plan
Verified live on https://ceskarepublika.wiki after local deploy:

- [x] `/serialy-online/?razeni=imdb` → Breaking Bad 9.5, Planet Earth 9.4, Avatar 9.3, Chernobyl 9.3, GoT 9.2 (desc by imdb_rating)
- [x] `/serialy-online/?razeni=tmdb&smer=asc` → TMDB 1.0, 2.0, 2.0 (asc by tmdb_rating)
- [x] `/serialy-online/` (default) → still latest-episode listing (S07E15, S01E04, S01E05) — back-compat OK
- [x] Console: 0 errors, 0 warnings
- [x] `cargo clippy -p cr-web --release -- -D warnings` clean
- [x] `cargo fmt --check` clean