### PR TITLE
fix(importers): seed tmdb_rating + tmdb_vote_count at INSERT

### DIFF
--- a/scripts/auto_import/enricher.py
+++ b/scripts/auto_import/enricher.py
@@ -164,6 +164,7 @@ def upsert_film(
             "has_subtitles = has_subtitles OR %s, "
             "imdb_id = COALESCE(imdb_id, %s), "
             "tmdb_rating = COALESCE(tmdb_rating, %s), "
+            "tmdb_vote_count = COALESCE(tmdb_vote_count, %s), "
             "tmdb_rating_synced_at = COALESCE(tmdb_rating_synced_at, now()), "
             "csfd_rating = COALESCE(csfd_rating, %s), "
             "tmdb_poster_path = COALESCE(tmdb_poster_path, %s), "
@@ -172,7 +173,7 @@ def upsert_film(
             (sktorrent_video_id, sktorrent_cdn, qualities_str,
              has_dub, has_subtitles,
              movie.imdb_id,
-             movie.vote_average, csfd_rating,
+             movie.vote_average, movie.vote_count, csfd_rating,
              movie.poster_path,
              film_id),
         )
@@ -210,29 +211,33 @@ def upsert_film(
     generated = generate_unique_cs(title_cs, movie.year, sources, is_series=False)
     description = generated or movie.overview_cs or movie.overview_en
 
-    # tmdb_rating is seeded from TMDB's vote_average. csfd_rating comes
-    # straight from the SK Torrent title when present ("= CSFD 82%"). Both
-    # NULL for new-release films and obscure CZ titles; the list page
-    # already handles missing ratings gracefully. The sibling `imdb_rating`
-    # column is populated separately by scripts/sync-imdb-ratings.py
-    # (#690) from the public IMDb datasets TSV.
+    # tmdb_rating + tmdb_vote_count are seeded from TMDB's vote_average /
+    # vote_count. csfd_rating comes straight from the SK Torrent title when
+    # present ("= CSFD 82%"). All three may be NULL for new-release films
+    # and obscure CZ titles; the list page already handles missing ratings
+    # gracefully. The sibling `imdb_rating` column is populated separately
+    # by scripts/sync-imdb-ratings.py (#690) from the public IMDb datasets
+    # TSV. Seeding both rating + vote_count at INSERT closes #590 — before
+    # this the row was NULL until the daily sync-tmdb-ratings.py /changes
+    # poller happened to include the tmdb_id in its window.
     tmdb_rating = movie.vote_average
+    tmdb_vote_count = movie.vote_count
     cur.execute(
         """INSERT INTO films
            (title, original_title, slug, year, description,
             imdb_id, tmdb_id, runtime_min,
-            tmdb_rating, tmdb_rating_synced_at, csfd_rating,
+            tmdb_rating, tmdb_vote_count, tmdb_rating_synced_at, csfd_rating,
             sktorrent_video_id, sktorrent_cdn, sktorrent_qualities,
             has_dub, has_subtitles,
             tmdb_poster_path,
             added_at, sktorrent_added_at)
-           VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, now(), %s, %s, %s, %s, %s, %s, %s, now(), now())
+           VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, now(), %s, %s, %s, %s, %s, %s, %s, now(), now())
            RETURNING id""",
         (
             title_cs, title_en if title_en != title_cs else None, slug, movie.year,
             description,
             movie.imdb_id, movie.tmdb_id, movie.runtime_min,
-            tmdb_rating, csfd_rating,
+            tmdb_rating, tmdb_vote_count, csfd_rating,
             sktorrent_video_id, sktorrent_cdn, qualities_str,
             has_dub, has_subtitles,
             movie.poster_path,

--- a/scripts/auto_import/series_enricher.py
+++ b/scripts/auto_import/series_enricher.py
@@ -132,12 +132,22 @@ def ensure_series(
     generated = generate_unique_cs(name_cs, tv.first_air_year, sources, is_series=True)
     description = generated or tv.overview_cs or tv.overview_en
 
+    # Seed tmdb_rating + tmdb_vote_count at INSERT (#590). Both may be None
+    # for brand-new shows with no votes — the resolver already coerces
+    # vote_average=0/vote_count=0 to None to avoid bogus 0.0 ratings on the
+    # list page. tmdb_rating_synced_at is stamped unconditionally (matching
+    # the films INSERT in enricher.py) so the daily sync-tmdb-ratings.py
+    # treats this row as "we tried, no votes yet" instead of "never synced".
     cur.execute(
         """INSERT INTO series
            (title, original_title, slug, first_air_year, last_air_year,
             description, imdb_id, tmdb_id,
-            season_count, episode_count, tmdb_poster_path, added_at)
-           VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s, now())
+            season_count, episode_count, tmdb_poster_path,
+            tmdb_rating, tmdb_vote_count, tmdb_rating_synced_at,
+            added_at)
+           VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,
+                   %s,%s,now(),
+                   now())
            RETURNING id""",
         (
             name_cs, name_en if name_en != name_cs else None, slug,
@@ -146,6 +156,7 @@ def ensure_series(
             tv.imdb_id, tv.tmdb_id,
             tv.season_count, tv.episode_count,
             tv.poster_path,
+            tv.vote_average, tv.vote_count,
         ),
     )
     series_id = cur.fetchone()[0]

--- a/scripts/auto_import/tmdb_resolver.py
+++ b/scripts/auto_import/tmdb_resolver.py
@@ -306,6 +306,24 @@ def _tv_search_queries(parsed: ParsedTitle) -> list[tuple[str, dict]]:
     return out
 
 
+def _vote_pair(src: dict, src_en: dict) -> dict:
+    """Return {vote_average, vote_count} with the project-wide gating rule:
+    rating is only meaningful when vote_count > 0. Both fields move in
+    lockstep — either both populated or both None. Resolves from `src`
+    first, falls back to `src_en` per field (the CS endpoint occasionally
+    omits one or the other). See #590 acceptance criteria.
+    """
+    vc_raw = src.get("vote_count") or src_en.get("vote_count")
+    vote_count = int(vc_raw) if vc_raw else None
+    if vote_count is None:
+        return {"vote_average": None, "vote_count": None}
+    va_raw = src.get("vote_average") or src_en.get("vote_average")
+    return {
+        "vote_average": float(va_raw) if va_raw else None,
+        "vote_count": vote_count,
+    }
+
+
 def _build_movie_resolution(session: requests.Session, candidate: dict, score: float) -> MovieResolution | None:
     """Fetch full /movie/{id} (CS + EN) and return a complete MovieResolution."""
     tmdb_id = candidate.get("id")
@@ -321,15 +339,9 @@ def _build_movie_resolution(session: requests.Session, candidate: dict, score: f
     rd = (cs or src_en).get("release_date") or ""
     year = int(rd[:4]) if len(rd) >= 4 and rd[:4].isdigit() else None
 
-    # TMDB returns vote_average=0 for brand-new films with no votes yet —
-    # treat that as "no rating" to avoid seeding the column with a bogus 0.0
-    # that the list page would then display as a legit rating. Same gate
-    # applies to vote_count: 0 means "TMDB has the row but no votes", which
-    # we want represented as NULL in the DB (the column is nullable).
-    va_raw = src.get("vote_average") or src_en.get("vote_average")
-    vote_average = float(va_raw) if va_raw else None
-    vc_raw = src.get("vote_count") or src_en.get("vote_count")
-    vote_count = int(vc_raw) if vc_raw else None
+    # vote_average + vote_count via the project-wide _vote_pair gating
+    # rule: both populated or both None, never a rating without votes.
+    votes = _vote_pair(src, src_en)
 
     raw_cs_title = (cs or {}).get("title")
     en_title = src_en.get("title") or src.get("title")
@@ -348,8 +360,7 @@ def _build_movie_resolution(session: requests.Session, candidate: dict, score: f
         runtime_min=src.get("runtime") or src_en.get("runtime"),
         poster_path=src.get("poster_path") or src_en.get("poster_path"),
         genre_ids=[g["id"] for g in (src.get("genres") or src_en.get("genres") or []) if g.get("id")],
-        vote_average=vote_average,
-        vote_count=vote_count,
+        **votes,
         popularity=float(candidate.get("popularity") or 0.0),
         raw_search_score=score,
     )
@@ -392,25 +403,11 @@ def _build_tv_resolution(session: requests.Session, candidate: dict, score: floa
         episode_count=src.get("number_of_episodes"),
         poster_path=src.get("poster_path") or src_en.get("poster_path"),
         genre_ids=[g["id"] for g in (src.get("genres") or src_en.get("genres") or []) if g.get("id")],
-        # TMDB returns vote_average=0 for TV shows with no votes yet —
-        # treat that as None so we don't pollute `series.tmdb_rating`
-        # with a spurious 0.0 (same rule as the films resolver above).
-        # Resolve from src first, fall back to src_en — and crucially
-        # coerce BEFORE the float() call so a None from one side doesn't
-        # crash the other side's lookup. Previously this expression
-        # called `float(src.get("vote_average"))` even when src lacked
-        # the key but src_en had it, raising TypeError, and silently
-        # stored 0.0 when src had 0 but src_en had a real rating.
-        vote_average=(
-            (lambda va: float(va) if va else None)(
-                src.get("vote_average") or src_en.get("vote_average")
-            )
-        ),
-        vote_count=(
-            (lambda vc: int(vc) if vc else None)(
-                src.get("vote_count") or src_en.get("vote_count")
-            )
-        ),
+        # Rating gated on vote_count > 0 (same rule as the films resolver):
+        # TMDB occasionally returns a non-zero average with vote_count=0
+        # after a vote retraction. We mirror the films behavior so the
+        # listing page never shows a badge backed by zero votes.
+        **_vote_pair(src, src_en),
         popularity=float(candidate.get("popularity") or 0.0),
         raw_search_score=score,
     )

--- a/scripts/auto_import/tmdb_resolver.py
+++ b/scripts/auto_import/tmdb_resolver.py
@@ -116,6 +116,10 @@ class MovieResolution:
     # populated separately by scripts/sync-imdb-ratings.py from the public
     # IMDb datasets TSV (#690).
     vote_average: float | None = None
+    # TMDB's vote_count — paired with vote_average. Persisted into
+    # `films.tmdb_vote_count` so the listing-rating filter (#704) can
+    # apply a credibility threshold ("hide titles with <N votes").
+    vote_count: int | None = None
     popularity: float = 0.0
     raw_search_score: float = 0.0  # how confident we are in the match
 
@@ -143,6 +147,9 @@ class TvResolution:
     # as the films resolver: TMDB returns vote_average=0 to mean "no
     # votes," not "zero stars," so we coerce that to None.
     vote_average: float | None = None
+    # Paired vote_count — persisted into `series.tmdb_vote_count` /
+    # `tv_shows.tmdb_vote_count`. None when there are no votes yet.
+    vote_count: int | None = None
     popularity: float = 0.0
     raw_search_score: float = 0.0
 
@@ -316,9 +323,13 @@ def _build_movie_resolution(session: requests.Session, candidate: dict, score: f
 
     # TMDB returns vote_average=0 for brand-new films with no votes yet —
     # treat that as "no rating" to avoid seeding the column with a bogus 0.0
-    # that the list page would then display as a legit rating.
+    # that the list page would then display as a legit rating. Same gate
+    # applies to vote_count: 0 means "TMDB has the row but no votes", which
+    # we want represented as NULL in the DB (the column is nullable).
     va_raw = src.get("vote_average") or src_en.get("vote_average")
     vote_average = float(va_raw) if va_raw else None
+    vc_raw = src.get("vote_count") or src_en.get("vote_count")
+    vote_count = int(vc_raw) if vc_raw else None
 
     raw_cs_title = (cs or {}).get("title")
     en_title = src_en.get("title") or src.get("title")
@@ -338,6 +349,7 @@ def _build_movie_resolution(session: requests.Session, candidate: dict, score: f
         poster_path=src.get("poster_path") or src_en.get("poster_path"),
         genre_ids=[g["id"] for g in (src.get("genres") or src_en.get("genres") or []) if g.get("id")],
         vote_average=vote_average,
+        vote_count=vote_count,
         popularity=float(candidate.get("popularity") or 0.0),
         raw_search_score=score,
     )
@@ -392,6 +404,11 @@ def _build_tv_resolution(session: requests.Session, candidate: dict, score: floa
         vote_average=(
             (lambda va: float(va) if va else None)(
                 src.get("vote_average") or src_en.get("vote_average")
+            )
+        ),
+        vote_count=(
+            (lambda vc: int(vc) if vc else None)(
+                src.get("vote_count") or src_en.get("vote_count")
             )
         ),
         popularity=float(candidate.get("popularity") or 0.0),

--- a/scripts/auto_import/tv_show_enricher.py
+++ b/scripts/auto_import/tv_show_enricher.py
@@ -109,11 +109,21 @@ def process_tv_show_episode(
         base_slug = _slugify(title) or f"tv-porad-{tv.tmdb_id}"
         slug = _unique_slug(cur, base_slug)
         try:
+            # Seed tmdb_rating + tmdb_vote_count at INSERT (#590). Same
+            # rationale as series_enricher.py: the resolver maps TMDB's
+            # vote_average=0/vote_count=0 ("no votes yet") to None so the
+            # list page doesn't render bogus 0.0 ratings, and synced_at is
+            # stamped unconditionally so the daily sync can distinguish
+            # "we tried, no votes" from "never synced".
             cur.execute(
                 """INSERT INTO tv_shows (title, slug, tmdb_id, imdb_id,
                        first_air_year, description,
-                       tmdb_poster_path, added_at)
-                   VALUES (%s, %s, %s, %s, %s, %s, %s, now())
+                       tmdb_poster_path,
+                       tmdb_rating, tmdb_vote_count, tmdb_rating_synced_at,
+                       added_at)
+                   VALUES (%s, %s, %s, %s, %s, %s, %s,
+                           %s, %s, now(),
+                           now())
                    RETURNING id""",
                 (
                     title[:255],
@@ -123,6 +133,8 @@ def process_tv_show_episode(
                     tv.first_air_year,
                     description,
                     tv.poster_path,
+                    tv.vote_average,
+                    tv.vote_count,
                 ),
             )
             tv_show_id = cur.fetchone()[0]

--- a/scripts/import-prehrajto-new-films.py
+++ b/scripts/import-prehrajto-new-films.py
@@ -444,11 +444,18 @@ def fetch_tmdb_movie(tmdb_id: int, api_key: str) -> dict | None:
     src_en = en or {}
     rd = src_cs.get("release_date") or src_en.get("release_date") or ""
     year = int(rd[:4]) if len(rd) >= 4 and rd[:4].isdigit() else None
-    # vote_average=0 / vote_count=0 means "no votes yet" on TMDB — coerce
-    # to None so we don't seed films.tmdb_rating with a bogus 0.0 that the
-    # listing page would render as a legit "zero stars" badge (#590).
-    va_raw = src_cs.get("vote_average") or src_en.get("vote_average")
+    # Rating is gated on vote_count > 0 (#590 acceptance criterion):
+    # TMDB sometimes returns a non-zero average with vote_count=0 (after
+    # a vote retraction) and always vote_average=0 for brand-new films.
+    # Both cases must store tmdb_rating=NULL, so we parse vote_count
+    # first and only keep vote_average when there are actual votes.
     vc_raw = src_cs.get("vote_count") or src_en.get("vote_count")
+    vote_count = int(vc_raw) if vc_raw else None
+    if vote_count is None:
+        vote_average = None
+    else:
+        va_raw = src_cs.get("vote_average") or src_en.get("vote_average")
+        vote_average = float(va_raw) if va_raw else None
     return {
         "tmdb_id": tmdb_id,
         "imdb_id": src_cs.get("imdb_id") or src_en.get("imdb_id") or None,
@@ -461,8 +468,8 @@ def fetch_tmdb_movie(tmdb_id: int, api_key: str) -> dict | None:
         "runtime_min": src_cs.get("runtime") or src_en.get("runtime") or None,
         "poster_path": src_cs.get("poster_path") or src_en.get("poster_path") or None,
         "genre_ids": [g["id"] for g in (src_cs.get("genres") or src_en.get("genres") or []) if g.get("id")],
-        "vote_average": float(va_raw) if va_raw else None,
-        "vote_count": int(vc_raw) if vc_raw else None,
+        "vote_average": vote_average,
+        "vote_count": vote_count,
     }
 
 

--- a/scripts/import-prehrajto-new-films.py
+++ b/scripts/import-prehrajto-new-films.py
@@ -433,8 +433,8 @@ def fetch_tmdb_movie(tmdb_id: int, api_key: str) -> dict | None:
     """Fetch cs-CZ + en-US /movie/{id} and merge into one dict.
 
     Returns keys: title_cs, title_en, original_title, overview_cs, overview_en,
-    year, runtime_min, poster_path, genre_ids, imdb_id. Returns None if both
-    language fetches fail (usually a stale tmdb_id).
+    year, runtime_min, poster_path, genre_ids, imdb_id, vote_average, vote_count.
+    Returns None if both language fetches fail (usually a stale tmdb_id).
     """
     cs = tmdb_get(f"/movie/{tmdb_id}", {"language": "cs-CZ"}, api_key)
     en = tmdb_get(f"/movie/{tmdb_id}", {"language": "en-US"}, api_key)
@@ -444,6 +444,11 @@ def fetch_tmdb_movie(tmdb_id: int, api_key: str) -> dict | None:
     src_en = en or {}
     rd = src_cs.get("release_date") or src_en.get("release_date") or ""
     year = int(rd[:4]) if len(rd) >= 4 and rd[:4].isdigit() else None
+    # vote_average=0 / vote_count=0 means "no votes yet" on TMDB — coerce
+    # to None so we don't seed films.tmdb_rating with a bogus 0.0 that the
+    # listing page would render as a legit "zero stars" badge (#590).
+    va_raw = src_cs.get("vote_average") or src_en.get("vote_average")
+    vc_raw = src_cs.get("vote_count") or src_en.get("vote_count")
     return {
         "tmdb_id": tmdb_id,
         "imdb_id": src_cs.get("imdb_id") or src_en.get("imdb_id") or None,
@@ -456,6 +461,8 @@ def fetch_tmdb_movie(tmdb_id: int, api_key: str) -> dict | None:
         "runtime_min": src_cs.get("runtime") or src_en.get("runtime") or None,
         "poster_path": src_cs.get("poster_path") or src_en.get("poster_path") or None,
         "genre_ids": [g["id"] for g in (src_cs.get("genres") or src_en.get("genres") or []) if g.get("id")],
+        "vote_average": float(va_raw) if va_raw else None,
+        "vote_count": int(vc_raw) if vc_raw else None,
     }
 
 
@@ -637,11 +644,17 @@ def main() -> int:
         # INSERT film. ON CONFLICT (imdb_id) requires the partial UNIQUE index
         # added by migration 050; we always supply a non-NULL imdb_id so the
         # conflict target is well-defined.
+        # tmdb_rating + tmdb_vote_count are seeded from TMDB at INSERT
+        # (#590). tmdb_rating_synced_at is stamped unconditionally so the
+        # daily sync-tmdb-ratings.py knows the row was already touched —
+        # before this fix the row stayed NULL until sync happened to hit
+        # the tmdb_id via /movie/changes, which only includes recently
+        # updated TMDB titles and never our backlog imports.
         insert_film_sql = """
         INSERT INTO films (
             title, original_title, slug, year, description,
             imdb_id, tmdb_id, runtime_min,
-            tmdb_rating, csfd_rating,
+            tmdb_rating, tmdb_vote_count, tmdb_rating_synced_at, csfd_rating,
             sktorrent_video_id, sktorrent_cdn, sktorrent_qualities,
             has_dub, has_subtitles,
             prehrajto_url, prehrajto_has_dub, prehrajto_has_subs,
@@ -651,7 +664,7 @@ def main() -> int:
         ) VALUES (
             %(title)s, %(original_title)s, %(slug)s, %(year)s, %(description)s,
             %(imdb_id)s, %(tmdb_id)s, %(runtime_min)s,
-            NULL, NULL,
+            %(tmdb_rating)s, %(tmdb_vote_count)s, NOW(), NULL,
             NULL, NULL, NULL,
             false, false,
             NULL, %(has_cz_audio)s, %(has_cz_subs)s,
@@ -846,6 +859,8 @@ def main() -> int:
                         "imdb_id": imdb,
                         "tmdb_id": tmdb_id,
                         "runtime_min": runtime_min,
+                        "tmdb_rating": movie.get("vote_average"),
+                        "tmdb_vote_count": movie.get("vote_count"),
                         "has_cz_audio": has_cz_audio,
                         "has_cz_subs": has_cz_subs,
                         "primary_upload": primary_upload_id,

--- a/scripts/import-prehrajto-series.py
+++ b/scripts/import-prehrajto-series.py
@@ -544,7 +544,9 @@ def _stamp_ratings(cur, series_id: int, tv,
               tmdb_rating           = COALESCE(tmdb_rating, %s),
               tmdb_vote_count       = COALESCE(tmdb_vote_count, %s),
               tmdb_rating_synced_at = CASE
-                  WHEN tmdb_rating IS NULL AND %s IS NOT NULL THEN now()
+                  WHEN (tmdb_rating IS NULL AND %s IS NOT NULL)
+                    OR (tmdb_vote_count IS NULL AND %s IS NOT NULL)
+                      THEN now()
                   ELSE tmdb_rating_synced_at
               END,
               imdb_rating           = COALESCE(imdb_rating, %s),
@@ -554,7 +556,7 @@ def _stamp_ratings(cur, series_id: int, tv,
                   ELSE imdb_rating_synced_at
               END
            WHERE id = %s""",
-        (tmdb_rating, tmdb_vote_count, tmdb_rating,
+        (tmdb_rating, tmdb_vote_count, tmdb_rating, tmdb_vote_count,
          imdb_rating, imdb_votes, imdb_rating,
          series_id),
     )

--- a/scripts/import-prehrajto-series.py
+++ b/scripts/import-prehrajto-series.py
@@ -530,6 +530,7 @@ def _stamp_ratings(cur, series_id: int, tv,
     convention as `sync-imdb-ratings.py`.
     """
     tmdb_rating = tv.vote_average
+    tmdb_vote_count = tv.vote_count
     imdb_rating: float | None = None
     imdb_votes: int | None = None
     if getattr(tv, "imdb_id", None):
@@ -541,6 +542,7 @@ def _stamp_ratings(cur, series_id: int, tv,
     cur.execute(
         """UPDATE series SET
               tmdb_rating           = COALESCE(tmdb_rating, %s),
+              tmdb_vote_count       = COALESCE(tmdb_vote_count, %s),
               tmdb_rating_synced_at = CASE
                   WHEN tmdb_rating IS NULL AND %s IS NOT NULL THEN now()
                   ELSE tmdb_rating_synced_at
@@ -552,7 +554,7 @@ def _stamp_ratings(cur, series_id: int, tv,
                   ELSE imdb_rating_synced_at
               END
            WHERE id = %s""",
-        (tmdb_rating, tmdb_rating,
+        (tmdb_rating, tmdb_vote_count, tmdb_rating,
          imdb_rating, imdb_votes, imdb_rating,
          series_id),
     )

--- a/scripts/import-prehrajto-tmdb-as-film.py
+++ b/scripts/import-prehrajto-tmdb-as-film.py
@@ -191,15 +191,20 @@ def _build_film_row(merged: dict) -> Optional[dict]:
     # the consolidation migration enforces project-wide.
     _ = (overview_cs, overview_en)  # documented intent; not persisted
 
-    # vote_average=0 / vote_count=0 mean "no votes yet" on TMDB — store
-    # both as NULL so the list page doesn't render a bogus 0/10 rating
-    # (#590). Goes into `tmdb_rating` + `tmdb_vote_count`; the real IMDb
-    # rating in `imdb_rating` is filled in separately by
+    # Rating is gated on vote_count > 0 (#590 acceptance criterion):
+    # if TMDB has no votes yet, both tmdb_rating and tmdb_vote_count
+    # land as NULL — even if vote_average happens to be non-zero (which
+    # TMDB occasionally returns right after a vote retraction). The
+    # listing page treats NULL as "no badge" instead of "0/10". The
+    # real IMDb rating in `imdb_rating` is filled in separately by
     # scripts/sync-imdb-ratings.py from the IMDb datasets TSV (#690).
-    va_raw = cs.get("vote_average") or en.get("vote_average")
-    tmdb_rating = float(va_raw) if va_raw else None
     vc_raw = cs.get("vote_count") or en.get("vote_count")
     tmdb_vote_count = int(vc_raw) if vc_raw else None
+    if tmdb_vote_count is None:
+        tmdb_rating = None
+    else:
+        va_raw = cs.get("vote_average") or en.get("vote_average")
+        tmdb_rating = float(va_raw) if va_raw else None
 
     poster_path = cs.get("poster_path") or en.get("poster_path")
     imdb_id = cs.get("imdb_id") or en.get("imdb_id")

--- a/scripts/import-prehrajto-tmdb-as-film.py
+++ b/scripts/import-prehrajto-tmdb-as-film.py
@@ -191,12 +191,15 @@ def _build_film_row(merged: dict) -> Optional[dict]:
     # the consolidation migration enforces project-wide.
     _ = (overview_cs, overview_en)  # documented intent; not persisted
 
-    # vote_average=0 means "no votes yet" — store as NULL so the list
-    # page doesn't render a bogus 0/10 rating. Goes into `tmdb_rating`;
-    # the real IMDb rating in `imdb_rating` is filled in separately by
+    # vote_average=0 / vote_count=0 mean "no votes yet" on TMDB — store
+    # both as NULL so the list page doesn't render a bogus 0/10 rating
+    # (#590). Goes into `tmdb_rating` + `tmdb_vote_count`; the real IMDb
+    # rating in `imdb_rating` is filled in separately by
     # scripts/sync-imdb-ratings.py from the IMDb datasets TSV (#690).
     va_raw = cs.get("vote_average") or en.get("vote_average")
     tmdb_rating = float(va_raw) if va_raw else None
+    vc_raw = cs.get("vote_count") or en.get("vote_count")
+    tmdb_vote_count = int(vc_raw) if vc_raw else None
 
     poster_path = cs.get("poster_path") or en.get("poster_path")
     imdb_id = cs.get("imdb_id") or en.get("imdb_id")
@@ -214,6 +217,7 @@ def _build_film_row(merged: dict) -> Optional[dict]:
         "year": year,
         "runtime_min": int(runtime) if runtime else None,
         "tmdb_rating": tmdb_rating,
+        "tmdb_vote_count": tmdb_vote_count,
         "tmdb_poster_path": poster_path,
         "genre_ids": genre_ids,
     }
@@ -233,16 +237,16 @@ def _insert_film(cur, row: dict) -> int:
         """INSERT INTO films
                (title, original_title, slug, year,
                 imdb_id, tmdb_id, runtime_min,
-                tmdb_rating, tmdb_rating_synced_at,
+                tmdb_rating, tmdb_vote_count, tmdb_rating_synced_at,
                 tmdb_poster_path,
                 added_at)
-           VALUES (%s, %s, %s, %s, %s, %s, %s, %s, now(), %s, now())
+           VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, now(), %s, now())
            RETURNING id""",
         (
             row["title"], row.get("original_title"), slug,
             row.get("year"),
             row.get("imdb_id"), row["tmdb_id"], row.get("runtime_min"),
-            row.get("tmdb_rating"),
+            row.get("tmdb_rating"), row.get("tmdb_vote_count"),
             row.get("tmdb_poster_path"),
         ),
     )

--- a/scripts/import-sledujteto-films.py
+++ b/scripts/import-sledujteto-films.py
@@ -492,15 +492,19 @@ def build_film_row(
     )
     year = int(release_date[:4]) if release_date and len(release_date) >= 4 else None
 
-    # TMDB returns 0.0 for films with no votes; we store NULL in that case
-    # so the listing badge is hidden rather than showing a misleading 0.0.
-    # Same rule for vote_count: 0 → None (#590). The real IMDb rating lives
-    # in `films.imdb_rating` and is populated separately by
-    # scripts/sync-imdb-ratings.py from the IMDb datasets TSV.
-    vote_average = (tmdb_meta or {}).get("vote_average")
-    tmdb_rating = float(vote_average) if vote_average and vote_average > 0 else None
+    # Rating is gated on vote_count > 0 (#590 acceptance criterion):
+    # both tmdb_rating and tmdb_vote_count must land as NULL when TMDB
+    # has no votes yet, even if vote_average is non-zero (TMDB sometimes
+    # returns this after a vote retraction). The listing badge hides
+    # NULL ratings. The real IMDb rating lives in `films.imdb_rating`
+    # and is populated separately by scripts/sync-imdb-ratings.py.
     vote_count = (tmdb_meta or {}).get("vote_count")
     tmdb_vote_count = int(vote_count) if vote_count and vote_count > 0 else None
+    if tmdb_vote_count is None:
+        tmdb_rating = None
+    else:
+        vote_average = (tmdb_meta or {}).get("vote_average")
+        tmdb_rating = float(vote_average) if vote_average and vote_average > 0 else None
 
     return {
         "title": title[:255],

--- a/scripts/import-sledujteto-films.py
+++ b/scripts/import-sledujteto-films.py
@@ -320,12 +320,12 @@ INSERT_FILM_SQL = """
 INSERT INTO films (
     title, original_title, slug, year, description,
     tmdb_id, runtime_min, tmdb_poster_path, lang,
-    tmdb_rating, tmdb_rating_synced_at,
+    tmdb_rating, tmdb_vote_count, tmdb_rating_synced_at,
     created_at, added_at
 ) VALUES (
     %(title)s, %(original_title)s, %(slug)s, %(year)s, %(description)s,
     %(tmdb_id)s, %(runtime_min)s, %(tmdb_poster_path)s, %(lang)s,
-    %(tmdb_rating)s, NOW(),
+    %(tmdb_rating)s, %(tmdb_vote_count)s, NOW(),
     NOW(), NOW()
 )
 RETURNING id
@@ -494,10 +494,13 @@ def build_film_row(
 
     # TMDB returns 0.0 for films with no votes; we store NULL in that case
     # so the listing badge is hidden rather than showing a misleading 0.0.
-    # The real IMDb rating lives in `films.imdb_rating` and is populated
-    # separately by scripts/sync-imdb-ratings.py from the IMDb datasets TSV.
+    # Same rule for vote_count: 0 → None (#590). The real IMDb rating lives
+    # in `films.imdb_rating` and is populated separately by
+    # scripts/sync-imdb-ratings.py from the IMDb datasets TSV.
     vote_average = (tmdb_meta or {}).get("vote_average")
     tmdb_rating = float(vote_average) if vote_average and vote_average > 0 else None
+    vote_count = (tmdb_meta or {}).get("vote_count")
+    tmdb_vote_count = int(vote_count) if vote_count and vote_count > 0 else None
 
     return {
         "title": title[:255],
@@ -510,6 +513,7 @@ def build_film_row(
         "tmdb_poster_path": ((tmdb_meta or {}).get("poster_path") or "")[:64] or None,
         "lang": ((tmdb_meta or {}).get("original_language") or "")[:20] or None,
         "tmdb_rating": tmdb_rating,
+        "tmdb_vote_count": tmdb_vote_count,
     }
 
 


### PR DESCRIPTION
<!-- claude-session: fd55863a-01fd-456b-b70d-ea0440e6400a -->

Closes #590

## Summary
Wires TMDB's `vote_average` + `vote_count` into every importer's INSERT path so newly imported films/series/tv_shows get rated immediately, instead of staying NULL until the daily `sync-tmdb-ratings.py` happens to include the `tmdb_id` in its `/movie/changes` window (which only covers recently-edited TMDB titles, not backlog imports).

## What changed
Seven importers + the resolver dataclasses:
- `auto_import/tmdb_resolver.py` — `MovieResolution`/`TvResolution` gained `vote_count`; both `_build_movie_resolution` and `_build_tv_resolution` populate it from TMDB, with `vote_count=0 → None` (same rule as `vote_average=0`)
- `auto_import/enricher.py` — films INSERT + UPDATE both write `tmdb_vote_count` alongside the existing `tmdb_rating`
- `auto_import/series_enricher.py` — previously wrote no rating columns; now seeds all three (rating, count, synced_at)
- `auto_import/tv_show_enricher.py` — same fix
- `scripts/import-prehrajto-new-films.py` — `NULL, NULL` was hardcoded; now extracts `vote_average`+`vote_count` from `fetch_tmdb_movie()` (which the script was already calling) and threads them through
- `scripts/import-prehrajto-series.py` — `_stamp_ratings()` writes `tmdb_vote_count` alongside `tmdb_rating`
- `scripts/import-prehrajto-tmdb-as-film.py` — payload + INSERT both carry `tmdb_vote_count`
- `scripts/import-sledujteto-films.py` — payload + `INSERT_FILM_SQL` both carry `tmdb_vote_count`

## Out of scope
`scripts/import-tv-porady.py` is a one-shot staging→prod migration whose source table (`sktorrent_tv_porady`) has no rating columns. Adding TMDB API calls there is a separate change. The daily auto-import flow for tv_shows goes through `tv_show_enricher.py` which IS covered here.

## Test plan
- [x] `python3 -m py_compile` on every changed file
- [x] Local TMDB resolver round-trip: `_build_movie_resolution` for `tmdb_id=298504` returns `vote_average=7.119, vote_count=118`; `_build_tv_resolution` for `tmdb_id=60625` returns `vote_average=8.675, vote_count=10827`
- [x] Deploy via `./scripts/deploy.sh` (rsync picked up all 8 changed scripts, restart, /health 200)
- [x] **End-to-end test against prod** with savepoint+rollback: a synthetic INSERT for `tmdb_id=1314481` ("Ďábel nosí Pradu 2") produced `tmdb_rating=6.761, tmdb_vote_count=469, tmdb_rating_synced_at=now()` — all three populated as required by the acceptance criteria
- [x] `https://ceskarepublika.wiki/filmy-online/` still serves 200 after deploy
- [ ] Tomorrow's 05:09 UTC `cr-auto-import.timer` is the real-world dogfood test — new films will arrive with both columns populated