### PR TITLE
feat(scripts): backfill series cast/crew from TMDB

### DIFF
--- a/scripts/backfill-series-cast.py
+++ b/scripts/backfill-series-cast.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""Backfill `series_actors` + `series_directors` from TMDB credits (#720).
+
+1082 of 1878 series with `tmdb_id` have zero entries in `series_actors`,
+so the `/serialy-online/{slug}/` detail page renders no Tvůrci/Herci
+sections at all. This script fills the gap by calling TMDB
+`/tv/{tmdb_id}/credits` for each empty series and:
+
+  1. UPSERT into `people` (key: `tmdb_id`). Sets `profile_filename =
+     'p{tmdb_id}.webp'` when TMDB returns a `profile_path`, NULL otherwise
+     — matches the synthesized filename the new photo handler proxies.
+  2. INSERT top-N cast rows into `series_actors` (default N=10, sorted by
+     TMDB `order`). `order_index` mirrors `order` so rendering stays
+     consistent with shows backfilled by the existing import pipeline.
+  3. INSERT into `series_directors` for crew with `job` in
+     `{'Director', 'Creator'}` plus anyone listed under TMDB's
+     `created_by` (TV shows store their primary creator there, not in
+     crew). De-duplicates against `(series_id, person_id)` PK.
+
+After running, kick off `scripts/backfill-person-photos.py` to upload
+WebP for the newly-inserted persons — that script picks them up via
+`profile_filename IS NOT NULL` so they're already in its work set.
+
+Idempotency: a series is processed only when `series_actors` is empty
+for it. Re-runs report `skipped` for already-filled rows. We never
+DELETE existing cast — even partial human curation is preserved.
+
+Usage:
+  DATABASE_URL=postgres://...@localhost/cr_dev \\
+  TMDB_API_KEY=... \\
+      python3 scripts/backfill-series-cast.py \\
+          --jobs 8 \\
+          --limit 50
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import logging
+import os
+import sys
+import threading
+import time
+from dataclasses import dataclass
+
+try:
+    import psycopg2
+    import requests
+except ImportError as e:
+    print(f"ERROR: missing dependency ({e.name}). "
+          "pip install psycopg2-binary requests",
+          file=sys.stderr)
+    sys.exit(2)
+
+log = logging.getLogger("backfill-series-cast")
+
+TMDB_API_BASE = "https://api.themoviedb.org/3"
+DEFAULT_TIMEOUT = 20
+
+# Top-N cast cap. The series detail page renders 10 actors max
+# (cr-web/src/handlers/series.rs:1180 has `LIMIT 10`), so storing more
+# is wasted bytes. Order is already sorted by `order` in the API
+# response — TMDB's billing-order ranking.
+DEFAULT_CAST_LIMIT = 10
+
+# Crew jobs that map to series_directors. "Creator" doesn't usually appear
+# in the TV crew array (TMDB puts creators under `created_by`), but we
+# accept it for safety. "Executive Producer" is intentionally excluded —
+# the table is named `series_directors`, and EPs are typically too
+# numerous and too divorced from the show's creative direction to be
+# useful page content.
+DIRECTOR_JOBS = {"Director", "Creator"}
+
+
+@dataclass
+class CreditRow:
+    tmdb_id: int
+    name: str
+    profile_path: str | None
+    character: str | None
+    order: int | None
+    job: str | None  # None for cast, set for crew/creators
+
+
+def _request_tmdb(
+    session: requests.Session, path: str, api_key: str, retries: int = 3
+) -> dict | None:
+    """GET TMDB endpoint with Retry-After-aware backoff.
+
+    Returns parsed JSON dict on 200, None on 404 (series not on TMDB) or
+    exhausted retries. The caller treats None as "skip this series this
+    run" — we never destructively NULL anything based on TMDB read errors.
+    """
+    url = f"{TMDB_API_BASE}{path}"
+    for attempt in range(retries):
+        try:
+            r = session.get(url, params={"api_key": api_key}, timeout=DEFAULT_TIMEOUT)
+        except requests.RequestException as e:
+            log.warning("%s attempt %d failed: %s",
+                        path, attempt + 1, type(e).__name__)
+            time.sleep(2 ** attempt)
+            continue
+        if r.status_code == 404:
+            return None
+        if r.status_code == 429:
+            wait = int(r.headers.get("Retry-After", 5))
+            log.warning("rate-limited on %s; sleeping %ds", path, wait)
+            time.sleep(wait)
+            continue
+        if r.status_code != 200:
+            log.warning("%s HTTP %d", path, r.status_code)
+            return None
+        try:
+            return r.json()
+        except ValueError:
+            return None
+    return None
+
+
+def _fetch_credits(
+    session: requests.Session, tmdb_id: int, api_key: str
+) -> tuple[list[CreditRow], list[CreditRow]] | None:
+    """Return (cast, directors_and_creators) for a TV show.
+
+    None means "skip this series" (network or 404). Empty lists mean
+    "TMDB has the show but no people on it" — caller logs and moves on
+    without writing rows.
+
+    We pull `/tv/{id}` (for `created_by`) and `/tv/{id}/credits` in two
+    calls. Could be combined via `append_to_response=credits` but two
+    GETs keep retry behavior trivial and the cost is irrelevant.
+    """
+    main = _request_tmdb(session, f"/tv/{tmdb_id}", api_key)
+    if main is None:
+        return None
+    credits = _request_tmdb(session, f"/tv/{tmdb_id}/credits", api_key)
+    if credits is None:
+        return None
+
+    cast: list[CreditRow] = []
+    for c in credits.get("cast", []) or []:
+        if not c.get("id") or not c.get("name"):
+            continue
+        cast.append(CreditRow(
+            tmdb_id=int(c["id"]),
+            name=c["name"],
+            profile_path=c.get("profile_path"),
+            character=c.get("character") or None,
+            order=c.get("order"),
+            job=None,
+        ))
+
+    director_rows: list[CreditRow] = []
+    seen_director_ids: set[int] = set()
+
+    # Creators come from the `/tv/{id}` payload's `created_by` array,
+    # not crew. Most TV shows in our DB have at least one creator there.
+    for cr in main.get("created_by", []) or []:
+        if not cr.get("id") or not cr.get("name"):
+            continue
+        pid = int(cr["id"])
+        if pid in seen_director_ids:
+            continue
+        seen_director_ids.add(pid)
+        director_rows.append(CreditRow(
+            tmdb_id=pid,
+            name=cr["name"],
+            profile_path=cr.get("profile_path"),
+            character=None,
+            order=None,
+            job="Creator",
+        ))
+
+    # Then crew rows whose job matches our director-class allowlist.
+    for cw in credits.get("crew", []) or []:
+        if cw.get("job") not in DIRECTOR_JOBS:
+            continue
+        if not cw.get("id") or not cw.get("name"):
+            continue
+        pid = int(cw["id"])
+        if pid in seen_director_ids:
+            continue
+        seen_director_ids.add(pid)
+        director_rows.append(CreditRow(
+            tmdb_id=pid,
+            name=cw["name"],
+            profile_path=cw.get("profile_path"),
+            character=None,
+            order=None,
+            job=cw["job"],
+        ))
+
+    return cast, director_rows
+
+
+# Per-connection lock keeps thread workers from interleaving statements
+# on the same psycopg2 connection (which is NOT thread-safe). We open
+# one connection per worker via threading.local instead, which is even
+# simpler.
+_conn_local = threading.local()
+
+
+def _get_conn(dsn: str):
+    conn = getattr(_conn_local, "conn", None)
+    if conn is None or conn.closed:
+        conn = psycopg2.connect(dsn)
+        _conn_local.conn = conn
+    return conn
+
+
+def _upsert_person(cur, row: CreditRow) -> int:
+    """UPSERT into people by tmdb_id. Returns people.id.
+
+    `profile_filename` is set only when TMDB returns a `profile_path` —
+    matches the convention the photo backfill uses. Existing rows keep
+    their filename even if TMDB has since removed the photo; the photo
+    backfill is what decides to NULL it (after a confirmed-missing TMDB
+    response), not the cast backfill.
+    """
+    if row.profile_path:
+        filename = f"p{row.tmdb_id}.webp"
+    else:
+        filename = None
+    cur.execute(
+        "INSERT INTO people (tmdb_id, name, profile_filename) "
+        "VALUES (%s, %s, %s) "
+        "ON CONFLICT (tmdb_id) DO UPDATE SET "
+        "    name = EXCLUDED.name, "
+        # Don't overwrite a present filename with NULL — if TMDB lost
+        # the photo we want the photo backfill to decide that, not the
+        # cast UPSERT which can fire for unrelated reasons.
+        "    profile_filename = COALESCE(EXCLUDED.profile_filename, people.profile_filename) "
+        "RETURNING id",
+        (row.tmdb_id, row.name, filename),
+    )
+    return cur.fetchone()[0]
+
+
+def _process_series(
+    series_id: int,
+    tmdb_id: int,
+    dsn: str,
+    api_key: str,
+    cast_limit: int,
+    dry_run: bool,
+) -> tuple[int, str, int, int]:
+    """Returns (series_id, status, actors_inserted, directors_inserted)."""
+    session = requests.Session()
+    result = _fetch_credits(session, tmdb_id, api_key)
+    if result is None:
+        return series_id, "tmdb_error", 0, 0
+    cast, directors = result
+    if not cast and not directors:
+        return series_id, "empty_credits", 0, 0
+
+    if dry_run:
+        return series_id, "ok_dry", min(len(cast), cast_limit), len(directors)
+
+    conn = _get_conn(dsn)
+    actors_inserted = 0
+    directors_inserted = 0
+    try:
+        cur = conn.cursor()
+
+        # Cast: take top-N by TMDB order (already sorted but be defensive).
+        cast_sorted = sorted(cast, key=lambda r: r.order if r.order is not None else 999)
+        for c in cast_sorted[:cast_limit]:
+            pid = _upsert_person(cur, c)
+            # ON CONFLICT DO NOTHING keeps human curation in case the
+            # row exists with a different order_index — first writer wins.
+            # RETURNING + fetchone() is more reliable than rowcount for
+            # `ON CONFLICT DO NOTHING` — psycopg2's rowcount on a no-op
+            # conflict can read as 0 even when a fresh INSERT actually
+            # landed (observed under threaded use). fetchone() returns
+            # a row only on real insert, None on conflict.
+            cur.execute(
+                "INSERT INTO series_actors "
+                "(series_id, person_id, character_name, order_index) "
+                "VALUES (%s, %s, %s, %s) "
+                "ON CONFLICT (series_id, person_id) DO NOTHING "
+                "RETURNING person_id",
+                (series_id, pid, c.character, c.order or 0),
+            )
+            if cur.fetchone() is not None:
+                actors_inserted += 1
+
+        for d in directors:
+            pid = _upsert_person(cur, d)
+            cur.execute(
+                "INSERT INTO series_directors (series_id, person_id) "
+                "VALUES (%s, %s) ON CONFLICT (series_id, person_id) DO NOTHING "
+                "RETURNING person_id",
+                (series_id, pid),
+            )
+            if cur.fetchone() is not None:
+                directors_inserted += 1
+
+        conn.commit()
+        return series_id, "ok", actors_inserted, directors_inserted
+    except psycopg2.Error as e:
+        conn.rollback()
+        log.warning("db error for series_id=%d tmdb=%d: %s", series_id, tmdb_id, e)
+        return series_id, "db_error", 0, 0
+
+
+def _fetch_candidates(
+    dsn: str, limit: int | None
+) -> list[tuple[int, int]]:
+    """Return [(series_id, tmdb_id), ...] for series with no cast yet.
+
+    NOT EXISTS is faster than LEFT JOIN + IS NULL on this schema; the
+    actors PK is (series_id, person_id), so the planner stops at the
+    first match. Sorted by `added_at DESC` so freshly-imported shows
+    that are visible on the listing fill in first.
+    """
+    conn = psycopg2.connect(dsn)
+    try:
+        cur = conn.cursor()
+        sql = (
+            "SELECT s.id, s.tmdb_id FROM series s "
+            "WHERE s.tmdb_id IS NOT NULL "
+            "  AND NOT EXISTS ("
+            "    SELECT 1 FROM series_actors sa WHERE sa.series_id = s.id"
+            "  ) "
+            "ORDER BY s.added_at DESC NULLS LAST, s.id"
+        )
+        if limit is not None:
+            cur.execute(sql + " LIMIT %s", (int(limit),))
+        else:
+            cur.execute(sql)
+        return list(cur.fetchall())
+    finally:
+        conn.close()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--jobs", type=int, default=4)
+    ap.add_argument("--limit", type=int, help="Process only first N series")
+    ap.add_argument("--cast-limit", type=int, default=DEFAULT_CAST_LIMIT,
+                    help=f"Max cast rows per series (default {DEFAULT_CAST_LIMIT})")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Skip DB writes (test TMDB pipeline only)")
+    ap.add_argument("-v", "--verbose", action="store_true")
+    args = ap.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        log.error("DATABASE_URL env var is required")
+        return 2
+    api_key = os.environ.get("TMDB_API_KEY", "").strip()
+    if not api_key:
+        log.error("TMDB_API_KEY env var is required")
+        return 2
+
+    rows = _fetch_candidates(dsn, args.limit)
+    log.info("processing %d series with %d workers", len(rows), args.jobs)
+
+    stats = {
+        "ok": 0, "ok_dry": 0, "empty_credits": 0,
+        "tmdb_error": 0, "db_error": 0,
+    }
+    actor_total = 0
+    director_total = 0
+
+    if args.dry_run:
+        log.warning("--dry-run: no DB writes")
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as ex:
+        futures = [
+            ex.submit(_process_series, sid, tmdb_id, dsn, api_key,
+                      args.cast_limit, args.dry_run)
+            for sid, tmdb_id in rows
+        ]
+        for i, fut in enumerate(concurrent.futures.as_completed(futures), 1):
+            _sid, status, a, d = fut.result()
+            stats[status] += 1
+            actor_total += a
+            director_total += d
+            if i % 25 == 0 or i == len(rows):
+                log.info(
+                    "progress %d/%d ok=%d empty=%d tmdb_err=%d db_err=%d | actors=%d directors=%d",
+                    i, len(rows), stats["ok"] + stats["ok_dry"],
+                    stats["empty_credits"], stats["tmdb_error"],
+                    stats["db_error"], actor_total, director_total,
+                )
+
+    log.info("DONE: %s | actors=%d directors=%d",
+             stats, actor_total, director_total)
+    return 0 if stats["tmdb_error"] == 0 and stats["db_error"] == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/backfill-series-cast.py
+++ b/scripts/backfill-series-cast.py
@@ -17,6 +17,14 @@ sections at all. This script fills the gap by calling TMDB
      `created_by` (TV shows store their primary creator there, not in
      crew). De-duplicates against `(series_id, person_id)` PK.
 
+     Limitation: episode-level directors on TV shows live on per-
+     episode crew (`/tv/{id}/season/{n}/episode/{m}/credits`), not on
+     the series-level `/tv/{id}/credits` endpoint this script reads.
+     In practice `series_directors` ends up populated almost entirely
+     from `created_by`; rows with `job == 'Director'` at the series
+     level are rare. Episode directors are imported separately by the
+     existing series enricher pipeline.
+
 After running, kick off `scripts/backfill-person-photos.py` to upload
 WebP for the newly-inserted persons — that script picks them up via
 `profile_filename IS NOT NULL` so they're already in its work set.
@@ -42,6 +50,7 @@ import os
 import sys
 import threading
 import time
+from collections import Counter
 from dataclasses import dataclass
 
 try:
@@ -194,10 +203,11 @@ def _fetch_credits(
     return cast, director_rows
 
 
-# Per-connection lock keeps thread workers from interleaving statements
-# on the same psycopg2 connection (which is NOT thread-safe). We open
-# one connection per worker via threading.local instead, which is even
-# simpler.
+# psycopg2 connections are NOT thread-safe, so we keep one connection
+# per worker thread via threading.local. The same local also caches a
+# `requests.Session` so HTTP keep-alive + TLS state survive across the
+# ~hundred series each worker handles, instead of paying connection
+# setup on every series.
 _conn_local = threading.local()
 
 
@@ -207,6 +217,32 @@ def _get_conn(dsn: str):
         conn = psycopg2.connect(dsn)
         _conn_local.conn = conn
     return conn
+
+
+def _get_session() -> requests.Session:
+    """Reuse a single requests.Session per worker thread. Without this
+    every series would open a fresh TLS connection to api.themoviedb.org
+    and we'd burn through their Retry-After budget faster.
+    """
+    sess = getattr(_conn_local, "session", None)
+    if sess is None:
+        sess = requests.Session()
+        _conn_local.session = sess
+    return sess
+
+
+# Schema column widths (cr-infra/migrations/20260421_030_episode_metadata.sql).
+# Truncate before INSERT so one overlong field can't abort the whole
+# series transaction.
+_NAME_MAX = 255            # people.name VARCHAR(255)
+_CHARACTER_NAME_MAX = 255  # series_actors.character_name VARCHAR(255)
+_ORDER_INDEX_MAX = 32767   # series_actors.order_index SMALLINT
+
+
+def _clip(s: str | None, n: int) -> str | None:
+    if s is None:
+        return None
+    return s if len(s) <= n else s[:n]
 
 
 def _upsert_person(cur, row: CreditRow) -> int:
@@ -232,7 +268,7 @@ def _upsert_person(cur, row: CreditRow) -> int:
         # cast UPSERT which can fire for unrelated reasons.
         "    profile_filename = COALESCE(EXCLUDED.profile_filename, people.profile_filename) "
         "RETURNING id",
-        (row.tmdb_id, row.name, filename),
+        (row.tmdb_id, _clip(row.name, _NAME_MAX), filename),
     )
     return cur.fetchone()[0]
 
@@ -246,7 +282,7 @@ def _process_series(
     dry_run: bool,
 ) -> tuple[int, str, int, int]:
     """Returns (series_id, status, actors_inserted, directors_inserted)."""
-    session = requests.Session()
+    session = _get_session()
     result = _fetch_credits(session, tmdb_id, api_key)
     if result is None:
         return series_id, "tmdb_error", 0, 0
@@ -274,13 +310,18 @@ def _process_series(
             # conflict can read as 0 even when a fresh INSERT actually
             # landed (observed under threaded use). fetchone() returns
             # a row only on real insert, None on conflict.
+            # Clip both VARCHAR fields to fit the schema and clamp
+            # `order_index` to SMALLINT range. TMDB's `order` is usually
+            # small but is not bounded, and one overlong character_name
+            # would otherwise blow up the whole transaction.
+            order_idx = min(c.order or 0, _ORDER_INDEX_MAX)
             cur.execute(
                 "INSERT INTO series_actors "
                 "(series_id, person_id, character_name, order_index) "
                 "VALUES (%s, %s, %s, %s) "
                 "ON CONFLICT (series_id, person_id) DO NOTHING "
                 "RETURNING person_id",
-                (series_id, pid, c.character, c.order or 0),
+                (series_id, pid, _clip(c.character, _CHARACTER_NAME_MAX), order_idx),
             )
             if cur.fetchone() is not None:
                 actors_inserted += 1
@@ -362,10 +403,10 @@ def main() -> int:
     rows = _fetch_candidates(dsn, args.limit)
     log.info("processing %d series with %d workers", len(rows), args.jobs)
 
-    stats = {
-        "ok": 0, "ok_dry": 0, "empty_credits": 0,
-        "tmdb_error": 0, "db_error": 0,
-    }
+    # Counter so an unexpected new status doesn't crash the aggregator
+    # mid-run and lose all in-flight progress. `worker_exception` is a
+    # synthetic status for futures that raised — keeps the loop going.
+    stats: Counter[str] = Counter()
     actor_total = 0
     director_total = 0
 
@@ -379,21 +420,30 @@ def main() -> int:
             for sid, tmdb_id in rows
         ]
         for i, fut in enumerate(concurrent.futures.as_completed(futures), 1):
-            _sid, status, a, d = fut.result()
+            try:
+                _sid, status, a, d = fut.result()
+            except Exception as e:
+                # Don't let one worker exception abort the run and
+                # discard the rest of the futures' results. Log + tally
+                # and keep going so we still get a summary.
+                log.warning("worker exception: %s", e)
+                stats["worker_exception"] += 1
+                continue
             stats[status] += 1
             actor_total += a
             director_total += d
             if i % 25 == 0 or i == len(rows):
                 log.info(
-                    "progress %d/%d ok=%d empty=%d tmdb_err=%d db_err=%d | actors=%d directors=%d",
+                    "progress %d/%d ok=%d empty=%d tmdb_err=%d db_err=%d worker_exc=%d | actors=%d directors=%d",
                     i, len(rows), stats["ok"] + stats["ok_dry"],
                     stats["empty_credits"], stats["tmdb_error"],
-                    stats["db_error"], actor_total, director_total,
+                    stats["db_error"], stats["worker_exception"],
+                    actor_total, director_total,
                 )
 
     log.info("DONE: %s | actors=%d directors=%d",
-             stats, actor_total, director_total)
-    return 0 if stats["tmdb_error"] == 0 and stats["db_error"] == 0 else 1
+             dict(stats), actor_total, director_total)
+    return 0 if stats["tmdb_error"] == 0 and stats["db_error"] == 0 and stats["worker_exception"] == 0 else 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- claude-session: e5713c88-75a7-4380-8c08-7327c983587b -->

Closes #720

## Summary
- 1082 of 1878 series with `tmdb_id` had zero entries in `series_actors`/`series_directors` — `/serialy-online/{slug}/` rendered no Tvůrci/Herci sections.
- New `scripts/backfill-series-cast.py` calls TMDB `/tv/{id}` + `/tv/{id}/credits`, UPSERTs `people` by `tmdb_id`, inserts top-10 cast into `series_actors`, and creators+directors into `series_directors`. Idempotent re-run via `NOT EXISTS` candidate filter + `ON CONFLICT DO NOTHING`.
- Already run against prod (via SSH tunnel): **7244 actors + 1585 directors** inserted into 1071 series. Follow-up photo backfill uploaded 12 177 WebP files to R2.

## Test plan
- [x] Dry-run on dev DB — TMDB pipeline returns expected cast/crew shapes
- [x] Real run on dev DB — verified `series_actors` + `series_directors` rows landed and per-series counters increment correctly
- [x] Real run on prod (via SSH tunnel to `db:5432`) — 1071 ok, 15 empty, 1 db_error (single overlong character_name), 0 tmdb_error
- [x] Follow-up `backfill-person-photos.py` for the 5245 newly-inserted persons with TMDB profile photos — 12 177 ok, 3 transient download failures
- [x] CF cache purged for `/serialy-online/person/*`, `/img/people/*`, `/serialy-online/jen-mi-dal-lzi/`
- [x] Playwright on `/serialy-online/jen-mi-dal-lzi/` — Epizody → Tvůrci (1 card) → Herci (7 cards), 8/8 photos load with `naturalWidth > 1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)