### PR TITLE
feat(web): audio language filter on /serialy-online/ with coverage modes

### DIFF
--- a/cr-infra/migrations/20260611_071_series_audio_langs_rollup.sql
+++ b/cr-infra/migrations/20260611_071_series_audio_langs_rollup.sql
@@ -1,0 +1,148 @@
+-- =============================================================================
+-- Series language rollups: aggregate episode.audio_langs / subtitle_langs up
+-- to the parent series, with both UNION (any) and INTERSECTION (all) semantics.
+--
+-- Why two arrays per kind?
+--   - `audio_langs_any` — languages where AT LEAST ONE episode has a source in
+--     that language. Drives the "alespoň částečně v jazyce" filter mode.
+--   - `audio_langs_all` — languages where EVERY episode of the series has at
+--     least one source in that language. Drives the "kompletně v jazyce"
+--     filter mode. A series with only S01 in CZ and S02+ in EN-only has
+--     `audio_langs_any = {cs, en}` but `audio_langs_all = {en}` (assuming
+--     every episode has EN).
+--
+-- Language is a property of the video source, not of the series. These
+-- rollups are pure derived state: the source-of-truth is video_sources
+-- (already rolled into episodes.audio_langs by migration 058). This
+-- migration adds a second hop episode → series.
+-- =============================================================================
+
+ALTER TABLE series
+    ADD COLUMN IF NOT EXISTS audio_langs_any    TEXT[] NOT NULL DEFAULT '{}'::TEXT[],
+    ADD COLUMN IF NOT EXISTS audio_langs_all    TEXT[] NOT NULL DEFAULT '{}'::TEXT[],
+    ADD COLUMN IF NOT EXISTS subtitle_langs_any TEXT[] NOT NULL DEFAULT '{}'::TEXT[],
+    ADD COLUMN IF NOT EXISTS subtitle_langs_all TEXT[] NOT NULL DEFAULT '{}'::TEXT[];
+
+CREATE INDEX IF NOT EXISTS idx_series_audio_langs_any_gin
+    ON series USING GIN (audio_langs_any);
+CREATE INDEX IF NOT EXISTS idx_series_audio_langs_all_gin
+    ON series USING GIN (audio_langs_all);
+CREATE INDEX IF NOT EXISTS idx_series_subtitle_langs_any_gin
+    ON series USING GIN (subtitle_langs_any);
+CREATE INDEX IF NOT EXISTS idx_series_subtitle_langs_all_gin
+    ON series USING GIN (subtitle_langs_all);
+
+-- =============================================================================
+-- Recompute function — single atomic UPDATE per series, mirroring the pattern
+-- from migration 058's recompute_video_rollups_for_parent().
+--
+-- INTERSECTION semantics:
+--   We count occurrences of each language across episodes and keep only those
+--   whose count equals the total episode count. Edge cases:
+--     - 0 episodes  → both _any and _all are {} (empty array).
+--     - 1 episode with audio_langs={'cs','en'} → both _any and _all = {cs,en}.
+--     - 2 episodes {cs,en} + {cs} → _any={cs,en}, _all={cs}.
+--     - 2 episodes {cs} + {} → _any={cs}, _all={} (one episode misses it).
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION recompute_series_lang_rollups(p_series_id INTEGER)
+RETURNS VOID AS $$
+BEGIN
+    UPDATE series s SET
+        audio_langs_any = COALESCE(
+            (SELECT array_agg(DISTINCT lang ORDER BY lang)
+             FROM (
+                 SELECT unnest(e.audio_langs) AS lang
+                 FROM episodes e
+                 WHERE e.series_id = p_series_id
+             ) u),
+            '{}'::TEXT[]),
+        audio_langs_all = COALESCE(
+            (WITH ep_total AS (
+                 SELECT COUNT(*) AS n FROM episodes WHERE series_id = p_series_id
+             ),
+             lang_counts AS (
+                 SELECT unnest(e.audio_langs) AS lang, COUNT(*) AS cnt
+                 FROM episodes e
+                 WHERE e.series_id = p_series_id
+                 GROUP BY 1
+             )
+             SELECT array_agg(lang ORDER BY lang)
+             FROM lang_counts, ep_total
+             WHERE ep_total.n > 0 AND cnt = ep_total.n),
+            '{}'::TEXT[]),
+        subtitle_langs_any = COALESCE(
+            (SELECT array_agg(DISTINCT lang ORDER BY lang)
+             FROM (
+                 SELECT unnest(e.subtitle_langs) AS lang
+                 FROM episodes e
+                 WHERE e.series_id = p_series_id
+             ) u),
+            '{}'::TEXT[]),
+        subtitle_langs_all = COALESCE(
+            (WITH ep_total AS (
+                 SELECT COUNT(*) AS n FROM episodes WHERE series_id = p_series_id
+             ),
+             lang_counts AS (
+                 SELECT unnest(e.subtitle_langs) AS lang, COUNT(*) AS cnt
+                 FROM episodes e
+                 WHERE e.series_id = p_series_id
+                 GROUP BY 1
+             )
+             SELECT array_agg(lang ORDER BY lang)
+             FROM lang_counts, ep_total
+             WHERE ep_total.n > 0 AND cnt = ep_total.n),
+            '{}'::TEXT[])
+    WHERE s.id = p_series_id;
+END;
+$$ LANGUAGE plpgsql;
+
+-- =============================================================================
+-- Trigger on episodes — fires when audio_langs / subtitle_langs change (which
+-- happens whenever migration 058's video_sources trigger updates the episode).
+-- Also fires on INSERT/DELETE/series_id change so the series rollup stays
+-- accurate when episodes appear/disappear or are re-parented.
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION trg_episodes_series_rollup() RETURNS TRIGGER AS $$
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        PERFORM recompute_series_lang_rollups(NEW.series_id);
+    ELSIF TG_OP = 'DELETE' THEN
+        PERFORM recompute_series_lang_rollups(OLD.series_id);
+    ELSE  -- UPDATE
+        PERFORM recompute_series_lang_rollups(NEW.series_id);
+        IF OLD.series_id IS DISTINCT FROM NEW.series_id THEN
+            PERFORM recompute_series_lang_rollups(OLD.series_id);
+        END IF;
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Idempotent trigger creation. CREATE TRIGGER doesn't support IF NOT EXISTS
+-- on Postgres before 14; dropping first works on all supported versions and
+-- keeps re-runs safe (e.g. fresh CI DB after a partial dev-only apply).
+DROP TRIGGER IF EXISTS trg_episodes_series_rollup_aiud ON episodes;
+CREATE TRIGGER trg_episodes_series_rollup_aiud
+    AFTER INSERT OR DELETE ON episodes
+    FOR EACH ROW EXECUTE FUNCTION trg_episodes_series_rollup();
+
+DROP TRIGGER IF EXISTS trg_episodes_series_rollup_au ON episodes;
+CREATE TRIGGER trg_episodes_series_rollup_au
+    AFTER UPDATE OF audio_langs, subtitle_langs, series_id ON episodes
+    FOR EACH ROW EXECUTE FUNCTION trg_episodes_series_rollup();
+
+-- =============================================================================
+-- One-shot backfill — populate the four rollup columns for every existing
+-- series. After this runs the trigger keeps them in sync.
+-- =============================================================================
+
+DO $$
+DECLARE
+    sid INTEGER;
+BEGIN
+    FOR sid IN SELECT id FROM series LOOP
+        PERFORM recompute_series_lang_rollups(sid);
+    END LOOP;
+END $$;

--- a/cr-web/src/handlers/series.rs
+++ b/cr-web/src/handlers/series.rs
@@ -216,6 +216,15 @@ pub struct SeriesQuery {
     rok: Option<String>,   // year filter
     rezim: Option<String>, // "and" / "or"
     smer: Option<String>,  // "asc" / "desc"
+    // #716 — audio-language filter. Same `audio=cs,sk,en` shape as
+    // FilmsQuery, but with a coverage-mode switch unique to series:
+    // language is a property of the video source on each episode, not
+    // of the series itself, so a series can be partially or fully in a
+    // language. `audio_mode=any` (default) means "at least one episode
+    // has a source in every selected language"; `audio_mode=all` means
+    // "every episode has a source in every selected language".
+    audio: Option<String>,
+    audio_mode: Option<String>,
 }
 
 impl SeriesQuery {
@@ -301,6 +310,40 @@ impl SeriesQuery {
     fn year_filter(&self) -> Option<i16> {
         self.rok.as_ref().and_then(|s| s.trim().parse().ok())
     }
+
+    /// Parse `audio=cs,sk,en` into validated ISO-639 codes. Mirrors
+    /// FilmsQuery::audio_langs_filter — the regex-shape guard avoids
+    /// dirty values in the GIN-array binding even though the binding
+    /// itself is parameterised.
+    pub(crate) fn audio_langs_filter(&self) -> Option<Vec<String>> {
+        let raw = self.audio.as_deref()?.trim();
+        if raw.is_empty() {
+            return None;
+        }
+        let langs: Vec<String> = raw
+            .split(',')
+            .map(|s| s.trim().to_ascii_lowercase())
+            .filter(|s| !s.is_empty() && s.len() <= 3 && s.chars().all(|c| c.is_ascii_lowercase()))
+            .collect();
+        if langs.is_empty() { None } else { Some(langs) }
+    }
+
+    /// `true` when the user picked the strict "every episode has it"
+    /// mode. Default (None or anything else) is the permissive `any`
+    /// mode that hits `series.audio_langs_any`.
+    pub(crate) fn audio_mode_is_all(&self) -> bool {
+        self.audio_mode.as_deref() == Some("all")
+    }
+
+    /// Column name on `series` to apply `@>` against. Centralised so
+    /// every WHERE-clause builder picks the same one.
+    pub(crate) fn audio_rollup_column(&self) -> &'static str {
+        if self.audio_mode_is_all() {
+            "s.audio_langs_all"
+        } else {
+            "s.audio_langs_any"
+        }
+    }
 }
 
 #[derive(Template)]
@@ -325,6 +368,11 @@ struct SeriesListTemplate {
     selected_genre_slugs: Vec<String>,
     /// Genres per series, keyed by series id — rendered as chips in desktop list view.
     series_genres_map: std::collections::HashMap<i32, Vec<SeriesGenreNameRow>>,
+    /// Audio-language filter (#716). Comma-separated ISO codes selected by user.
+    selected_audio_langs: Vec<String>,
+    /// `true` when `audio_mode=all` is active (strict "every episode has it").
+    /// `false` is the permissive "any episode" default.
+    audio_mode_all: bool,
 }
 
 impl SeriesListTemplate {
@@ -336,6 +384,12 @@ impl SeriesListTemplate {
     }
     fn is_current_genre(&self, g: &GenreRow) -> bool {
         self.current_genre.as_ref().is_some_and(|cg| cg.id == g.id)
+    }
+    fn is_audio_selected(&self, lang: &str) -> bool {
+        self.selected_audio_langs.iter().any(|l| l == lang)
+    }
+    fn has_audio_filter(&self) -> bool {
+        !self.selected_audio_langs.is_empty()
     }
     // NOTE: Askama auto-refs arguments in template method calls — `{{ self.series_genres(s.id) }}`
     // generates a call with `&s.id`. Keep the signature as `&i32` to match; Copilot's
@@ -413,6 +467,8 @@ pub async fn series_list(
     let include = params.include_genres();
     let exclude = params.exclude_genres();
     let year_f = params.year_filter();
+    let audio_langs = params.audio_langs_filter();
+    let audio_col = params.audio_rollup_column();
 
     // Search mode: show series results (by title). No search: show latest-
     // episode-per-series grid (bombuj.si style).
@@ -429,15 +485,25 @@ pub async fn series_list(
             .votes_threshold_predicate()
             .map(|p| format!(" AND {p}"))
             .unwrap_or_default();
+        // #716 audio filter. $1 is the search pattern, $2 the audio array
+        // (when present), then LIMIT/OFFSET trail. We thread the audio
+        // bind index dynamically so the same SQL string serves both
+        // "filter present" and "no filter" cases.
+        let (audio_clause, limit_idx, offset_idx) = if audio_langs.is_some() {
+            (format!(" AND {audio_col} @> $2::TEXT[]"), 3, 4)
+        } else {
+            (String::new(), 2, 3)
+        };
         let count_query = format!(
             "SELECT count(*) as count FROM series s \
              WHERE (unaccent(s.title) ILIKE unaccent($1) \
-                OR unaccent(s.original_title) ILIKE unaccent($1)){votes_clause}"
+                OR unaccent(s.original_title) ILIKE unaccent($1)){votes_clause}{audio_clause}"
         );
-        let count_row = sqlx::query_as::<_, CountRow>(&count_query)
-            .bind(pattern)
-            .fetch_one(&state.db)
-            .await?;
+        let mut cq = sqlx::query_as::<_, CountRow>(&count_query).bind(pattern);
+        if let Some(ref langs) = audio_langs {
+            cq = cq.bind(langs.clone());
+        }
+        let count_row = cq.fetch_one(&state.db).await?;
 
         let query = format!(
             "SELECT s.id, s.title, s.slug, s.first_air_year, s.last_air_year, \
@@ -446,13 +512,16 @@ pub async fn series_list(
              s.tmdb_poster_path \
              FROM series s \
              WHERE (unaccent(s.title) ILIKE unaccent($1) \
-                OR unaccent(s.original_title) ILIKE unaccent($1)){votes_clause} \
+                OR unaccent(s.original_title) ILIKE unaccent($1)){votes_clause}{audio_clause} \
              ORDER BY \
                (CASE WHEN s.title ILIKE $1 OR s.original_title ILIKE $1 THEN 0 ELSE 1 END), \
-               {order} LIMIT $2 OFFSET $3"
+               {order} LIMIT ${limit_idx} OFFSET ${offset_idx}"
         );
-        let rows = sqlx::query_as::<_, SeriesRow>(&query)
-            .bind(pattern)
+        let mut rq = sqlx::query_as::<_, SeriesRow>(&query).bind(pattern);
+        if let Some(ref langs) = audio_langs {
+            rq = rq.bind(langs.clone());
+        }
+        let rows = rq
             .bind(SERIES_PER_PAGE)
             .bind(offset)
             .fetch_all(&state.db)
@@ -474,12 +543,15 @@ pub async fn series_list(
             params.genre_mode_and(),
             &exclude,
             year_f,
+            audio_langs.as_deref(),
+            audio_col,
             params.votes_threshold_predicate(),
             offset,
         )
         .await?;
         (total, rows, Vec::new())
-    } else if include.is_empty() && exclude.is_empty() && year_f.is_none() {
+    } else if include.is_empty() && exclude.is_empty() && year_f.is_none() && audio_langs.is_none()
+    {
         // Default home listing (no filters): latest episode per series
         let count_row = sqlx::query_as::<_, CountRow>(
             "SELECT count(DISTINCT e.series_id) as count FROM episodes e",
@@ -493,6 +565,8 @@ pub async fn series_list(
             false,
             &[],
             None,
+            None,
+            audio_col,
             params.sort_desc(),
             SERIES_PER_PAGE,
             offset,
@@ -501,15 +575,24 @@ pub async fn series_list(
         (count_row.count.unwrap_or(0), Vec::new(), episodes)
     } else {
         // Filters active on the all-series page
-        let count_row =
-            count_filtered_series(&state, &include, params.genre_mode_and(), &exclude, year_f)
-                .await?;
+        let count_row = count_filtered_series(
+            &state,
+            &include,
+            params.genre_mode_and(),
+            &exclude,
+            year_f,
+            audio_langs.as_deref(),
+            audio_col,
+        )
+        .await?;
         let episodes = fetch_latest_episode_cards(
             &state,
             &include,
             params.genre_mode_and(),
             &exclude,
             year_f,
+            audio_langs.as_deref(),
+            audio_col,
             params.sort_desc(),
             SERIES_PER_PAGE,
             offset,
@@ -540,7 +623,8 @@ pub async fn series_list(
     });
 
     let selected_genre_slugs: Vec<String> = include.clone();
-    let open_filter = !selected_genre_slugs.is_empty();
+    let selected_audio_langs: Vec<String> = audio_langs.clone().unwrap_or_default();
+    let open_filter = !selected_genre_slugs.is_empty() || !selected_audio_langs.is_empty();
     let series_genres_map = load_series_genres_map(&state.db, &series, &episodes).await?;
 
     let tmpl = SeriesListTemplate {
@@ -558,6 +642,8 @@ pub async fn series_list(
         open_filter,
         selected_genre_slugs,
         series_genres_map,
+        selected_audio_langs,
+        audio_mode_all: params.audio_mode_is_all(),
     };
     let html = tmpl.render()?;
     // Search-result HTML is `?q=`-derived: tag it `private,
@@ -594,6 +680,8 @@ async fn run_shows_mode_query(
     include_mode_and: bool,
     exclude_slugs: &[String],
     year_f: Option<i16>,
+    audio_langs: Option<&[String]>,
+    audio_col: &str,
     votes_predicate: Option<&str>,
     offset: i64,
 ) -> WebResult<(Vec<SeriesRow>, i64)> {
@@ -629,6 +717,10 @@ async fn run_shows_mode_query(
         where_parts.push(format!("s.first_air_year = ${bind_idx}"));
         bind_idx += 1;
     }
+    if audio_langs.is_some() {
+        where_parts.push(format!("{audio_col} @> ${bind_idx}::TEXT[]"));
+        bind_idx += 1;
+    }
     if let Some(p) = votes_predicate {
         where_parts.push(p.to_string());
     }
@@ -649,6 +741,9 @@ async fn run_shows_mode_query(
     }
     if let Some(yr) = year_f {
         cq = cq.bind(yr);
+    }
+    if let Some(langs) = audio_langs {
+        cq = cq.bind(langs.to_vec());
     }
     let count_row = cq.fetch_one(db).await?;
 
@@ -672,6 +767,9 @@ async fn run_shows_mode_query(
     if let Some(yr) = year_f {
         rq = rq.bind(yr);
     }
+    if let Some(langs) = audio_langs {
+        rq = rq.bind(langs.to_vec());
+    }
     let rows = rq.bind(SERIES_PER_PAGE).bind(offset).fetch_all(db).await?;
     Ok((rows, count_row.count.unwrap_or(0)))
 }
@@ -686,6 +784,8 @@ async fn fetch_latest_episode_cards(
     include_mode_and: bool,
     exclude_slugs: &[String],
     year_f: Option<i16>,
+    audio_langs: Option<&[String]>,
+    audio_col: &str,
     desc: bool,
     limit: i64,
     offset: i64,
@@ -720,6 +820,10 @@ async fn fetch_latest_episode_cards(
     }
     if year_f.is_some() {
         where_parts.push(format!("s.first_air_year = ${bind_idx}"));
+        bind_idx += 1;
+    }
+    if audio_langs.is_some() {
+        where_parts.push(format!("{audio_col} @> ${bind_idx}::TEXT[]"));
     }
     let series_filter = if where_parts.is_empty() {
         String::new()
@@ -771,16 +875,22 @@ async fn fetch_latest_episode_cards(
     if let Some(yr) = year_f {
         q = q.bind(yr);
     }
+    if let Some(langs) = audio_langs {
+        q = q.bind(langs.to_vec());
+    }
     Ok(q.fetch_all(&state.db).await?)
 }
 
-/// Count series matching include/exclude/year filters (for pagination).
+/// Count series matching include/exclude/year/audio filters (for pagination).
+#[allow(clippy::too_many_arguments)]
 async fn count_filtered_series(
     state: &AppState,
     include_slugs: &[String],
     include_mode_and: bool,
     exclude_slugs: &[String],
     year_f: Option<i16>,
+    audio_langs: Option<&[String]>,
+    audio_col: &str,
 ) -> WebResult<i64> {
     let mut where_parts: Vec<String> =
         vec!["EXISTS (SELECT 1 FROM episodes e WHERE e.series_id = s.id)".to_string()];
@@ -813,6 +923,10 @@ async fn count_filtered_series(
     }
     if year_f.is_some() {
         where_parts.push(format!("s.first_air_year = ${bind_idx}"));
+        bind_idx += 1;
+    }
+    if audio_langs.is_some() {
+        where_parts.push(format!("{audio_col} @> ${bind_idx}::TEXT[]"));
     }
     let sql = format!(
         "SELECT count(*) as count FROM series s WHERE {}",
@@ -827,6 +941,9 @@ async fn count_filtered_series(
     }
     if let Some(yr) = year_f {
         q = q.bind(yr);
+    }
+    if let Some(langs) = audio_langs {
+        q = q.bind(langs.to_vec());
     }
     let row = q.fetch_one(&state.db).await?;
     Ok(row.count.unwrap_or(0))
@@ -1256,6 +1373,8 @@ async fn series_by_genre(
     // honors the requested order — pre-fix this branch always rendered
     // the latest-episode grid which is hard-coded `created_at DESC`, so
     // the user's "Podle hodnocení TMDB" pick was silently ignored.
+    let audio_langs = params.audio_langs_filter();
+    let audio_col = params.audio_rollup_column();
     let (series_rows, episodes, total_count) = if params.wants_shows_mode() {
         let (rows, total) = run_shows_mode_query(
             &state.db,
@@ -1264,6 +1383,8 @@ async fn series_by_genre(
             params.genre_mode_and(),
             &exclude,
             year_f,
+            audio_langs.as_deref(),
+            audio_col,
             params.votes_threshold_predicate(),
             offset,
         )
@@ -1276,6 +1397,8 @@ async fn series_by_genre(
             params.genre_mode_and(),
             &exclude,
             year_f,
+            audio_langs.as_deref(),
+            audio_col,
         )
         .await?;
         let eps = fetch_latest_episode_cards(
@@ -1284,6 +1407,8 @@ async fn series_by_genre(
             params.genre_mode_and(),
             &exclude,
             year_f,
+            audio_langs.as_deref(),
+            audio_col,
             params.sort_desc(),
             SERIES_PER_PAGE,
             offset,
@@ -1304,6 +1429,7 @@ async fn series_by_genre(
     let query_string = build_series_query_string(&params);
     let series_genres_map = load_series_genres_map(&state.db, &series_rows, &episodes).await?;
 
+    let selected_audio_langs: Vec<String> = audio_langs.clone().unwrap_or_default();
     let tmpl = SeriesListTemplate {
         img: state.image_base_url.clone(),
         episodes,
@@ -1316,9 +1442,11 @@ async fn series_by_genre(
         sort_key: params.sort_key().to_string(),
         query_string,
         search_query: None,
-        open_filter: open_filter || !zanry_extras.is_empty(),
+        open_filter: open_filter || !zanry_extras.is_empty() || !selected_audio_langs.is_empty(),
         selected_genre_slugs: zanry_extras,
         series_genres_map,
+        selected_audio_langs,
+        audio_mode_all: params.audio_mode_is_all(),
     };
     Ok(Html(tmpl.render()?).into_response())
 }
@@ -1572,6 +1700,14 @@ fn build_series_query_string(params: &SeriesQuery) -> String {
         && !r.is_empty()
     {
         parts.push(("rok", r.clone()));
+    }
+    if let Some(ref a) = params.audio
+        && !a.is_empty()
+    {
+        parts.push(("audio", a.clone()));
+    }
+    if params.audio_mode_is_all() {
+        parts.push(("audio_mode", "all".to_string()));
     }
     super::build_pagination_qs(&parts)
 }

--- a/cr-web/src/handlers/series.rs
+++ b/cr-web/src/handlers/series.rs
@@ -373,6 +373,10 @@ struct SeriesListTemplate {
     /// `true` when `audio_mode=all` is active (strict "every episode has it").
     /// `false` is the permissive "any episode" default.
     audio_mode_all: bool,
+    /// Full set of query params currently on the URL, keyed by param name.
+    /// Used by chip-removal links so a click rebuilds the URL minus one
+    /// param while preserving everything else (Copilot review on PR #717).
+    full_query: std::collections::BTreeMap<String, Vec<String>>,
 }
 
 impl SeriesListTemplate {
@@ -390,6 +394,41 @@ impl SeriesListTemplate {
     }
     fn has_audio_filter(&self) -> bool {
         !self.selected_audio_langs.is_empty()
+    }
+
+    /// Build a URL back to /serialy-online/ with the current filters
+    /// minus one audio language. Mirrors films `remove_audio_url`. If
+    /// the removed language was the last one, `audio_mode` is dropped
+    /// too so the URL doesn't carry a dangling coverage flag with no
+    /// languages to apply it to. `strana` is reset so removing a filter
+    /// returns the user to page 1 of the new result set.
+    fn remove_audio_url(&self, lang: &str) -> String {
+        let mut params = self.full_query.clone();
+        if let Some(vs) = params.get_mut("audio") {
+            let rebuilt: Vec<String> = vs
+                .iter()
+                .filter_map(|existing_csv| {
+                    let filtered: Vec<&str> = existing_csv
+                        .split(',')
+                        .map(|s| s.trim())
+                        .filter(|s| *s != lang)
+                        .collect();
+                    if filtered.is_empty() {
+                        None
+                    } else {
+                        Some(filtered.join(","))
+                    }
+                })
+                .collect();
+            if rebuilt.is_empty() {
+                params.remove("audio");
+                params.remove("audio_mode");
+            } else {
+                *vs = rebuilt;
+            }
+        }
+        params.remove("strana");
+        build_series_filter_url(&params)
     }
     // NOTE: Askama auto-refs arguments in template method calls — `{{ self.series_genres(s.id) }}`
     // generates a call with `&s.id`. Keep the signature as `&i32` to match; Copilot's
@@ -644,6 +683,7 @@ pub async fn series_list(
         series_genres_map,
         selected_audio_langs,
         audio_mode_all: params.audio_mode_is_all(),
+        full_query: build_series_query_map(&params),
     };
     let html = tmpl.render()?;
     // Search-result HTML is `?q=`-derived: tag it `private,
@@ -1447,6 +1487,7 @@ async fn series_by_genre(
         series_genres_map,
         selected_audio_langs,
         audio_mode_all: params.audio_mode_is_all(),
+        full_query: build_series_query_map(&params),
     };
     Ok(Html(tmpl.render()?).into_response())
 }
@@ -1669,6 +1710,75 @@ pub async fn series_cover_large_dynamic(
 }
 
 /// Build pagination query string for series list views.
+/// Snapshot the active query into a BTreeMap that chip-removal links
+/// can mutate without touching the SeriesQuery itself. Keys mirror the
+/// SeriesQuery field names so build_series_filter_url emits the same
+/// shape the handler accepts on the next request.
+fn build_series_query_map(params: &SeriesQuery) -> std::collections::BTreeMap<String, Vec<String>> {
+    let mut map: std::collections::BTreeMap<String, Vec<String>> =
+        std::collections::BTreeMap::new();
+    if let Some(z) = params.zanry.as_ref()
+        && !z.trim().is_empty()
+    {
+        map.insert("zanry".into(), vec![z.clone()]);
+    }
+    if let Some(b) = params.bez.as_ref()
+        && !b.trim().is_empty()
+    {
+        map.insert("bez".into(), vec![b.clone()]);
+    }
+    if let Some(q) = params.q.as_ref()
+        && !q.trim().is_empty()
+    {
+        map.insert("q".into(), vec![q.clone()]);
+    }
+    if let Some(r) = params.rok.as_ref()
+        && !r.trim().is_empty()
+    {
+        map.insert("rok".into(), vec![r.clone()]);
+    }
+    if let Some(r) = params.razeni.as_ref()
+        && !r.trim().is_empty()
+    {
+        map.insert("razeni".into(), vec![r.clone()]);
+    }
+    if let Some(s) = params.smer.as_ref()
+        && !s.trim().is_empty()
+    {
+        map.insert("smer".into(), vec![s.clone()]);
+    }
+    if let Some(rz) = params.rezim.as_ref()
+        && !rz.trim().is_empty()
+    {
+        map.insert("rezim".into(), vec![rz.clone()]);
+    }
+    if let Some(a) = params.audio.as_ref()
+        && !a.trim().is_empty()
+    {
+        map.insert("audio".into(), vec![a.clone()]);
+    }
+    if let Some(m) = params.audio_mode.as_ref()
+        && !m.trim().is_empty()
+    {
+        map.insert("audio_mode".into(), vec![m.clone()]);
+    }
+    map
+}
+
+fn build_series_filter_url(params: &std::collections::BTreeMap<String, Vec<String>>) -> String {
+    let mut parts = Vec::new();
+    for (key, values) in params {
+        for v in values {
+            parts.push(format!("{}={}", key, urlencoding::encode(v)));
+        }
+    }
+    if parts.is_empty() {
+        "/serialy-online/".to_string()
+    } else {
+        format!("/serialy-online/?{}", parts.join("&"))
+    }
+}
+
 fn build_series_query_string(params: &SeriesQuery) -> String {
     let mut parts: Vec<(&str, String)> = Vec::new();
     if params.razeni.is_some() {

--- a/cr-web/templates/series_list.html
+++ b/cr-web/templates/series_list.html
@@ -93,6 +93,21 @@
                     <option value="asc">↑ Vzestupně</option>
                 </select>
             </label>
+            {# Quick audio-language selector (#716). Five options cover the
+               common cases at a glance; cross-language combinations are
+               still available through the detailed filter panel. The
+               value encodes both language and coverage mode so a single
+               onchange call can rewrite both URL params at once. #}
+            <label class="toolbar-group">
+                <span class="toolbar-label">Jazyk:</span>
+                <select id="quick-audio" onchange="applyQuickAudio(this.value)" title="Zvuková verze epizod" class="quick-audio-select">
+                    <option value="vse">Vše</option>
+                    <option value="cs:all">Česky kompletně</option>
+                    <option value="cs:any">Česky alespoň částečně</option>
+                    <option value="sk:all">Slovensky kompletně</option>
+                    <option value="sk:any">Slovensky alespoň částečně</option>
+                </select>
+            </label>
             <button class="view-btn view-toggle" id="btn-view-toggle" onclick="toggleView()" title="Přepnout na zobrazení seznamem" aria-label="Zobrazení">
                 <svg class="view-icon-grid" width="18" height="18" viewBox="0 0 18 18"><rect x="1" y="2" width="16" height="3" rx="1" fill="currentColor"/><rect x="1" y="7.5" width="16" height="3" rx="1" fill="currentColor"/><rect x="1" y="13" width="16" height="3" rx="1" fill="currentColor"/></svg>
                 <svg class="view-icon-list" width="18" height="18" viewBox="0 0 18 18" style="display:none;"><rect x="1" y="1" width="7" height="7" rx="1" fill="currentColor"/><rect x="10" y="1" width="7" height="7" rx="1" fill="currentColor"/><rect x="1" y="10" width="7" height="7" rx="1" fill="currentColor"/><rect x="10" y="10" width="7" height="7" rx="1" fill="currentColor"/></svg>
@@ -620,6 +635,44 @@ function applyFilters() {
 function resetFilters() {
     window.location = '/serialy-online/';
 }
+
+/* --- Quick audio selector in the toolbar (#716) ---
+   Value encodes "lang:mode" so one onchange call rewrites both params.
+   "vse" clears both. Cross-lang combinations (e.g. CZ+SK) still need
+   the detailed filter panel; this is the one-click shortcut for the
+   90 % case. */
+function applyQuickAudio(value) {
+    var u = new URL(window.location.href);
+    u.searchParams.delete('strana');
+    if (!value || value === 'vse') {
+        u.searchParams.delete('audio');
+        u.searchParams.delete('audio_mode');
+    } else {
+        var parts = value.split(':');
+        u.searchParams.set('audio', parts[0]);
+        if (parts[1] === 'all') u.searchParams.set('audio_mode', 'all');
+        else u.searchParams.delete('audio_mode');
+    }
+    window.location = u.toString();
+}
+
+/* Prefill the quick audio selector from URL on page load so the
+   selected option survives reload / back-button navigation. */
+(function() {
+    var qa = document.getElementById('quick-audio');
+    if (!qa) return;
+    var urlP = new URLSearchParams(window.location.search);
+    var lang = urlP.get('audio');
+    var mode = urlP.get('audio_mode') === 'all' ? 'all' : 'any';
+    // Only reflect a single-language selection — multi-lang stays on
+    // "Vše" so the dropdown doesn't lie about the active filter.
+    if (lang && !lang.includes(',')) {
+        var v = lang + ':' + mode;
+        if (Array.from(qa.options).some(function(o){ return o.value === v; })) {
+            qa.value = v;
+        }
+    }
+})();
 
 /* --- Filter: prefill + mutual exclusion + badge counter --- */
 (function() {

--- a/cr-web/templates/series_list.html
+++ b/cr-web/templates/series_list.html
@@ -155,11 +155,57 @@
                 <option value="">Všechny roky</option>
             </select>
         </div>
+        {# Audio-language filter (#716). Language is a property of the video
+           source on each episode, so a series may be only partially in CZ
+           (e.g. just S01) or fully in CZ (every episode has a CZ source).
+           The "Pokrytí" toggle picks which rollup column the WHERE applies
+           against: any → series.audio_langs_any, all → audio_langs_all. #}
+        <div class="filter-section">
+            <div class="filter-label-row">
+                <label>Jazyk zvuku:</label>
+                <div class="genre-mode">
+                    <label class="mode-option">
+                        <input type="radio" name="audio_mode" value="any"{% if !audio_mode_all %} checked{% endif %}>
+                        <span>Alespoň částečně</span>
+                    </label>
+                    <label class="mode-option">
+                        <input type="radio" name="audio_mode" value="all"{% if audio_mode_all %} checked{% endif %}>
+                        <span>Kompletně</span>
+                    </label>
+                    <button type="button" class="help-icon" aria-label="Nápověda k pokrytí jazyka" onclick="this.classList.toggle('show')" onkeydown="if(event.key==='Enter'||event.key===' ')event.stopPropagation()">?<span class="help-popup"><strong>Alespoň částečně:</strong> seriál má v&nbsp;daném jazyce alespoň jednu epizodu (např. jen 1.&nbsp;sérii v&nbsp;češtině).<br><strong>Kompletně:</strong> seriál má v&nbsp;daném jazyce <em>každou</em> epizodu.</span></button>
+                </div>
+            </div>
+            <div class="filter-genres" id="filter-audio">
+                <label class="filter-chip"><input type="checkbox" value="cs" data-filter="audio"{% if self.is_audio_selected("cs") %} checked{% endif %}> Čeština</label>
+                <label class="filter-chip"><input type="checkbox" value="sk" data-filter="audio"{% if self.is_audio_selected("sk") %} checked{% endif %}> Slovenština</label>
+                <label class="filter-chip"><input type="checkbox" value="en" data-filter="audio"{% if self.is_audio_selected("en") %} checked{% endif %}> Angličtina</label>
+            </div>
+        </div>
         <div class="filter-actions">
             <button class="btn-apply" onclick="applyFilters()">Použít filtr</button>
             <button class="btn-reset" onclick="resetFilters()">Zrušit filtry</button>
         </div>
     </div>
+
+    {# Active filter chips for audio. Show "🎧 Čeština (kompletně)" /
+       "🎧 Čeština (částečně)" so the user sees both which language AND
+       which coverage mode is on. Clicking removes the audio filter
+       entirely (since the chips are mode-bound). #}
+    {% if self.has_audio_filter() %}
+    <div class="active-filters" id="active-filters">
+        <span class="active-filters-label">Aktivní filtry:</span>
+        {% for lang in selected_audio_langs %}
+        <span class="active-filter-chip" title="Pokrytí: {% if audio_mode_all %}kompletně{% else %}alespoň částečně{% endif %}">
+            🎧
+            {% if lang.as_str() == "cs" %}Čeština
+            {%- else if lang.as_str() == "sk" %}Slovenština
+            {%- else if lang.as_str() == "en" %}Angličtina
+            {%- else %}{{ lang }}{% endif %}
+            ({% if audio_mode_all %}kompletně{% else %}částečně{% endif %})
+        </span>
+        {% endfor %}
+    </div>
+    {% endif %}
 
     {# Main grid: episodes (default) or series (search mode) #}
     {% if !episodes.is_empty() %}
@@ -520,6 +566,11 @@ function applyFilters() {
     var sortDir = document.getElementById('sort-dir').value;
     var rezimEl = document.querySelector('input[name="rezim"]:checked');
     var rezim = rezimEl ? rezimEl.value : 'or';
+    // #716 — audio filter + coverage mode (any/all).
+    var audioEls = document.querySelectorAll('#filter-audio input:checked');
+    var audioLangs = Array.from(audioEls).map(function(el){ return el.value; });
+    var audioModeEl = document.querySelector('input[name="audio_mode"]:checked');
+    var audioMode = audioModeEl ? audioModeEl.value : 'any';
 
     var panel = document.getElementById('filter-panel');
     var currentGenre = panel ? panel.getAttribute('data-current-genre') : null;
@@ -546,6 +597,16 @@ function applyFilters() {
     }
     if (exc.length) u.searchParams.set('bez', exc.join(','));
     if (year) u.searchParams.set('rok', year);
+    // #716 — emit audio + audio_mode. Omit both when no languages selected
+    // so the URL stays clean; omit audio_mode when it's the default `any`.
+    if (audioLangs.length > 0) {
+        u.searchParams.set('audio', audioLangs.join(','));
+        if (audioMode === 'all') u.searchParams.set('audio_mode', 'all');
+        else u.searchParams.delete('audio_mode');
+    } else {
+        u.searchParams.delete('audio');
+        u.searchParams.delete('audio_mode');
+    }
     // Apply sort field + direction (mirror films_list.html). Drop both
     // params when they're the defaults so URLs stay clean and shareable.
     var defaultDir = sortField === 'nazev' ? 'asc' : 'desc';
@@ -590,6 +651,19 @@ function resetFilters() {
     if (yearParam) {
         var yrSel = document.getElementById('filter-year');
         if (yrSel) yrSel.value = yearParam;
+    }
+    // #716 — prefill audio chips + coverage mode radio from URL.
+    var audioParam = urlParams.get('audio');
+    if (audioParam) {
+        audioParam.split(',').forEach(function(lang){
+            var cb = panel.querySelector('#filter-audio input[value="' + lang + '"]');
+            if (cb) cb.checked = true;
+        });
+    }
+    var audioModeParam = urlParams.get('audio_mode');
+    if (audioModeParam === 'all') {
+        var rb = panel.querySelector('input[name="audio_mode"][value="all"]');
+        if (rb) rb.checked = true;
     }
 
     function updateFilterBadge() {

--- a/cr-web/templates/series_list.html
+++ b/cr-web/templates/series_list.html
@@ -204,20 +204,23 @@
 
     {# Active filter chips for audio. Show "🎧 Čeština (kompletně)" /
        "🎧 Čeština (částečně)" so the user sees both which language AND
-       which coverage mode is on. Clicking removes the audio filter
-       entirely (since the chips are mode-bound). #}
+       which coverage mode is on. Each chip is an <a> link that removes
+       that one language from the audio CSV (preserving the others), so
+       a user with `?audio=cs,sk` clicking on "Čeština" lands on
+       `?audio=sk`. Mirrors films_list.html (#717 Copilot review). #}
     {% if self.has_audio_filter() %}
     <div class="active-filters" id="active-filters">
         <span class="active-filters-label">Aktivní filtry:</span>
         {% for lang in selected_audio_langs %}
-        <span class="active-filter-chip" title="Pokrytí: {% if audio_mode_all %}kompletně{% else %}alespoň částečně{% endif %}">
+        <a class="active-filter-chip" href="{{ self.remove_audio_url(lang) }}" title="Odebrat filtr zvuku ({% if audio_mode_all %}kompletně{% else %}alespoň částečně{% endif %})">
             🎧
             {% if lang.as_str() == "cs" %}Čeština
             {%- else if lang.as_str() == "sk" %}Slovenština
             {%- else if lang.as_str() == "en" %}Angličtina
             {%- else %}{{ lang }}{% endif %}
             ({% if audio_mode_all %}kompletně{% else %}částečně{% endif %})
-        </span>
+            <span class="chip-x">✕</span>
+        </a>
         {% endfor %}
     </div>
     {% endif %}


### PR DESCRIPTION
<!-- claude-session: e5713c88-75a7-4380-8c08-7327c983587b -->

Closes #716

## Summary

Adds an audio-language filter to `/serialy-online/`, mirroring `/filmy-online/` but with a coverage-mode toggle unique to series. Language is a property of a video source on an episode, not of the series itself, so a show can be **partially** in CZ (only S01) or **fully** in CZ (every episode has at least one CZ source).

Two new rollup columns on `series`:
- `audio_langs_any` — UNION across all episodes → drives the "alespoň částečně" filter
- `audio_langs_all` — INTERSECTION across all episodes → drives the "kompletně" filter

Plus `subtitle_langs_any` / `_all` symmetrically. A trigger on `episodes` (AFTER INSERT/DELETE + AFTER UPDATE of `audio_langs`, `subtitle_langs`, `series_id`) keeps the rollups fresh; episode-level `audio_langs` is already maintained by the migration-058 trigger on `video_sources`, so the new code is a second hop video_sources → episode → series. Migration backfills all existing series.

URL shape: `?audio=cs[,sk,en]&audio_mode=all` (default `any`). UI: a "Pokrytí" radio toggle (Alespoň částečně / Kompletně) next to the language chips so the user picks once which rollup the WHERE applies against. Active filter chips read e.g. "🎧 Čeština (kompletně)".

Handler changes touch all four query branches (search-mode, shows-mode, default-no-filters, filtered) plus the genre-detail handler.

## Test plan

- [x] Local: `cargo check / test / clippy -D warnings / fmt --check` all green
- [x] Local Playwright on dev (cr_dev, 835 series): URL prefill works, chip renders, counts 835 / 681 partial / 392 full, console clean
- [x] Production deploy: `./scripts/deploy.sh` (~20s, cargo zigbuild + scp), `/health` green
- [x] Production Playwright: 1800 series total, 1159 partial-CZ, 715 full-CZ, 74 partial-SK, 0 EN
- [x] User scenario verified on prod: **Městečko South Park** (331 episodes, only some CZ) appears under `?audio=cs&audio_mode=any` but NOT under `?audio=cs&audio_mode=all` — exactly the use case the issue describes
- [x] Zero console errors on prod `/serialy-online/` after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)