### PR TITLE
fix(deploy): sync scripts/ alongside binary in one helper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -368,25 +368,41 @@ cargo run -p cr-web    # Listens on port 3000
 
 **CRITICAL: Deploy is ALWAYS done from the LOCAL machine. NEVER run `docker compose build` on the server.**
 
-The deploy process is: cross-compile locally → scp binary → docker cp → restart. This takes ~20 seconds for incremental builds and keeps the server minimal (no Rust toolchain, no build tools).
+The deploy process is: cross-compile locally → scp binary → rsync scripts/ → restart. This takes ~20 seconds for incremental builds and keeps the server minimal (no Rust toolchain, no build tools).
 
 **Standard deploy (after merge to main):**
 ```bash
 # 1. Pull latest main
 git checkout main && git pull
 
-# 2. Cross-compile locally (~10s incremental, ~90s clean build)
-#    IMPORTANT: If migration files changed, do `cargo clean` first to force recompile!
-SQLX_OFFLINE=true cargo zigbuild --release --target aarch64-unknown-linux-musl -p cr-web
+# 2. If migrations changed, `cargo clean` first to force re-embedding of checksums.
+[ -n "$(git diff HEAD~1 --name-only -- 'cr-infra/migrations/*.sql')" ] && cargo clean
 
-# 3. Upload binary to VPS + replace in container + restart (~10s)
-scp -P 2222 target/aarch64-unknown-linux-musl/release/cr-web root@46.225.101.253:/tmp/cr-web-new
-ssh -p 2222 root@46.225.101.253 "docker cp /tmp/cr-web-new cr-web-1:/app/cr-web && docker compose -f /opt/cr/docker-compose.yml restart web"
+# 3. One-shot deploy: drift check → cross-compile → scp binary → rsync scripts/
+#    → restart container → curl /health. Takes ~20s on a warm cache.
+./scripts/deploy.sh
 
-# 4. Health check (MUST return 200)
-curl -s -o /dev/null -w "%{http_code}" https://ceskarepublika.wiki/health
+# 4. Playwright verify (from local PC) — see "Playwright Testing Rules" above
+```
 
-# 5. Playwright verify (from local PC)
+`scripts/deploy.sh` is the single source of truth for the deploy sequence. Read it before running if you want to understand each step; the script is heavily commented. Always rsyncs `scripts/` alongside the binary — Python importers and the Rust binary share schema assumptions (column names, table layout), so they must move together. Skipping the script sync caused a real incident on 2026-05-13: 12 films imported with TMDB rating in the wrong column because `enricher.py` on prod was 2 days stale relative to the post-migration-069 schema (see #707).
+
+If you must run the steps manually (e.g. partial deploy of just the binary or just the scripts), the canonical commands are:
+
+```bash
+# Just the binary. /opt/cr/cr-web-bin is bind-mounted into /app/cr-web in
+# the running container, so we can't overwrite it in place — plain scp
+# fails with ETXTBSY (running executable) and `docker cp` fails with
+# "device or resource busy" against the bind mount. Stop the container,
+# replace the file on the host, start the container. ~5s downtime.
+ssh -p 2222 root@46.225.101.253 "docker compose -f /opt/cr/docker-compose.yml stop web"
+scp -P 2222 target/aarch64-unknown-linux-musl/release/cr-web \
+    root@46.225.101.253:/opt/cr/cr-web-bin
+ssh -p 2222 root@46.225.101.253 "docker compose -f /opt/cr/docker-compose.yml start web"
+
+# Just the scripts (e.g. fixing a Python-only bug between Rust deploys):
+rsync -avz --delete --exclude '__pycache__/' --exclude '*.pyc' \
+    -e "ssh -p 2222" scripts/ root@46.225.101.253:/opt/cr/scripts/
 ```
 
 **For template/static file changes** (no Rust recompilation needed):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -375,8 +375,10 @@ The deploy process is: cross-compile locally → scp binary → rsync scripts/ �
 # 1. Pull latest main
 git checkout main && git pull
 
-# 2. If migrations changed, `cargo clean` first to force re-embedding of checksums.
-[ -n "$(git diff HEAD~1 --name-only -- 'cr-infra/migrations/*.sql')" ] && cargo clean
+# 2. If THIS pull introduced migration changes, `cargo clean` first to force
+#    re-embedding of checksums. `@{1}..HEAD` reads the reflog so it catches
+#    multi-commit fast-forwards (HEAD~1 would only see the topmost commit).
+[ -n "$(git diff '@{1}..HEAD' --name-only -- 'cr-infra/migrations/*.sql')" ] && cargo clean
 
 # 3. One-shot deploy: drift check → cross-compile → scp binary → rsync scripts/
 #    → restart container → curl /health. Takes ~20s on a warm cache.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Deploy cr-web to production in one command.
+#
+# Steps:
+#   0. Drift check  — dry-run rsync of scripts/ so we see what changed since
+#                     the last deploy (warns if a previous deploy was incomplete)
+#   1. Cross-compile cr-web for aarch64-unknown-linux-musl with cargo zigbuild
+#   2. rsync scripts/ to /opt/cr/scripts/ (excludes __pycache__, --delete) —
+#      done BEFORE the container restart so the new scripts are already in
+#      place if the web container or one of the timer-driven importers fires
+#      during the restart window.
+#   3. docker compose stop web → scp binary to /opt/cr/cr-web-bin →
+#      docker compose start web. Stopping the container is necessary because:
+#        - plain scp over /opt/cr/cr-web-bin fails with ETXTBSY (kernel
+#          refuses to overwrite a running executable),
+#        - `docker cp` onto /app/cr-web fails with "device or resource busy"
+#          because /app/cr-web inside the container is a bind mount of
+#          /opt/cr/cr-web-bin (per the prod-only compose edit).
+#      Downtime is a few seconds. The web container's restart policy is
+#      `unless-stopped` so the explicit start in step 3c is required.
+#   4. curl /health and wait up to 10s for a 200 response
+
+set -euo pipefail
+
+VPS_HOST="46.225.101.253"
+VPS_PORT="2222"
+VPS_USER="root"
+TARGET="aarch64-unknown-linux-musl"
+PROD_URL="https://ceskarepublika.wiki"
+COMPOSE_FILE="/opt/cr/docker-compose.yml"
+REMOTE_BIN="/opt/cr/cr-web-bin"
+COMPOSE_SERVICE="web"
+REMOTE_SCRIPTS="/opt/cr/scripts/"
+
+cd "$(dirname "$0")/.."  # project root
+
+ssh_cmd=(ssh -p "$VPS_PORT" "${VPS_USER}@${VPS_HOST}")
+rsync_ssh="ssh -p $VPS_PORT"
+
+# 0. Drift check — dry-run rsync, count files that would change. Same exclude
+#    list as the real rsync in step 3 so the warning is honest.
+echo "==> Checking scripts/ drift against ${VPS_HOST}:${REMOTE_SCRIPTS} ..."
+drift_output=$(rsync -an --delete --itemize-changes \
+  --exclude '__pycache__/' \
+  --exclude '*.pyc' \
+  -e "$rsync_ssh" \
+  scripts/ "${VPS_USER}@${VPS_HOST}:${REMOTE_SCRIPTS}" \
+  | grep -v '^$' || true)
+drift_count=$(echo "$drift_output" | grep -cv '^\s*$' || true)
+if [ "$drift_count" -gt 0 ]; then
+  echo "    $drift_count file(s) differ — the rsync in step 3 will bring them in sync:"
+  echo "$drift_output" | sed 's/^/      /'
+else
+  echo "    scripts/ is already in sync."
+fi
+
+# 1. Cross-compile
+echo "==> Cross-compiling cr-web for $TARGET ..."
+SQLX_OFFLINE=true cargo zigbuild --release --target "$TARGET" -p cr-web
+
+bin_path="target/$TARGET/release/cr-web"
+if [ ! -f "$bin_path" ]; then
+  echo "ERROR: build did not produce $bin_path" >&2
+  exit 1
+fi
+
+# 2. Sync scripts/ FIRST (before the container goes down) so timer-driven
+#    importers that fire during our restart window already see the new code.
+#    --delete so removed files disappear from the server.
+echo "==> Syncing scripts/ ..."
+rsync -avz --delete \
+  --exclude '__pycache__/' \
+  --exclude '*.pyc' \
+  -e "$rsync_ssh" \
+  scripts/ "${VPS_USER}@${VPS_HOST}:${REMOTE_SCRIPTS}"
+
+# 3. Stop web → replace binary on host → start web. Stopping is required
+#    because /opt/cr/cr-web-bin is bind-mounted into a running container
+#    and neither scp (ETXTBSY) nor docker cp (device-busy on bind mount)
+#    can overwrite it while the container runs.
+echo "==> Stopping ${COMPOSE_SERVICE} container ..."
+"${ssh_cmd[@]}" "docker compose -f ${COMPOSE_FILE} stop ${COMPOSE_SERVICE}"
+
+echo "==> Uploading binary to ${REMOTE_BIN} ..."
+scp -P "$VPS_PORT" "$bin_path" "${VPS_USER}@${VPS_HOST}:${REMOTE_BIN}"
+
+echo "==> Starting ${COMPOSE_SERVICE} container ..."
+"${ssh_cmd[@]}" "docker compose -f ${COMPOSE_FILE} start ${COMPOSE_SERVICE}"
+
+# 4. Health check — poll /health until 200 or 10s deadline.
+echo "==> Waiting for /health ..."
+for i in $(seq 1 10); do
+  sleep 1
+  code=$(curl -s -o /dev/null -w "%{http_code}" "${PROD_URL}/health" || echo "000")
+  if [ "$code" = "200" ]; then
+    echo "==> Healthy after ${i}s. Deploy done."
+    exit 0
+  fi
+done
+
+echo "ERROR: /health did not return 200 within 10s." >&2
+echo "       Check logs: ssh -p $VPS_PORT ${VPS_USER}@${VPS_HOST} docker logs --tail 50 cr-web-1" >&2
+exit 1

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -7,8 +7,7 @@
 #   1. Cross-compile cr-web for aarch64-unknown-linux-musl with cargo zigbuild
 #   2. rsync scripts/ to /opt/cr/scripts/ (excludes __pycache__, --delete) —
 #      done BEFORE the container restart so the new scripts are already in
-#      place if the web container or one of the timer-driven importers fires
-#      during the restart window.
+#      place if a timer-driven importer fires during the restart window.
 #   3. docker compose stop web → scp binary to /opt/cr/cr-web-bin →
 #      docker compose start web. Stopping the container is necessary because:
 #        - plain scp over /opt/cr/cr-web-bin fails with ETXTBSY (kernel
@@ -16,8 +15,9 @@
 #        - `docker cp` onto /app/cr-web fails with "device or resource busy"
 #          because /app/cr-web inside the container is a bind mount of
 #          /opt/cr/cr-web-bin (per the prod-only compose edit).
-#      Downtime is a few seconds. The web container's restart policy is
-#      `unless-stopped` so the explicit start in step 3c is required.
+#      A trap covers the gap: if anything between `stop` and the final
+#      `start` fails, we attempt to restart the container so prod doesn't
+#      stay down with an old binary still on disk.
 #   4. curl /health and wait up to 10s for a 200 response
 
 set -euo pipefail
@@ -37,18 +37,22 @@ cd "$(dirname "$0")/.."  # project root
 ssh_cmd=(ssh -p "$VPS_PORT" "${VPS_USER}@${VPS_HOST}")
 rsync_ssh="ssh -p $VPS_PORT"
 
-# 0. Drift check — dry-run rsync, count files that would change. Same exclude
-#    list as the real rsync in step 3 so the warning is honest.
+# 0. Drift check — dry-run rsync, count files that would change. Mirror the
+#    real sync flags from step 2 (sans -v/-z) so the warning is honest.
 echo "==> Checking scripts/ drift against ${VPS_HOST}:${REMOTE_SCRIPTS} ..."
-drift_output=$(rsync -an --delete --itemize-changes \
+drift_output=$(rsync --archive --dry-run --delete --itemize-changes \
   --exclude '__pycache__/' \
   --exclude '*.pyc' \
   -e "$rsync_ssh" \
   scripts/ "${VPS_USER}@${VPS_HOST}:${REMOTE_SCRIPTS}" \
   | grep -v '^$' || true)
-drift_count=$(echo "$drift_output" | grep -cv '^\s*$' || true)
+if [ -z "$drift_output" ]; then
+  drift_count=0
+else
+  drift_count=$(printf '%s\n' "$drift_output" | wc -l | tr -d '[:space:]')
+fi
 if [ "$drift_count" -gt 0 ]; then
-  echo "    $drift_count file(s) differ — the rsync in step 3 will bring them in sync:"
+  echo "    $drift_count file(s) differ — the rsync in step 2 will bring them in sync:"
   echo "$drift_output" | sed 's/^/      /'
 else
   echo "    scripts/ is already in sync."
@@ -74,18 +78,30 @@ rsync -avz --delete \
   -e "$rsync_ssh" \
   scripts/ "${VPS_USER}@${VPS_HOST}:${REMOTE_SCRIPTS}"
 
-# 3. Stop web → replace binary on host → start web. Stopping is required
-#    because /opt/cr/cr-web-bin is bind-mounted into a running container
-#    and neither scp (ETXTBSY) nor docker cp (device-busy on bind mount)
-#    can overwrite it while the container runs.
+# 3. Stop web → replace binary on host → start web.
+#    A trap covers the gap so a mid-deploy failure (e.g. scp interrupted)
+#    doesn't leave the container stopped and the site offline.
+container_stopped=0
+restart_on_failure() {
+  local rc=$?
+  if [ "$rc" -ne 0 ] && [ "$container_stopped" = "1" ]; then
+    echo "ERROR mid-deploy (rc=$rc) — restarting ${COMPOSE_SERVICE} to recover prod ..." >&2
+    "${ssh_cmd[@]}" "docker compose -f ${COMPOSE_FILE} start ${COMPOSE_SERVICE}" >&2 || \
+      echo "WARN: recovery start also failed; investigate manually." >&2
+  fi
+}
+trap restart_on_failure EXIT
+
 echo "==> Stopping ${COMPOSE_SERVICE} container ..."
 "${ssh_cmd[@]}" "docker compose -f ${COMPOSE_FILE} stop ${COMPOSE_SERVICE}"
+container_stopped=1
 
 echo "==> Uploading binary to ${REMOTE_BIN} ..."
 scp -P "$VPS_PORT" "$bin_path" "${VPS_USER}@${VPS_HOST}:${REMOTE_BIN}"
 
 echo "==> Starting ${COMPOSE_SERVICE} container ..."
 "${ssh_cmd[@]}" "docker compose -f ${COMPOSE_FILE} start ${COMPOSE_SERVICE}"
+container_stopped=0
 
 # 4. Health check — poll /health until 200 or 10s deadline.
 echo "==> Waiting for /health ..."


### PR DESCRIPTION
<!-- claude-session: fd55863a-01fd-456b-b70d-ea0440e6400a -->

Closes #707

## Summary
- Add `scripts/deploy.sh` — one-shot deploy: drift check → cargo zigbuild → rsync scripts/ → stop+scp+start → curl /health
- Update CLAUDE.md deploy section to point at the helper and document the real ETXTBSY / "device or resource busy" reasons we have to stop the container

## Why
On 2026-05-13 morning, the cr-auto-import.timer (05:09 UTC) inserted 12 films with TMDB vote_average in the wrong column because `/opt/cr/scripts/auto_import/enricher.py` was 2 days stale relative to migration 069 (#691). The Rust binary was redeployed; the Python sync was forgotten. `scripts/deploy.sh` makes "ship both" the default and adds a dry-run drift warning that flags this kind of partial-deploy aftermath before the next push.

## Test plan
- [x] Local syntax check (`bash -n scripts/deploy.sh`)
- [x] First run end-to-end against prod (shipped the helper itself + ~5s downtime, /health OK)
- [x] Second run shows "scripts/ is already in sync." (idempotence)
- [x] Playwright check on `https://ceskarepublika.wiki/filmy-online/` — site renders, today's films show TMDB badges
- [x] Real deploy procedure now matches CLAUDE.md instead of drifting from it