### PR TITLE
feat(web): filter rating-sort listings by minimum vote count (#704)

### DIFF
--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -412,6 +412,19 @@ impl FilmsQuery {
         self.razeni.as_deref().unwrap_or("pridano")
     }
 
+    /// Credibility threshold for rating-sort listings (#704). 10/10 with 5
+    /// voters used to outrank Shawshank's 3M voters at the top of
+    /// `?razeni=imdb` / `?razeni=tmdb`; the thresholds keep low-sample
+    /// outliers off the leaderboard. NULL votes evaluate to false in the
+    /// inequality, so no explicit `IS NOT NULL` is needed.
+    fn votes_threshold_predicate(&self) -> Option<&'static str> {
+        match self.razeni.as_deref() {
+            Some("imdb") => Some("f.imdb_votes >= 500"),
+            Some("tmdb") => Some("f.tmdb_vote_count >= 50"),
+            _ => None,
+        }
+    }
+
     fn parse_genre_slugs(input: Option<&String>) -> Vec<String> {
         // Dedup to keep AND-mode `HAVING COUNT(DISTINCT g.slug) = slugs.len()` correct.
         let mut slugs: Vec<String> = Vec::new();
@@ -1091,6 +1104,9 @@ async fn films_by_genre(
     if let Some(af) = params.audio_filter() {
         where_parts.push(af.to_string());
     }
+    if let Some(p) = params.votes_threshold_predicate() {
+        where_parts.push(p.to_string());
+    }
     let where_clause = where_parts.join(" AND ");
 
     // Count
@@ -1417,6 +1433,9 @@ async fn run_films_query(
                  WHERE vs.film_id = f.id AND vs.is_alive)"
             .to_string(),
     );
+    if let Some(p) = params.votes_threshold_predicate() {
+        where_parts.push(p.to_string());
+    }
 
     let where_clause = if where_parts.is_empty() {
         String::new()

--- a/cr-web/src/handlers/series.rs
+++ b/cr-web/src/handlers/series.rs
@@ -254,6 +254,16 @@ impl SeriesQuery {
         self.razeni.as_deref().unwrap_or("pridano")
     }
 
+    /// Credibility threshold for rating-sort listings (#704). Mirrors
+    /// FilmsQuery::votes_threshold_predicate — see comment there.
+    fn votes_threshold_predicate(&self) -> Option<&'static str> {
+        match self.razeni.as_deref() {
+            Some("imdb") => Some("s.imdb_votes >= 500"),
+            Some("tmdb") => Some("s.tmdb_vote_count >= 50"),
+            _ => None,
+        }
+    }
+
     /// Whether the user picked a non-default sort that the latest-episode
     /// listing can't honour (it's hard-ordered by `created_at`). When true
     /// and no genre/year filters are active, the handler switches to a
@@ -449,7 +459,12 @@ pub async fn series_list(
         // silently ignore `razeni=`, so switch to a series-by-`order_clause`
         // query (parity with tv_porady, originally surfaced by Copilot review
         // on #702).
-        let count_row = sqlx::query_as::<_, CountRow>("SELECT count(*) as count FROM series")
+        let votes_filter = params
+            .votes_threshold_predicate()
+            .map(|p| format!("WHERE {p}"))
+            .unwrap_or_default();
+        let count_query = format!("SELECT count(*) as count FROM series s {votes_filter}");
+        let count_row = sqlx::query_as::<_, CountRow>(&count_query)
             .fetch_one(&state.db)
             .await?;
         let query = format!(
@@ -457,7 +472,7 @@ pub async fn series_list(
              s.description, s.original_title, s.tmdb_rating, s.imdb_rating, s.csfd_rating, \
              s.season_count, s.episode_count, s.added_at, \
              s.tmdb_poster_path \
-             FROM series s \
+             FROM series s {votes_filter} \
              ORDER BY {order} LIMIT $1 OFFSET $2"
         );
         let rows = sqlx::query_as::<_, SeriesRow>(&query)

--- a/cr-web/src/handlers/series.rs
+++ b/cr-web/src/handlers/series.rs
@@ -421,14 +421,22 @@ pub async fn series_list(
     // only hits via the leading CASE in ORDER BY — when the user typed
     // diacritics, rows whose title literally contains them rank first.
     let (total_count, series, episodes) = if let Some(ref pattern) = search_q {
-        let count_row = sqlx::query_as::<_, CountRow>(
-            "SELECT count(*) as count FROM series \
-             WHERE unaccent(title) ILIKE unaccent($1) \
-                OR unaccent(original_title) ILIKE unaccent($1)",
-        )
-        .bind(pattern)
-        .fetch_one(&state.db)
-        .await?;
+        // Apply the #704 vote-count threshold here too — Copilot review on
+        // PR #710 caught that a `razeni=imdb` search would otherwise still
+        // surface low-vote outliers at the top of the result list.
+        let votes_clause = params
+            .votes_threshold_predicate()
+            .map(|p| format!(" AND {p}"))
+            .unwrap_or_default();
+        let count_query = format!(
+            "SELECT count(*) as count FROM series s \
+             WHERE (unaccent(s.title) ILIKE unaccent($1) \
+                OR unaccent(s.original_title) ILIKE unaccent($1)){votes_clause}"
+        );
+        let count_row = sqlx::query_as::<_, CountRow>(&count_query)
+            .bind(pattern)
+            .fetch_one(&state.db)
+            .await?;
 
         let query = format!(
             "SELECT s.id, s.title, s.slug, s.first_air_year, s.last_air_year, \
@@ -436,8 +444,8 @@ pub async fn series_list(
              s.season_count, s.episode_count, s.added_at, \
              s.tmdb_poster_path \
              FROM series s \
-             WHERE unaccent(s.title) ILIKE unaccent($1) \
-                OR unaccent(s.original_title) ILIKE unaccent($1) \
+             WHERE (unaccent(s.title) ILIKE unaccent($1) \
+                OR unaccent(s.original_title) ILIKE unaccent($1)){votes_clause} \
              ORDER BY \
                (CASE WHEN s.title ILIKE $1 OR s.original_title ILIKE $1 THEN 0 ELSE 1 END), \
                {order} LIMIT $2 OFFSET $3"

--- a/cr-web/src/handlers/tv_porady.rs
+++ b/cr-web/src/handlers/tv_porady.rs
@@ -196,6 +196,16 @@ impl TvShowQuery {
         self.razeni.as_deref().unwrap_or("pridano")
     }
 
+    /// Credibility threshold for rating-sort listings (#704). Mirrors
+    /// FilmsQuery::votes_threshold_predicate — see comment there.
+    fn votes_threshold_predicate(&self) -> Option<&'static str> {
+        match self.razeni.as_deref() {
+            Some("imdb") => Some("s.imdb_votes >= 500"),
+            Some("tmdb") => Some("s.tmdb_vote_count >= 50"),
+            _ => None,
+        }
+    }
+
     /// Whether the user picked a non-default sort that the latest-episode
     /// listing can't honour (it's hard-ordered by `created_at`). When true,
     /// the handler switches to a shows-by-`order_clause` query instead so
@@ -309,7 +319,12 @@ pub async fn tv_porady_list(
         // home view. When the user explicitly asks for a different order,
         // switch to a shows-by-`order_clause` query so the page actually
         // reorders instead of silently ignoring `razeni=` (#702 review).
-        let count_row = sqlx::query_as::<_, CountRow>("SELECT count(*) as count FROM tv_shows")
+        let votes_filter = params
+            .votes_threshold_predicate()
+            .map(|p| format!("WHERE {p}"))
+            .unwrap_or_default();
+        let count_query = format!("SELECT count(*) as count FROM tv_shows s {votes_filter}");
+        let count_row = sqlx::query_as::<_, CountRow>(&count_query)
             .fetch_one(&state.db)
             .await?;
         let query = format!(
@@ -317,7 +332,7 @@ pub async fn tv_porady_list(
              s.description, s.original_title, s.tmdb_rating, s.imdb_rating, s.csfd_rating, \
              s.season_count, s.episode_count, s.added_at, \
              s.tmdb_poster_path \
-             FROM tv_shows s \
+             FROM tv_shows s {votes_filter} \
              ORDER BY {order} LIMIT $1 OFFSET $2"
         );
         let rows = sqlx::query_as::<_, TvShowRow>(&query)

--- a/cr-web/src/handlers/tv_porady.rs
+++ b/cr-web/src/handlers/tv_porady.rs
@@ -284,14 +284,22 @@ pub async fn tv_porady_list(
     // parity with films/series). Diacritic-exact hits rank first via
     // the leading CASE in ORDER BY.
     let (total_count, shows, episodes) = if let Some(ref pattern) = search_q {
-        let count_row = sqlx::query_as::<_, CountRow>(
-            "SELECT count(*) as count FROM tv_shows \
-             WHERE unaccent(title) ILIKE unaccent($1) \
-                OR unaccent(original_title) ILIKE unaccent($1)",
-        )
-        .bind(pattern)
-        .fetch_one(&state.db)
-        .await?;
+        // Same vote-count gating as the shows-mode branch — surfaced by
+        // Copilot review on PR #710. Otherwise a `?q=…&razeni=imdb` search
+        // would re-introduce low-vote outliers at the top.
+        let votes_clause = params
+            .votes_threshold_predicate()
+            .map(|p| format!(" AND {p}"))
+            .unwrap_or_default();
+        let count_query = format!(
+            "SELECT count(*) as count FROM tv_shows s \
+             WHERE (unaccent(s.title) ILIKE unaccent($1) \
+                OR unaccent(s.original_title) ILIKE unaccent($1)){votes_clause}"
+        );
+        let count_row = sqlx::query_as::<_, CountRow>(&count_query)
+            .bind(pattern)
+            .fetch_one(&state.db)
+            .await?;
 
         let query = format!(
             "SELECT s.id, s.title, s.slug, s.first_air_year, s.last_air_year, \
@@ -299,8 +307,8 @@ pub async fn tv_porady_list(
              s.season_count, s.episode_count, s.added_at, \
              s.tmdb_poster_path \
              FROM tv_shows s \
-             WHERE unaccent(s.title) ILIKE unaccent($1) \
-                OR unaccent(s.original_title) ILIKE unaccent($1) \
+             WHERE (unaccent(s.title) ILIKE unaccent($1) \
+                OR unaccent(s.original_title) ILIKE unaccent($1)){votes_clause} \
              ORDER BY \
                (CASE WHEN s.title ILIKE $1 OR s.original_title ILIKE $1 THEN 0 ELSE 1 END), \
                {order} LIMIT $2 OFFSET $3"


### PR DESCRIPTION
<!-- claude-session: fd55863a-01fd-456b-b70d-ea0440e6400a -->

Closes #704

## Summary
Top of `/filmy-online/?razeni=imdb` was outranked by titles with 5–15 voters scoring 9.9 — Shawshank's 3.18M-voter 9.3 sat below "Carter" (2025, IMDb 9.4 / 5 votes). Same problem on tmdb sort with a handful of `tmdb_vote_count = 1` rows.

Each Query struct gains `votes_threshold_predicate()` mapping `razeni=imdb` → `imdb_votes >= 500` and `razeni=tmdb` → `tmdb_vote_count >= 50`. NULL fails the inequality so no explicit `IS NOT NULL` is needed. Other sort keys (`pridano`, `rok`, `nazev`, `csfd`) stay unfiltered.

Applies to:
- `films.rs`: both `run_films_query` and `films_by_genre_inner`
- `series.rs`: the `wants_shows_mode` branch (only one that honors rating sort — latest-episode listing is hard-ordered by `created_at`)
- `tv_porady.rs`: same shows-mode branch as series

Schema: `imdb_votes` + `tmdb_vote_count` already exist on all three tables (migration 069), and #590 closed the gap leaving them NULL for fresh imports.

## Test plan
- [x] `cargo check -p cr-web`, `cargo clippy -p cr-web -- -D warnings`, `cargo fmt --check` — clean
- [x] `cargo test -p cr-web` — 46 passed
- [x] Local dev DB: `?razeni=rok` unchanged (22,524 films), `?razeni=imdb` filtered (top: Kingdom Come → Shawshank → Kmotr), `?razeni=tmdb` filtered (Kmotr → Kmotr II → Temný rytíř)
- [x] Deployed to prod via `./scripts/deploy.sh` — /health 200 OK
- [x] Playwright E2E on `https://ceskarepublika.wiki`:
  - `/filmy-online/?razeni=imdb&smer=desc` — total **22,310**, top: Kingdom Come, Doctor Who: Day of the Doctor, Top Gear: Bolivia, Shawshank, Kmotr, Iron Maiden, Nightwish, Temný rytíř, 12 rozhněvaných mužů, Kmotr II
  - `/filmy-online/?razeni=tmdb&smer=desc` — total **1,538**, top: Kouzelná výměna, Shawshank, Kmotr, 12 rozhněvaných mužů, Kmotr II, Temný rytíř
  - `/serialy-online/?razeni=imdb&smer=desc` — total **1,374**, top: Perníkový táta (Breaking Bad), Bratrstvo neohrožených, Zázračná planeta, Avatar, Černobyl, The Joy of Painting, The Wire, Hra o trůny, Sopranovi, Running Man
  - `/serialy-online/?razeni=tmdb&smer=desc` — total **310**, top: Breaking Bad, Avatar, One Piece, ER, Volejte Saulovi, Rick a Morty
  - `/tv-porady/?razeni=imdb&smer=desc` — top: Clarksonova farma, Grand Tour, Gordon Gino a Fred na cestách, FaceOff, Amazing Race, Survivor USA
  - `/tv-porady/?razeni=tmdb&smer=desc` — top: Clarksonova farma, Grand Tour, Top Boy, Survivor USA, Monstrum, Amazing Race
  - 0 console errors / 0 warnings across all 6 pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)