### PR TITLE
feat(web): series detail — episodes first, flat single-season, R2 person photos

### DIFF
--- a/cr-web/src/config.rs
+++ b/cr-web/src/config.rs
@@ -36,8 +36,6 @@ pub struct AppConfig {
     pub series_covers_dir: String,
     /// Series episode stills (small variant).
     pub series_stills_dir: String,
-    /// Series people (actor/crew portraits).
-    pub series_people_dir: String,
     /// Repo checkout root — where scripts/auto-import.py lives when the
     /// admin Run-now button spawns it as a subprocess.
     pub cr_repo_root: String,
@@ -125,8 +123,6 @@ impl AppConfig {
             .unwrap_or_else(|_| "data/series/covers-webp".to_string());
         let series_stills_dir = std::env::var("SERIES_STILLS_DIR")
             .unwrap_or_else(|_| "data/series/episode-stills".to_string());
-        let series_people_dir =
-            std::env::var("SERIES_PEOPLE_DIR").unwrap_or_else(|_| "data/series/people".to_string());
         let cr_repo_root = std::env::var("CR_REPO_ROOT").unwrap_or_else(|_| "/opt/cr".to_string());
 
         let admin_import_run_enabled = matches!(
@@ -186,7 +182,6 @@ impl AppConfig {
             film_covers_dir,
             series_covers_dir,
             series_stills_dir,
-            series_people_dir,
             cr_repo_root,
             admin_import_run_enabled,
             admin_cache_purge_enabled,

--- a/cr-web/src/handlers/series.rs
+++ b/cr-web/src/handlers/series.rs
@@ -1822,30 +1822,31 @@ fn build_series_query_string(params: &SeriesQuery) -> String {
     super::build_pagination_qs(&parts)
 }
 
-/// GET /serialy-online/person/{filename} — serve person profile image from disk.
+/// GET /serialy-online/person/{filename} — proxy person profile photo from
+/// R2 (`cr-images:people/{tmdb_id}.webp`). `filename` is the synthesized
+/// `p{tmdb_id}.webp` stored in `people.profile_filename`; we strip the
+/// prefix/suffix to get the tmdb_id and delegate to the same R2 fetch path
+/// the cover handlers use, falling back to a transparent placeholder on miss
+/// so a missing photo never becomes a broken image.
 pub async fn series_person_image(
     State(state): State<AppState>,
     Path(filename): Path<String>,
 ) -> WebResult<Response> {
     if !filename.ends_with(".webp") || filename.contains('/') || filename.contains("..") {
-        return Ok((StatusCode::NOT_FOUND, "Not found").into_response());
+        return Ok(super::cover_proxy::placeholder_webp());
     }
-    let dir = state.config.series_people_dir.clone();
-    let path = std::path::Path::new(&dir).join(&filename);
-    if path.exists()
-        && let Ok(bytes) = tokio::fs::read(&path).await
-    {
-        return Ok((
-            StatusCode::OK,
-            [
-                (header::CONTENT_TYPE, "image/webp"),
-                (header::CACHE_CONTROL, "public, max-age=31536000, immutable"),
-            ],
-            bytes,
-        )
-            .into_response());
+    let stem = &filename[..filename.len() - ".webp".len()];
+    let Some(rest) = stem.strip_prefix('p') else {
+        return Ok(super::cover_proxy::placeholder_webp());
+    };
+    if rest.is_empty() || !rest.chars().all(|c| c.is_ascii_digit()) {
+        return Ok(super::cover_proxy::placeholder_webp());
     }
-    Ok((StatusCode::NOT_FOUND, "Not found").into_response())
+    let key = format!("people/{rest}.webp");
+    if let Some(bytes) = super::cover_proxy::try_fetch_r2(&state, &key).await {
+        return Ok(super::cover_proxy::immutable_webp(bytes));
+    }
+    Ok(super::cover_proxy::placeholder_webp())
 }
 
 /// GET /serialy-online/still/{filename} — serve episode still from disk.

--- a/cr-web/templates/series_detail.html
+++ b/cr-web/templates/series_detail.html
@@ -168,7 +168,7 @@
             <div class="person-card">
                 {% match p.profile_filename %}
                 {% when Some with (f) %}
-                <img class="person-photo" src="/serialy-online/person/{{ f }}" alt="{{ p.name }}" title="{{ p.name }}" loading="lazy">
+                <img class="person-photo" src="/serialy-online/person/{{ f }}?v=2" alt="{{ p.name }}" title="{{ p.name }}" loading="lazy">
                 {% when None %}
                 <div class="person-photo placeholder">{{ p.name }}</div>
                 {% endmatch %}
@@ -187,7 +187,7 @@
             <div class="person-card">
                 {% match p.profile_filename %}
                 {% when Some with (f) %}
-                <img class="person-photo" src="/serialy-online/person/{{ f }}" alt="{{ p.name }}" title="{{ p.name }}" loading="lazy">
+                <img class="person-photo" src="/serialy-online/person/{{ f }}?v=2" alt="{{ p.name }}" title="{{ p.name }}" loading="lazy">
                 {% when None %}
                 <div class="person-photo placeholder">{{ p.name }}</div>
                 {% endmatch %}

--- a/cr-web/templates/series_detail.html
+++ b/cr-web/templates/series_detail.html
@@ -94,6 +94,72 @@
         </div>
     </div>
 
+    <div class="seasons-section">
+        <div class="seasons-header">
+            <h3>Epizody</h3>
+            <div class="films-toolbar">
+                <button class="view-btn view-toggle" id="btn-view-toggle" onclick="toggleEpView()" alt="Přepnout zobrazení" title="Přepnout zobrazení mřížka / seznam">
+                    <svg class="view-icon-grid" width="18" height="18" viewBox="0 0 18 18"><rect x="1" y="2" width="16" height="3" rx="1" fill="currentColor"/><rect x="1" y="7.5" width="16" height="3" rx="1" fill="currentColor"/><rect x="1" y="13" width="16" height="3" rx="1" fill="currentColor"/></svg>
+                    <svg class="view-icon-list" width="18" height="18" viewBox="0 0 18 18" style="display:none;"><rect x="1" y="1" width="7" height="7" rx="1" fill="currentColor"/><rect x="10" y="1" width="7" height="7" rx="1" fill="currentColor"/><rect x="1" y="10" width="7" height="7" rx="1" fill="currentColor"/><rect x="10" y="10" width="7" height="7" rx="1" fill="currentColor"/></svg>
+                </button>
+            </div>
+        </div>
+
+        {# Single-season series render flat — no toggle bar / "1. série" header.
+           Multi-season series keep the collapsible block per season. The
+           single-season branch also drops the per-season localStorage state
+           since there's nothing to toggle. #}
+        {% if seasons.len() == 1 %}
+            {% for season in seasons %}
+            <div class="episode-grid" id="season-{{ season.number }}">
+                {% for ep in season.episodes %}
+                <a class="episode-card" href="/serialy-online/{{ series.slug }}/{% match ep.slug %}{% when Some with (s) %}{{ s }}{% when None %}{{ ep.season }}x{{ ep.episode }}{% endmatch %}/"
+                   alt="S{{ ep.season }}E{{ ep.episode }}{% match ep.episode_name %}{% when Some with (n) %} — {{ n }}{% when None %}{% endmatch %}"
+                   title="S{{ ep.season }}E{{ ep.episode }}{% match ep.episode_name %}{% when Some with (n) %} — {{ n }}{% when None %}{% endmatch %}">
+                    <div class="ep-head">
+                        <span class="ep-badge">S{{ "{:02}"|format(ep.season) }}E{{ "{:02}"|format(ep.episode) }}</span>
+                        <h5 class="ep-title">{% match ep.episode_name %}{% when Some with (n) %}{% if !n.is_empty() && !n.starts_with(char::is_numeric) %}{{ n }}{% else %}Epizoda {{ ep.episode }}{% endif %}{% when None %}Epizoda {{ ep.episode }}{% endmatch %}</h5>
+                    </div>
+                    <div class="ep-meta">
+                        {% match ep.air_date %}{% when Some with (d) %}<span>📅 {{ d }}</span>{% when None %}{% endmatch %}
+                        {% match ep.runtime %}{% when Some with (r) %}<span>⏱ {{ r }} min</span>{% when None %}{% endmatch %}
+                    </div>
+                    {% match ep.overview %}{% when Some with (o) %}<p class="ep-overview">{{ o }}</p>{% when None %}{% endmatch %}
+                </a>
+                {% endfor %}
+            </div>
+            {% endfor %}
+        {% else %}
+            {% for season in seasons %}
+            <div class="season-block collapsed" data-season="{{ season.number }}">
+                <button class="season-title season-toggle" type="button" onclick="toggleSeason({{ season.number }})"
+                        alt="Sbalit nebo rozbalit sérii" title="Sbalit nebo rozbalit sérii">
+                    <span class="chev">▾</span>
+                    {% if season.number == 0 %}Speciály{% else %}{{ season.number }}. série{% endif %}
+                    <span class="ep-count">({{ season.episodes.len() }} epizod)</span>
+                </button>
+                <div class="episode-grid" id="season-{{ season.number }}">
+                    {% for ep in season.episodes %}
+                    <a class="episode-card" href="/serialy-online/{{ series.slug }}/{% match ep.slug %}{% when Some with (s) %}{{ s }}{% when None %}{{ ep.season }}x{{ ep.episode }}{% endmatch %}/"
+                       alt="S{{ ep.season }}E{{ ep.episode }}{% match ep.episode_name %}{% when Some with (n) %} — {{ n }}{% when None %}{% endmatch %}"
+                       title="S{{ ep.season }}E{{ ep.episode }}{% match ep.episode_name %}{% when Some with (n) %} — {{ n }}{% when None %}{% endmatch %}">
+                        <div class="ep-head">
+                            <span class="ep-badge">S{{ "{:02}"|format(ep.season) }}E{{ "{:02}"|format(ep.episode) }}</span>
+                            <h5 class="ep-title">{% match ep.episode_name %}{% when Some with (n) %}{% if !n.is_empty() && !n.starts_with(char::is_numeric) %}{{ n }}{% else %}Epizoda {{ ep.episode }}{% endif %}{% when None %}Epizoda {{ ep.episode }}{% endmatch %}</h5>
+                        </div>
+                        <div class="ep-meta">
+                            {% match ep.air_date %}{% when Some with (d) %}<span>📅 {{ d }}</span>{% when None %}{% endmatch %}
+                            {% match ep.runtime %}{% when Some with (r) %}<span>⏱ {{ r }} min</span>{% when None %}{% endmatch %}
+                        </div>
+                        {% match ep.overview %}{% when Some with (o) %}<p class="ep-overview">{{ o }}</p>{% when None %}{% endmatch %}
+                    </a>
+                    {% endfor %}
+                </div>
+            </div>
+            {% endfor %}
+        {% endif %}
+    </div>
+
     {% if !creators.is_empty() %}
     <section class="crew-section">
         <h3>Tvůrci</h3>
@@ -102,7 +168,7 @@
             <div class="person-card">
                 {% match p.profile_filename %}
                 {% when Some with (f) %}
-                <img class="person-photo" src="/serialy-online/person/{{ f }}" alt="{{ p.name }}" title="{{ p.name }}">
+                <img class="person-photo" src="/serialy-online/person/{{ f }}" alt="{{ p.name }}" title="{{ p.name }}" loading="lazy">
                 {% when None %}
                 <div class="person-photo placeholder">{{ p.name }}</div>
                 {% endmatch %}
@@ -121,7 +187,7 @@
             <div class="person-card">
                 {% match p.profile_filename %}
                 {% when Some with (f) %}
-                <img class="person-photo" src="/serialy-online/person/{{ f }}" alt="{{ p.name }}" title="{{ p.name }}">
+                <img class="person-photo" src="/serialy-online/person/{{ f }}" alt="{{ p.name }}" title="{{ p.name }}" loading="lazy">
                 {% when None %}
                 <div class="person-photo placeholder">{{ p.name }}</div>
                 {% endmatch %}
@@ -132,46 +198,6 @@
         </div>
     </section>
     {% endif %}
-
-    <div class="seasons-section">
-        <div class="seasons-header">
-            <h3>Epizody</h3>
-            <div class="films-toolbar">
-                <button class="view-btn view-toggle" id="btn-view-toggle" onclick="toggleEpView()" alt="Přepnout zobrazení" title="Přepnout zobrazení mřížka / seznam">
-                    <svg class="view-icon-grid" width="18" height="18" viewBox="0 0 18 18"><rect x="1" y="2" width="16" height="3" rx="1" fill="currentColor"/><rect x="1" y="7.5" width="16" height="3" rx="1" fill="currentColor"/><rect x="1" y="13" width="16" height="3" rx="1" fill="currentColor"/></svg>
-                    <svg class="view-icon-list" width="18" height="18" viewBox="0 0 18 18" style="display:none;"><rect x="1" y="1" width="7" height="7" rx="1" fill="currentColor"/><rect x="10" y="1" width="7" height="7" rx="1" fill="currentColor"/><rect x="1" y="10" width="7" height="7" rx="1" fill="currentColor"/><rect x="10" y="10" width="7" height="7" rx="1" fill="currentColor"/></svg>
-                </button>
-            </div>
-        </div>
-
-        {% for season in seasons %}
-        <div class="season-block collapsed" data-season="{{ season.number }}">
-            <button class="season-title season-toggle" type="button" onclick="toggleSeason({{ season.number }})"
-                    alt="Sbalit nebo rozbalit sérii" title="Sbalit nebo rozbalit sérii">
-                <span class="chev">▾</span>
-                {% if season.number == 0 %}Speciály{% else %}{{ season.number }}. série{% endif %}
-                <span class="ep-count">({{ season.episodes.len() }} epizod)</span>
-            </button>
-            <div class="episode-grid" id="season-{{ season.number }}">
-                {% for ep in season.episodes %}
-                <a class="episode-card" href="/serialy-online/{{ series.slug }}/{% match ep.slug %}{% when Some with (s) %}{{ s }}{% when None %}{{ ep.season }}x{{ ep.episode }}{% endmatch %}/"
-                   alt="S{{ ep.season }}E{{ ep.episode }}{% match ep.episode_name %}{% when Some with (n) %} — {{ n }}{% when None %}{% endmatch %}"
-                   title="S{{ ep.season }}E{{ ep.episode }}{% match ep.episode_name %}{% when Some with (n) %} — {{ n }}{% when None %}{% endmatch %}">
-                    <div class="ep-head">
-                        <span class="ep-badge">S{{ "{:02}"|format(ep.season) }}E{{ "{:02}"|format(ep.episode) }}</span>
-                        <h5 class="ep-title">{% match ep.episode_name %}{% when Some with (n) %}{% if !n.is_empty() && !n.starts_with(char::is_numeric) %}{{ n }}{% else %}Epizoda {{ ep.episode }}{% endif %}{% when None %}Epizoda {{ ep.episode }}{% endmatch %}</h5>
-                    </div>
-                    <div class="ep-meta">
-                        {% match ep.air_date %}{% when Some with (d) %}<span>📅 {{ d }}</span>{% when None %}{% endmatch %}
-                        {% match ep.runtime %}{% when Some with (r) %}<span>⏱ {{ r }} min</span>{% when None %}{% endmatch %}
-                    </div>
-                    {% match ep.overview %}{% when Some with (o) %}<p class="ep-overview">{{ o }}</p>{% when None %}{% endmatch %}
-                </a>
-                {% endfor %}
-            </div>
-        </div>
-        {% endfor %}
-    </div>
 </main>
 
 <style>

--- a/scripts/backfill-person-photos.py
+++ b/scripts/backfill-person-photos.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""Backfill person profile photos to R2 for series cast + crew.
+
+The `people` table stores `profile_filename = 'p{tmdb_id}.webp'` for every
+person TMDB knew had a profile photo, but the bytes were never persisted on
+production — `/opt/cr/data/series/people/` is empty and never bind-mounted
+into the container, so `series_person_image` returned 404 for every photo.
+
+This script mirrors the films/series cover pipeline (`backfill-sledujteto-
+covers.py`):
+
+  1. SELECT id, tmdb_id, profile_filename FROM people WHERE
+     profile_filename IS NOT NULL — these are TMDB-knew-they-had-a-photo
+     rows. If TMDB no longer returns one we'll NULL the column so the
+     template renders the placeholder card.
+  2. For each, GET /person/{tmdb_id} from TMDB to discover the current
+     `profile_path` (we never stored it; only the synthesized filename).
+  3. Download `https://image.tmdb.org/t/p/w185{profile_path}`, validate
+     it's a portrait image, convert to WebP 200×300 quality 85.
+  4. Upload to R2 at `cr-images:people/{tmdb_id}.webp` via the S3-compatible
+     API (boto3 + R2 access key, same auth path used elsewhere). The
+     `cr-img-proxy` Worker serves it at `/img/people/{tmdb_id}.webp`,
+     which is what the patched `series_person_image` handler proxies.
+  5. On failure (TMDB has no photo anymore, download/upload error) the
+     row's `profile_filename` is set to NULL so the template falls
+     through to the initials placeholder.
+
+Local-file cache at `--out-dir` (default `data/series/people/`) is purely
+an idempotency hint — re-running skips the TMDB fetch if the WebP exists
+on disk. The R2 upload still runs (cheap; wrangler put is idempotent).
+
+Usage:
+  DATABASE_URL=postgres://...@localhost/cr_dev \\
+  TMDB_API_KEY=... \\
+  R2_ACCOUNT_ID=... R2_ACCESS_KEY_ID=... R2_SECRET_ACCESS_KEY=... \\
+      python3 scripts/backfill-person-photos.py \\
+          --jobs 8 \\
+          --limit 50
+
+The R2_* env vars come straight from `.env` (loaded by python-dotenv when
+invoking via `dotenv run`). They authorize against the `cr-images` bucket
+via the S3-compatible endpoint, mirroring `backup-db.sh`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import io
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+
+try:
+    import boto3
+    import psycopg2
+    import requests
+    from botocore.config import Config as BotoConfig
+except ImportError as e:
+    print(f"ERROR: missing dependency ({e.name}). "
+          "pip install psycopg2-binary requests boto3",
+          file=sys.stderr)
+    sys.exit(2)
+
+try:
+    from PIL import Image
+except ImportError:
+    print("ERROR: Pillow not installed. pip install Pillow", file=sys.stderr)
+    sys.exit(2)
+
+log = logging.getLogger("backfill-person-photos")
+
+TMDB_API_BASE = "https://api.themoviedb.org/3"
+TMDB_IMG_BASE = "https://image.tmdb.org/t/p"
+DEFAULT_TIMEOUT = 20
+
+# Portrait integrity bounds. TMDB w185 is ~185×278; w300 is ~300×450. We
+# accept anything taller than wide with a reasonable minimum side. 1×1
+# tracking GIFs and landscape stills get rejected.
+_MIN_SIDE = 80
+_MIN_ASPECT = 0.4   # w/h — portrait
+_MAX_ASPECT = 1.1   # near-square OK
+
+
+def _fetch_tmdb_profile_path(
+    session: requests.Session, tmdb_id: int, api_key: str
+) -> str | None:
+    """GET /person/{tmdb_id} → profile_path or None.
+
+    None means "TMDB returned 200 but profile_path is null" (person no
+    longer has a photo on TMDB) OR a non-recoverable error. The caller
+    treats both as "give up on this row and NULL the filename".
+    """
+    url = f"{TMDB_API_BASE}/person/{tmdb_id}"
+    for attempt in range(3):
+        try:
+            r = session.get(url, params={"api_key": api_key}, timeout=DEFAULT_TIMEOUT)
+        except requests.RequestException as e:
+            log.warning("tmdb_id=%d /person fetch failed: %s",
+                        tmdb_id, type(e).__name__)
+            time.sleep(2 ** attempt)
+            continue
+        if r.status_code == 404:
+            return None
+        if r.status_code == 429:
+            wait = int(r.headers.get("Retry-After", 5))
+            log.warning("tmdb_id=%d rate-limited; sleeping %ds", tmdb_id, wait)
+            time.sleep(wait)
+            continue
+        if r.status_code != 200:
+            log.warning("tmdb_id=%d /person returned HTTP %d", tmdb_id, r.status_code)
+            return None
+        try:
+            data = r.json()
+        except ValueError:
+            return None
+        path = data.get("profile_path")
+        return path if path else None
+    return None
+
+
+def _download_and_convert(
+    session: requests.Session,
+    profile_path: str,
+    tmdb_id: int,
+    out_path: Path,
+) -> bool:
+    """Fetch w185 from TMDB → WebP 200×300 → out_path. Returns success."""
+    url = f"{TMDB_IMG_BASE}/w185{profile_path}"
+    try:
+        r = session.get(url, timeout=DEFAULT_TIMEOUT)
+    except requests.RequestException as e:
+        log.warning("tmdb_id=%d image fetch failed: %s",
+                    tmdb_id, type(e).__name__)
+        return False
+    if r.status_code != 200 or len(r.content) < 500:
+        log.warning("tmdb_id=%d image HTTP %d (size=%d)",
+                    tmdb_id, r.status_code, len(r.content))
+        return False
+
+    try:
+        img = Image.open(io.BytesIO(r.content)).convert("RGB")
+    except Exception as e:
+        log.warning("tmdb_id=%d decode failed: %s", tmdb_id, e)
+        return False
+
+    w, h = img.size
+    if w < _MIN_SIDE or h < _MIN_SIDE:
+        log.warning("tmdb_id=%d image too small: %dx%d", tmdb_id, w, h)
+        return False
+    aspect = w / h
+    if not (_MIN_ASPECT <= aspect <= _MAX_ASPECT):
+        log.warning("tmdb_id=%d aspect out of range: %dx%d (%.2f)",
+                    tmdb_id, w, h, aspect)
+        return False
+
+    # 200×300 portrait — matches the cards on series detail (.person-photo
+    # is `aspect-ratio: 2/3` so this is exact). Pillow's thumbnail keeps
+    # the larger dim within the box, preserving aspect.
+    img.thumbnail((200, 300), Image.LANCZOS)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    img.save(out_path, "WEBP", quality=85, method=6)
+    return True
+
+
+def _make_r2_client() -> "boto3.client":
+    account_id = os.environ.get("R2_ACCOUNT_ID", "").strip()
+    key_id = os.environ.get("R2_ACCESS_KEY_ID", "").strip()
+    secret = os.environ.get("R2_SECRET_ACCESS_KEY", "").strip()
+    if not (account_id and key_id and secret):
+        raise SystemExit(
+            "R2_ACCOUNT_ID / R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY required"
+        )
+    endpoint = f"https://{account_id}.r2.cloudflarestorage.com"
+    return boto3.client(
+        "s3",
+        endpoint_url=endpoint,
+        aws_access_key_id=key_id,
+        aws_secret_access_key=secret,
+        # R2 requires `auto` for region in the S3 SDK.
+        region_name="auto",
+        # signature_version: R2 wants SigV4 (boto3 default).
+        config=BotoConfig(signature_version="s3v4", retries={"max_attempts": 3}),
+    )
+
+
+def _upload_to_r2(s3, tmdb_id: int, local_path: Path) -> tuple[bool, str]:
+    key = f"people/{tmdb_id}.webp"
+    try:
+        with open(local_path, "rb") as f:
+            s3.put_object(
+                Bucket="cr-images",
+                Key=key,
+                Body=f,
+                ContentType="image/webp",
+                CacheControl="public, max-age=31536000, immutable",
+            )
+    except Exception as e:
+        return False, f"put_object failed for {key}: {type(e).__name__}: {e}"
+    return True, "ok"
+
+
+def _process_person(
+    person_id: int,
+    tmdb_id: int,
+    out_dir: Path,
+    s3,
+    api_key: str,
+) -> tuple[int, str]:
+    """Returns (person_id, status) where status is one of:
+        'ok'                 — R2 upload succeeded (filename kept)
+        'no_tmdb_photo'      — TMDB no longer has a profile photo (NULL filename)
+        'download_failed'    — fetch or decode failed (NULL filename)
+        'upload_failed'      — R2 put_object failed (filename kept, retry later)
+    """
+    out_path = out_dir / f"{tmdb_id}.webp"
+    session = requests.Session()
+
+    if not out_path.exists():
+        profile_path = _fetch_tmdb_profile_path(session, tmdb_id, api_key)
+        if not profile_path:
+            return person_id, "no_tmdb_photo"
+        if not _download_and_convert(session, profile_path, tmdb_id, out_path):
+            return person_id, "download_failed"
+
+    # Dry-run validates the TMDB → WebP pipeline without touching R2.
+    if s3 is None:
+        return person_id, "ok"
+
+    ok, msg = _upload_to_r2(s3, tmdb_id, out_path)
+    if not ok:
+        log.warning("upload_failed tmdb_id=%d: %s", tmdb_id, msg)
+        return person_id, "upload_failed"
+    return person_id, "ok"
+
+
+def _fetch_candidates(
+    dsn: str, limit: int | None
+) -> list[tuple[int, int]]:
+    """Return [(person_id, tmdb_id), ...] of rows still needing a photo.
+
+    Joins to series_actors/directors so we process people who are actually
+    referenced first — orphaned rows (no series_id link) wait. Frequency
+    of citation (more series = more visible) breaks ties.
+    """
+    conn = psycopg2.connect(dsn)
+    try:
+        cur = conn.cursor()
+        sql = (
+            "SELECT p.id, p.tmdb_id FROM people p "
+            "LEFT JOIN ("
+            "  SELECT person_id, COUNT(*) AS n FROM series_actors GROUP BY 1"
+            "  UNION ALL "
+            "  SELECT person_id, COUNT(*) AS n FROM series_directors GROUP BY 1"
+            ") refs ON refs.person_id = p.id "
+            "WHERE p.profile_filename IS NOT NULL AND p.tmdb_id IS NOT NULL "
+            "GROUP BY p.id, p.tmdb_id "
+            "ORDER BY SUM(refs.n) DESC NULLS LAST, p.id"
+        )
+        if limit is not None:
+            cur.execute(sql + " LIMIT %s", (int(limit),))
+        else:
+            cur.execute(sql)
+        return list(cur.fetchall())
+    finally:
+        conn.close()
+
+
+def _null_filename(dsn: str, person_ids: list[int]) -> None:
+    if not person_ids:
+        return
+    conn = psycopg2.connect(dsn)
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            "UPDATE people SET profile_filename = NULL WHERE id = ANY(%s)",
+            (person_ids,),
+        )
+        conn.commit()
+        log.info("nulled profile_filename for %d persons (no R2 photo)",
+                 len(person_ids))
+    finally:
+        conn.close()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--out-dir", default="data/series/people",
+        help="Local WebP cache dir (filenames: {tmdb_id}.webp)",
+    )
+    ap.add_argument("--jobs", type=int, default=4)
+    ap.add_argument("--limit", type=int, help="Process only first N rows")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Skip R2 upload and DB writes (test TMDB pipeline only)")
+    ap.add_argument("-v", "--verbose", action="store_true")
+    args = ap.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        log.error("DATABASE_URL env var is required")
+        return 2
+    api_key = os.environ.get("TMDB_API_KEY", "").strip()
+    if not api_key:
+        log.error("TMDB_API_KEY env var is required")
+        return 2
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    s3 = None if args.dry_run else _make_r2_client()
+
+    rows = _fetch_candidates(dsn, args.limit)
+    log.info("processing %d persons with %d workers", len(rows), args.jobs)
+
+    stats = {"ok": 0, "no_tmdb_photo": 0, "download_failed": 0, "upload_failed": 0}
+    null_ids: list[int] = []
+
+    if args.dry_run:
+        log.warning("--dry-run: no R2 upload, no DB writes")
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as ex:
+        futures = [
+            ex.submit(_process_person, pid, tmdb_id, out_dir, s3, api_key)
+            for pid, tmdb_id in rows
+        ]
+        for i, fut in enumerate(concurrent.futures.as_completed(futures), 1):
+            person_id, status = fut.result()
+            stats[status] += 1
+            if status in ("no_tmdb_photo", "download_failed"):
+                null_ids.append(person_id)
+            if i % 50 == 0 or i == len(rows):
+                log.info(
+                    "progress %d/%d ok=%d no_tmdb=%d dl_fail=%d up_fail=%d",
+                    i, len(rows), stats["ok"], stats["no_tmdb_photo"],
+                    stats["download_failed"], stats["upload_failed"],
+                )
+
+    if not args.dry_run:
+        _null_filename(dsn, null_ids)
+
+    log.info("DONE: %s", stats)
+    # Failures that warrant attention are upload errors (transient infra)
+    # and download errors (TMDB rate-limit / disk full). 'no_tmdb_photo' is
+    # expected for actors TMDB depublished.
+    return 0 if stats["upload_failed"] == 0 and stats["download_failed"] == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/backfill-person-photos.py
+++ b/scripts/backfill-person-photos.py
@@ -84,14 +84,29 @@ _MIN_ASPECT = 0.4   # w/h — portrait
 _MAX_ASPECT = 1.1   # near-square OK
 
 
+# Sentinel signalling "TMDB explicitly says this person has no photo".
+# Distinct from None (transient error) so the caller doesn't permanently
+# NULL `profile_filename` for what's actually a network blip / 5xx /
+# rate-limit exhaustion.
+_NO_PHOTO = "__no_photo__"
+
+
 def _fetch_tmdb_profile_path(
     session: requests.Session, tmdb_id: int, api_key: str
 ) -> str | None:
-    """GET /person/{tmdb_id} → profile_path or None.
+    """GET /person/{tmdb_id} → one of:
+        - profile path string (e.g. "/abc.jpg") — TMDB has a photo
+        - `_NO_PHOTO`                           — TMDB definitively has no photo
+                                                  (HTTP 200 + profile_path is null/missing,
+                                                  or HTTP 404)
+        - None                                  — transient error; the row should
+                                                  stay marked as "still needs a
+                                                  photo" so a later re-run retries.
 
-    None means "TMDB returned 200 but profile_path is null" (person no
-    longer has a photo on TMDB) OR a non-recoverable error. The caller
-    treats both as "give up on this row and NULL the filename".
+    Distinguishing transient errors from confirmed-missing is what keeps
+    a TMDB outage from permanently wiping `profile_filename` rows the
+    template uses to decide whether to render the WebP or the initials
+    placeholder.
     """
     url = f"{TMDB_API_BASE}/person/{tmdb_id}"
     for attempt in range(3):
@@ -103,7 +118,8 @@ def _fetch_tmdb_profile_path(
             time.sleep(2 ** attempt)
             continue
         if r.status_code == 404:
-            return None
+            # Person id is gone from TMDB — definitively no photo to fetch.
+            return _NO_PHOTO
         if r.status_code == 429:
             wait = int(r.headers.get("Retry-After", 5))
             log.warning("tmdb_id=%d rate-limited; sleeping %ds", tmdb_id, wait)
@@ -111,13 +127,15 @@ def _fetch_tmdb_profile_path(
             continue
         if r.status_code != 200:
             log.warning("tmdb_id=%d /person returned HTTP %d", tmdb_id, r.status_code)
-            return None
+            return None  # transient — caller keeps filename, retry next run
         try:
             data = r.json()
         except ValueError:
-            return None
+            return None  # transient — malformed body
         path = data.get("profile_path")
-        return path if path else None
+        # 200 + null profile_path is TMDB definitively saying "no photo".
+        return path if path else _NO_PHOTO
+    # Out of retries on network failures — leave the row alone.
     return None
 
 
@@ -209,18 +227,28 @@ def _process_person(
     s3,
     api_key: str,
 ) -> tuple[int, str]:
-    """Returns (person_id, status) where status is one of:
-        'ok'                 — R2 upload succeeded (filename kept)
-        'no_tmdb_photo'      — TMDB no longer has a profile photo (NULL filename)
-        'download_failed'    — fetch or decode failed (NULL filename)
-        'upload_failed'      — R2 put_object failed (filename kept, retry later)
+    """Returns (person_id, status). Only `no_tmdb_photo` is treated as a
+    definitive negative result that the caller propagates to NULL the
+    `people.profile_filename` row. Every other failure (transient TMDB,
+    download/decode hiccup, R2 outage) leaves the filename intact so a
+    future re-run can fill it in. The four-way split lets us report
+    cleanly in the summary line.
+
+        'ok'                 — R2 upload succeeded
+        'no_tmdb_photo'      — TMDB confirms no photo (200+null, or 404)
+                               → caller NULLs the row
+        'tmdb_error'         — transient TMDB error (retry next run, keep filename)
+        'download_failed'    — fetch or decode failed (retry next run, keep filename)
+        'upload_failed'      — R2 put_object failed (retry next run, keep filename)
     """
     out_path = out_dir / f"{tmdb_id}.webp"
     session = requests.Session()
 
     if not out_path.exists():
         profile_path = _fetch_tmdb_profile_path(session, tmdb_id, api_key)
-        if not profile_path:
+        if profile_path is None:
+            return person_id, "tmdb_error"
+        if profile_path == _NO_PHOTO:
             return person_id, "no_tmdb_photo"
         if not _download_and_convert(session, profile_path, tmdb_id, out_path):
             return person_id, "download_failed"
@@ -319,7 +347,10 @@ def main() -> int:
     rows = _fetch_candidates(dsn, args.limit)
     log.info("processing %d persons with %d workers", len(rows), args.jobs)
 
-    stats = {"ok": 0, "no_tmdb_photo": 0, "download_failed": 0, "upload_failed": 0}
+    stats = {
+        "ok": 0, "no_tmdb_photo": 0,
+        "tmdb_error": 0, "download_failed": 0, "upload_failed": 0,
+    }
     null_ids: list[int] = []
 
     if args.dry_run:
@@ -333,23 +364,32 @@ def main() -> int:
         for i, fut in enumerate(concurrent.futures.as_completed(futures), 1):
             person_id, status = fut.result()
             stats[status] += 1
-            if status in ("no_tmdb_photo", "download_failed"):
+            # Only confirmed-missing-on-TMDB NULLs the row. Transient
+            # statuses (tmdb_error / download_failed / upload_failed) keep
+            # `profile_filename` so the next backfill run retries them; a
+            # TMDB outage that produced thousands of tmdb_error responses
+            # would otherwise permanently wipe valid photo references.
+            if status == "no_tmdb_photo":
                 null_ids.append(person_id)
             if i % 50 == 0 or i == len(rows):
                 log.info(
-                    "progress %d/%d ok=%d no_tmdb=%d dl_fail=%d up_fail=%d",
+                    "progress %d/%d ok=%d no_tmdb=%d tmdb_err=%d dl_fail=%d up_fail=%d",
                     i, len(rows), stats["ok"], stats["no_tmdb_photo"],
-                    stats["download_failed"], stats["upload_failed"],
+                    stats["tmdb_error"], stats["download_failed"],
+                    stats["upload_failed"],
                 )
 
     if not args.dry_run:
         _null_filename(dsn, null_ids)
 
     log.info("DONE: %s", stats)
-    # Failures that warrant attention are upload errors (transient infra)
-    # and download errors (TMDB rate-limit / disk full). 'no_tmdb_photo' is
-    # expected for actors TMDB depublished.
-    return 0 if stats["upload_failed"] == 0 and stats["download_failed"] == 0 else 1
+    # Non-zero exit means something needs attention next run: TMDB
+    # outage, R2 token rotated, disk full. 'no_tmdb_photo' is expected
+    # steady-state for actors TMDB depublished.
+    transient = (
+        stats["tmdb_error"] + stats["download_failed"] + stats["upload_failed"]
+    )
+    return 0 if transient == 0 else 1
 
 
 if __name__ == "__main__":

--- a/workers/img-proxy/src/index.js
+++ b/workers/img-proxy/src/index.js
@@ -24,7 +24,7 @@ export default {
     // rather than looping through origin.
     const knownPrefixes = ['municipalities/', 'landmarks/', 'pools/',
                            'regions/', 'videos/', 'films/', 'series/',
-                           'tv-shows/'];
+                           'tv-shows/', 'people/'];
     const isKnownPrefix = knownPrefixes.some(p => key.startsWith(p));
     const segmentCount = key.split('/').length;
     if (!isKnownPrefix && segmentCount === 3) {


### PR DESCRIPTION
<!-- claude-session: fd55863a-01fd-456b-b70d-ea0440e6400a -->

Closes #718

## Summary
- **Reorder**: episodes (`.seasons-section`) now render **before** the crew sections (`.crew-section` for Tvůrci + Herci) on `/serialy-online/{slug}/`. Episodes are the page's primary purpose.
- **Single-season flat layout**: when `seasons.len() == 1`, drop the `.season-block` / `.season-toggle` wrapper — no "1. série" header bar, just the episode grid.
- **Person photos → R2**: the existing handler read from `data/series/people/` which was empty on prod and not bind-mounted into the container — every photo had been a 404 since the section launched. Patched `series_person_image` to proxy from R2 at `people/{tmdb_id}.webp`, added `people/` to the `cr-img-proxy` `knownPrefixes`, and added `scripts/backfill-person-photos.py` (TMDB `/person/{id}` → WebP 200×300 → boto3 `put_object`).

Backfill against prod (via SSH tunnel): **6919 ok / 16 no_tmdb_photo / 0 failed**. The 16 TMDB-depublished persons had their `profile_filename` set to NULL, so the template's existing `{% when None %}` branch shows the initials placeholder card.

## Test plan
- [x] `cargo check -p cr-web` clean
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p cr-web -- -D warnings` clean
- [x] `cargo test -p cr-web` — 46 passed
- [x] Local server: section order on Jeho temné esence = film-hero → seasons-section → crew (creators) → crew (actors)
- [x] Local server: single-season La Palma (2024) = no season-block / season-toggle, flat 12-episode grid
- [x] Deploy to prod via `./scripts/deploy.sh` — healthy
- [x] Playwright on https://ceskarepublika.wiki/serialy-online/jeho-temne-esence/ — h3 order [`Epizody`, `Tvůrci`, `Herci`], 3 `.season-block`, 11/11 person photos load with `naturalWidth>1` after CF purge
- [x] Playwright on https://ceskarepublika.wiki/serialy-online/inteligence/ — h3 = [`Epizody`] only, 0 `.season-block`, 13 `.episode-card` in flat grid
- [x] Cloudflare cache purged for `/serialy-online/person/*` + `/img/people/*` so fresh visitors see real photos immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)