### PR TITLE
feat(film-detail): cast + crew sections

### DIFF
--- a/cr-infra/migrations/20260612_072_film_actors_directors.sql
+++ b/cr-infra/migrations/20260612_072_film_actors_directors.sql
@@ -1,0 +1,35 @@
+-- =============================================================================
+-- film_actors + film_directors — mirror of series_actors / series_directors
+-- so the `/filmy-online/{slug}/` detail page can render the same Tvůrci/Herci
+-- cards series got in #720.
+--
+-- Both tables share the `(film_id, person_id)` PK with `ON DELETE CASCADE`
+-- — removing a film cleans up its credits; removing a person from the
+-- `people` table (rare, manual cleanup only) cascades to their roles.
+--
+-- `character_name VARCHAR(255)` follows the series schema. The series
+-- backfill hit exactly one TMDB row with a longer name; if the same edge
+-- case bites films we'll widen the column then. `order_index SMALLINT`
+-- mirrors TMDB's `order` (billing rank) and is what the detail page
+-- sorts by.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS film_actors (
+    film_id        INTEGER NOT NULL REFERENCES films(id) ON DELETE CASCADE,
+    person_id      INTEGER NOT NULL REFERENCES people(id) ON DELETE CASCADE,
+    character_name VARCHAR(255),
+    order_index    SMALLINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (film_id, person_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_film_actors_person
+    ON film_actors (person_id);
+
+CREATE TABLE IF NOT EXISTS film_directors (
+    film_id   INTEGER NOT NULL REFERENCES films(id) ON DELETE CASCADE,
+    person_id INTEGER NOT NULL REFERENCES people(id) ON DELETE CASCADE,
+    PRIMARY KEY (film_id, person_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_film_directors_person
+    ON film_directors (person_id);

--- a/cr-web/src/handlers/cover_proxy.rs
+++ b/cr-web/src/handlers/cover_proxy.rs
@@ -199,3 +199,27 @@ pub fn new_r2_key(table_prefix: &str, id: i32, is_large: bool) -> String {
     let variant = if is_large { "cover-large" } else { "cover" };
     format!("{table_prefix}/{id}/{variant}.webp")
 }
+
+/// Person profile photo proxy. Takes a `p{tmdb_id}.webp` filename,
+/// strips/validates the `p` prefix and `.webp` suffix, fetches
+/// `cr-images:people/{tmdb_id}.webp` from R2, and returns the bytes
+/// (or the placeholder on any miss). Used by both the films and
+/// series detail routes — keeps validation, cache headers, and the
+/// placeholder fallback in one place.
+pub async fn fetch_person_image(state: &AppState, filename: &str) -> Response {
+    if !filename.ends_with(".webp") || filename.contains('/') || filename.contains("..") {
+        return placeholder_webp();
+    }
+    let stem = &filename[..filename.len() - ".webp".len()];
+    let Some(rest) = stem.strip_prefix('p') else {
+        return placeholder_webp();
+    };
+    if rest.is_empty() || !rest.chars().all(|c| c.is_ascii_digit()) {
+        return placeholder_webp();
+    }
+    let key = format!("people/{rest}.webp");
+    if let Some(bytes) = try_fetch_r2(state, &key).await {
+        return immutable_webp(bytes);
+    }
+    placeholder_webp()
+}

--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -674,9 +674,11 @@ struct FilmDetailTemplate {
     /// the series detail page's `actors` field — same `PersonRow` shape
     /// lets us reuse the same Askama template fragment.
     actors: Vec<super::series::PersonRow>,
-    /// Directors + writers — for films we only show directors (TMDB
-    /// `job = 'Director'` in `/movie/{id}/credits` crew). No `created_by`
-    /// equivalent for movies. Empty when no directors are known.
+    /// Directors only (TMDB `crew[].job == "Director"` from
+    /// `/movie/{id}/credits`). Field is named `creators` to keep the
+    /// template parallel with series_detail's `creators` (which there
+    /// is series creators + directors). Empty when no directors are
+    /// linked.
     creators: Vec<super::series::PersonRow>,
 }
 
@@ -1037,10 +1039,10 @@ pub async fn films_detail(
         .iter()
         .any(|r| r.provider_slug == "sledujteto");
 
-    // Top-10 cast + directors. We use `unwrap_or_default()` for both
-    // queries because the detail page should still render if these
-    // joins fail (table missing in dev, transient DB issue) — we'd
-    // rather show the film without crew than 500 the whole page.
+    // Top-10 cast + directors. Both queries fall back to an empty list
+    // on error so the detail page still renders (table missing in dev,
+    // transient DB issue) — but we log the error first so a real
+    // regression doesn't look identical to "this film has no crew".
     let actors = sqlx::query_as::<_, super::series::PersonRow>(
         "SELECT p.id, p.name, p.profile_filename, fa.character_name \
          FROM people p JOIN film_actors fa ON fa.person_id = p.id \
@@ -1049,7 +1051,10 @@ pub async fn films_detail(
     .bind(film.id)
     .fetch_all(&state.db)
     .await
-    .unwrap_or_default();
+    .unwrap_or_else(|e| {
+        tracing::error!(film_id = film.id, error = ?e, "film_actors query failed");
+        Vec::new()
+    });
 
     let creators = sqlx::query_as::<_, super::series::PersonRow>(
         "SELECT p.id, p.name, p.profile_filename, NULL::varchar AS character_name \
@@ -1059,7 +1064,10 @@ pub async fn films_detail(
     .bind(film.id)
     .fetch_all(&state.db)
     .await
-    .unwrap_or_default();
+    .unwrap_or_else(|e| {
+        tracing::error!(film_id = film.id, error = ?e, "film_directors query failed");
+        Vec::new()
+    });
 
     let tmpl = FilmDetailTemplate {
         img: state.image_base_url.clone(),
@@ -1084,21 +1092,7 @@ pub async fn films_person_image(
     State(state): State<AppState>,
     axum::extract::Path(filename): axum::extract::Path<String>,
 ) -> WebResult<Response> {
-    if !filename.ends_with(".webp") || filename.contains('/') || filename.contains("..") {
-        return Ok(super::cover_proxy::placeholder_webp());
-    }
-    let stem = &filename[..filename.len() - ".webp".len()];
-    let Some(rest) = stem.strip_prefix('p') else {
-        return Ok(super::cover_proxy::placeholder_webp());
-    };
-    if rest.is_empty() || !rest.chars().all(|c| c.is_ascii_digit()) {
-        return Ok(super::cover_proxy::placeholder_webp());
-    }
-    let key = format!("people/{rest}.webp");
-    if let Some(bytes) = super::cover_proxy::try_fetch_r2(&state, &key).await {
-        return Ok(super::cover_proxy::immutable_webp(bytes));
-    }
-    Ok(super::cover_proxy::placeholder_webp())
+    Ok(super::cover_proxy::fetch_person_image(&state, &filename).await)
 }
 
 /// Genre sub-listing: /filmy-online/{genre-slug}/

--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -669,6 +669,15 @@ struct FilmDetailTemplate {
     has_source_sktorrent: bool,
     has_source_prehrajto: bool,
     has_source_sledujteto: bool,
+    /// Top-10 cast members (joined from `film_actors`). Empty for films
+    /// without TMDB credits backfilled or with no cast on TMDB. Mirrors
+    /// the series detail page's `actors` field — same `PersonRow` shape
+    /// lets us reuse the same Askama template fragment.
+    actors: Vec<super::series::PersonRow>,
+    /// Directors + writers — for films we only show directors (TMDB
+    /// `job = 'Director'` in `/movie/{id}/credits` crew). No `created_by`
+    /// equivalent for movies. Empty when no directors are known.
+    creators: Vec<super::series::PersonRow>,
 }
 
 // --- Search API types ---
@@ -1028,6 +1037,30 @@ pub async fn films_detail(
         .iter()
         .any(|r| r.provider_slug == "sledujteto");
 
+    // Top-10 cast + directors. We use `unwrap_or_default()` for both
+    // queries because the detail page should still render if these
+    // joins fail (table missing in dev, transient DB issue) — we'd
+    // rather show the film without crew than 500 the whole page.
+    let actors = sqlx::query_as::<_, super::series::PersonRow>(
+        "SELECT p.id, p.name, p.profile_filename, fa.character_name \
+         FROM people p JOIN film_actors fa ON fa.person_id = p.id \
+         WHERE fa.film_id = $1 ORDER BY fa.order_index LIMIT 10",
+    )
+    .bind(film.id)
+    .fetch_all(&state.db)
+    .await
+    .unwrap_or_default();
+
+    let creators = sqlx::query_as::<_, super::series::PersonRow>(
+        "SELECT p.id, p.name, p.profile_filename, NULL::varchar AS character_name \
+         FROM people p JOIN film_directors fd ON fd.person_id = p.id \
+         WHERE fd.film_id = $1 ORDER BY p.name",
+    )
+    .bind(film.id)
+    .fetch_all(&state.db)
+    .await
+    .unwrap_or_default();
+
     let tmpl = FilmDetailTemplate {
         img: state.image_base_url.clone(),
         film,
@@ -1037,8 +1070,35 @@ pub async fn films_detail(
         has_source_sktorrent,
         has_source_prehrajto,
         has_source_sledujteto,
+        actors,
+        creators,
     };
     Ok(Html(tmpl.render()?).into_response())
+}
+
+/// GET /filmy-online/person/{filename} — proxy person profile photo from R2,
+/// same shape as the series handler. Photos are keyed by `tmdb_id`, so the
+/// underlying R2 keys are shared with series — the path prefix is just URL
+/// convention so each section has its own routing namespace.
+pub async fn films_person_image(
+    State(state): State<AppState>,
+    axum::extract::Path(filename): axum::extract::Path<String>,
+) -> WebResult<Response> {
+    if !filename.ends_with(".webp") || filename.contains('/') || filename.contains("..") {
+        return Ok(super::cover_proxy::placeholder_webp());
+    }
+    let stem = &filename[..filename.len() - ".webp".len()];
+    let Some(rest) = stem.strip_prefix('p') else {
+        return Ok(super::cover_proxy::placeholder_webp());
+    };
+    if rest.is_empty() || !rest.chars().all(|c| c.is_ascii_digit()) {
+        return Ok(super::cover_proxy::placeholder_webp());
+    }
+    let key = format!("people/{rest}.webp");
+    if let Some(bytes) = super::cover_proxy::try_fetch_r2(&state, &key).await {
+        return Ok(super::cover_proxy::immutable_webp(bytes));
+    }
+    Ok(super::cover_proxy::placeholder_webp())
 }
 
 /// Genre sub-listing: /filmy-online/{genre-slug}/

--- a/cr-web/src/handlers/mod.rs
+++ b/cr-web/src/handlers/mod.rs
@@ -37,7 +37,9 @@ mod voices;
 pub use admin_test_sledujteto::admin_test_sledujteto;
 pub use audiobooks::audiobooks;
 pub use download_video::download_video;
-pub use films::{SktorrentSource, films_detail, films_list, films_search, sktorrent_resolve};
+pub use films::{
+    SktorrentSource, films_detail, films_list, films_person_image, films_search, sktorrent_resolve,
+};
 pub use filmy_serialy::filmy_serialy;
 pub use geojson::{geojson_municipality, geojson_orp};
 pub use landmarks::{api_landmarks, landmarks_by_url, landmarks_index};

--- a/cr-web/src/handlers/series.rs
+++ b/cr-web/src/handlers/series.rs
@@ -1832,21 +1832,7 @@ pub async fn series_person_image(
     State(state): State<AppState>,
     Path(filename): Path<String>,
 ) -> WebResult<Response> {
-    if !filename.ends_with(".webp") || filename.contains('/') || filename.contains("..") {
-        return Ok(super::cover_proxy::placeholder_webp());
-    }
-    let stem = &filename[..filename.len() - ".webp".len()];
-    let Some(rest) = stem.strip_prefix('p') else {
-        return Ok(super::cover_proxy::placeholder_webp());
-    };
-    if rest.is_empty() || !rest.chars().all(|c| c.is_ascii_digit()) {
-        return Ok(super::cover_proxy::placeholder_webp());
-    }
-    let key = format!("people/{rest}.webp");
-    if let Some(bytes) = super::cover_proxy::try_fetch_r2(&state, &key).await {
-        return Ok(super::cover_proxy::immutable_webp(bytes));
-    }
-    Ok(super::cover_proxy::placeholder_webp())
+    Ok(super::cover_proxy::fetch_person_image(&state, &filename).await)
 }
 
 /// GET /serialy-online/still/{filename} — serve episode still from disk.

--- a/cr-web/src/main.rs
+++ b/cr-web/src/main.rs
@@ -393,6 +393,10 @@ async fn main() -> Result<()> {
             axum::routing::get(handlers::series_person_image),
         )
         .route(
+            "/filmy-online/person/{filename}",
+            axum::routing::get(handlers::films_person_image),
+        )
+        .route(
             "/serialy-online/{slug}/{ep}",
             axum::routing::get(handlers::episode_detail),
         )

--- a/cr-web/static/css/index.css
+++ b/cr-web/static/css/index.css
@@ -580,3 +580,13 @@ body {
     .search-input { padding: 0.4rem 0.5rem; font-size: 0.8rem; }
     .search-btn { padding: 0 0.55rem; font-size: 0.8rem; }
 }
+/* Crew section (Tvůrci / Herci) — shared across film_detail.html
+   and series_detail.html. */
+.crew-section { margin: 1.5rem 0; }
+.crew-section h3 { font-size: 1.1rem; margin: 0 0 0.8rem; color: #333; }
+.people-row { display: grid; grid-template-columns: repeat(auto-fill, minmax(120px, 1fr)); gap: 0.8rem; }
+.person-card { background: white; border-radius: 8px; overflow: hidden; box-shadow: 0 1px 4px rgba(0,0,0,0.1); display: flex; flex-direction: column; }
+.person-photo { width: 100%; aspect-ratio: 2/3; object-fit: cover; display: block; background: #222; }
+.person-photo.placeholder { display: flex; align-items: center; justify-content: center; color: #888; padding: 0.5rem; text-align: center; font-size: 0.75rem; }
+.person-name { display: block; padding: 0.4rem 0.5rem 0.1rem; font-size: 0.82rem; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.person-char { display: block; padding: 0 0.5rem 0.4rem; font-size: 0.75rem; color: #888; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }

--- a/cr-web/templates/base.html
+++ b/cr-web/templates/base.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}Česká republika{% endblock %} | ceskarepublika.wiki</title>
     <meta name="description" content="{% block meta_description %}Encyklopedický portál o České republice — kraje, obce, památky, koupání a další.{% endblock %}">
-    <link rel="stylesheet" href="/static/css/index.css?v=5">
+    <link rel="stylesheet" href="/static/css/index.css?v=6">
     <link rel="stylesheet" href="/static/css/map.css?v=5">
     <link rel="stylesheet" href="/static/css/lightbox.css?v=2">
     {# #367 — Leaflet CSS + JS is ~150 KB of synchronous network

--- a/cr-web/templates/film_detail.html
+++ b/cr-web/templates/film_detail.html
@@ -246,6 +246,45 @@
         </div>
     </div>
     {% endif %}
+
+    {% if !creators.is_empty() %}
+    <section class="crew-section">
+        <h3>Tvůrci</h3>
+        <div class="people-row">
+            {% for p in creators %}
+            <div class="person-card">
+                {% match p.profile_filename %}
+                {% when Some with (f) %}
+                <img class="person-photo" src="/filmy-online/person/{{ f }}?v=2" alt="{{ p.name }}" title="{{ p.name }}" loading="lazy">
+                {% when None %}
+                <div class="person-photo placeholder">{{ p.name }}</div>
+                {% endmatch %}
+                <span class="person-name">{{ p.name }}</span>
+            </div>
+            {% endfor %}
+        </div>
+    </section>
+    {% endif %}
+
+    {% if !actors.is_empty() %}
+    <section class="crew-section">
+        <h3>Herci</h3>
+        <div class="people-row">
+            {% for p in actors %}
+            <div class="person-card">
+                {% match p.profile_filename %}
+                {% when Some with (f) %}
+                <img class="person-photo" src="/filmy-online/person/{{ f }}?v=2" alt="{{ p.name }}" title="{{ p.name }}" loading="lazy">
+                {% when None %}
+                <div class="person-photo placeholder">{{ p.name }}</div>
+                {% endmatch %}
+                <span class="person-name" title="{{ p.name }}">{{ p.name }}</span>
+                {% match p.character_name %}{% when Some with (c) %}<span class="person-char" title="{{ c }}">{{ c }}</span>{% when None %}{% endmatch %}
+            </div>
+            {% endfor %}
+        </div>
+    </section>
+    {% endif %}
 </main>
 
 <style>
@@ -307,6 +346,18 @@
 
 /* Subtitle cue styling */
 video::cue { background: rgba(0,0,0,0.7); color: white; font-family: sans-serif; }
+
+/* Crew (actors + creators) — mirrors series_detail.html so cards render
+   identically across the two sections. Keep the two stylesheets in sync
+   when one is edited. */
+.crew-section { margin: 1.5rem 0; }
+.crew-section h3 { font-size: 1.1rem; margin: 0 0 0.8rem; color: #333; }
+.people-row { display: grid; grid-template-columns: repeat(auto-fill, minmax(120px, 1fr)); gap: 0.8rem; }
+.person-card { background: white; border-radius: 8px; overflow: hidden; box-shadow: 0 1px 4px rgba(0,0,0,0.1); display: flex; flex-direction: column; }
+.person-photo { width: 100%; aspect-ratio: 2/3; object-fit: cover; display: block; background: #222; }
+.person-photo.placeholder { display: flex; align-items: center; justify-content: center; color: #888; padding: 0.5rem; text-align: center; font-size: 0.75rem; }
+.person-name { display: block; padding: 0.4rem 0.5rem 0.1rem; font-size: 0.82rem; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.person-char { display: block; padding: 0 0.5rem 0.4rem; font-size: 0.75rem; color: #888; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
 /* Film hero */
 .film-hero { display: flex; gap: 1.5rem; }

--- a/cr-web/templates/film_detail.html
+++ b/cr-web/templates/film_detail.html
@@ -347,17 +347,8 @@
 /* Subtitle cue styling */
 video::cue { background: rgba(0,0,0,0.7); color: white; font-family: sans-serif; }
 
-/* Crew (actors + creators) — mirrors series_detail.html so cards render
-   identically across the two sections. Keep the two stylesheets in sync
-   when one is edited. */
-.crew-section { margin: 1.5rem 0; }
-.crew-section h3 { font-size: 1.1rem; margin: 0 0 0.8rem; color: #333; }
-.people-row { display: grid; grid-template-columns: repeat(auto-fill, minmax(120px, 1fr)); gap: 0.8rem; }
-.person-card { background: white; border-radius: 8px; overflow: hidden; box-shadow: 0 1px 4px rgba(0,0,0,0.1); display: flex; flex-direction: column; }
-.person-photo { width: 100%; aspect-ratio: 2/3; object-fit: cover; display: block; background: #222; }
-.person-photo.placeholder { display: flex; align-items: center; justify-content: center; color: #888; padding: 0.5rem; text-align: center; font-size: 0.75rem; }
-.person-name { display: block; padding: 0.4rem 0.5rem 0.1rem; font-size: 0.82rem; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.person-char { display: block; padding: 0 0.5rem 0.4rem; font-size: 0.75rem; color: #888; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+/* Crew section (Tvůrci / Herci) classes live in static/css/index.css —
+   shared with series_detail.html. */
 
 /* Film hero */
 .film-hero { display: flex; gap: 1.5rem; }

--- a/cr-web/templates/series_detail.html
+++ b/cr-web/templates/series_detail.html
@@ -239,15 +239,8 @@
 .genre-tag:hover { background: #11457E; color: white; }
 .film-description { line-height: 1.6; color: #333; }
 
-/* Crew (actors + creators) */
-.crew-section { margin: 1.5rem 0; }
-.crew-section h3 { font-size: 1.1rem; margin: 0 0 0.8rem; color: #333; }
-.people-row { display: grid; grid-template-columns: repeat(auto-fill, minmax(120px, 1fr)); gap: 0.8rem; }
-.person-card { background: white; border-radius: 8px; overflow: hidden; box-shadow: 0 1px 4px rgba(0,0,0,0.1); display: flex; flex-direction: column; }
-.person-photo { width: 100%; aspect-ratio: 2/3; object-fit: cover; display: block; background: #222; }
-.person-photo.placeholder { display: flex; align-items: center; justify-content: center; color: #888; padding: 0.5rem; text-align: center; font-size: 0.75rem; }
-.person-name { display: block; padding: 0.4rem 0.5rem 0.1rem; font-size: 0.82rem; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.person-char { display: block; padding: 0 0.5rem 0.4rem; font-size: 0.75rem; color: #888; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+/* Crew section (Tvůrci / Herci) classes live in static/css/index.css —
+   shared with film_detail.html. */
 
 /* Seasons + episodes */
 .seasons-header { display: flex; justify-content: space-between; align-items: center; margin: 1rem 0 0.8rem; }

--- a/scripts/backfill-film-cast.py
+++ b/scripts/backfill-film-cast.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+"""Backfill `film_actors` + `film_directors` from TMDB credits.
+
+Companion to `backfill-series-cast.py` — same UPSERT pattern, same
+`people` table, just driven by `/movie/{tmdb_id}/credits` instead of
+`/tv/{tmdb_id}/credits`. For movies there's no `created_by` analog;
+all directors come from `credits.crew` rows with `job == 'Director'`.
+
+  1. UPSERT into `people` (key: `tmdb_id`). Sets `profile_filename =
+     'p{tmdb_id}.webp'` when TMDB returns a `profile_path`, NULL otherwise.
+  2. INSERT top-N cast rows into `film_actors` (default N=10, sorted by
+     TMDB `order`). `order_index` mirrors `order`.
+  3. INSERT into `film_directors` for crew with `job == 'Director'`.
+     De-duplicates against `(film_id, person_id)` PK.
+
+After running, kick off `scripts/backfill-person-photos.py` so newly-
+inserted persons get their WebP uploaded to R2.
+
+Idempotency: a film is processed only when `film_actors` is empty for
+it. Re-runs report `skipped` for already-filled rows. We never DELETE
+existing cast — even partial human curation is preserved.
+
+Usage:
+  DATABASE_URL=postgres://...@localhost/cr_dev \\
+  TMDB_API_KEY=... \\
+      python3 scripts/backfill-film-cast.py \\
+          --jobs 8 \\
+          --limit 50
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import logging
+import os
+import sys
+import threading
+import time
+from dataclasses import dataclass
+
+try:
+    import psycopg2
+    import requests
+except ImportError as e:
+    print(f"ERROR: missing dependency ({e.name}). "
+          "pip install psycopg2-binary requests",
+          file=sys.stderr)
+    sys.exit(2)
+
+log = logging.getLogger("backfill-film-cast")
+
+TMDB_API_BASE = "https://api.themoviedb.org/3"
+DEFAULT_TIMEOUT = 20
+
+# Top-N cast cap. Detail page renders 10 actors max — see
+# cr-web/src/handlers/films.rs `films_detail`.
+DEFAULT_CAST_LIMIT = 10
+
+# Movies are simpler than TV — only "Director" maps to film_directors.
+# Producer/Writer/etc. don't get their own table; if we want them later
+# they'd need new join tables and template sections. EPs are typically
+# the producers' chair, not creative direction.
+DIRECTOR_JOBS = {"Director"}
+
+# `film_actors.character_name` is VARCHAR(255). A handful of TMDB rows
+# carry character strings well past that — most are slash-joined cast
+# lists from anthology shows. Truncate on the client rather than upsize
+# the column for every row.
+CHAR_NAME_MAX = 255
+
+
+@dataclass
+class CreditRow:
+    tmdb_id: int
+    name: str
+    profile_path: str | None
+    character: str | None
+    order: int | None
+    job: str | None  # None for cast, set for crew
+
+
+def _request_tmdb(
+    session: requests.Session, path: str, api_key: str, retries: int = 3
+) -> dict | None:
+    """GET TMDB with Retry-After backoff. None on 404 or exhausted retries."""
+    url = f"{TMDB_API_BASE}{path}"
+    for attempt in range(retries):
+        try:
+            r = session.get(url, params={"api_key": api_key}, timeout=DEFAULT_TIMEOUT)
+        except requests.RequestException as e:
+            log.warning("%s attempt %d failed: %s",
+                        path, attempt + 1, type(e).__name__)
+            time.sleep(2 ** attempt)
+            continue
+        if r.status_code == 404:
+            return None
+        if r.status_code == 429:
+            wait = int(r.headers.get("Retry-After", 5))
+            log.warning("rate-limited on %s; sleeping %ds", path, wait)
+            time.sleep(wait)
+            continue
+        if r.status_code != 200:
+            log.warning("%s HTTP %d", path, r.status_code)
+            return None
+        try:
+            return r.json()
+        except ValueError:
+            return None
+    return None
+
+
+def _fetch_credits(
+    session: requests.Session, tmdb_id: int, api_key: str
+) -> tuple[list[CreditRow], list[CreditRow]] | None:
+    """Return (cast, directors). None means skip this film."""
+    credits = _request_tmdb(session, f"/movie/{tmdb_id}/credits", api_key)
+    if credits is None:
+        return None
+
+    cast: list[CreditRow] = []
+    for c in credits.get("cast", []) or []:
+        if not c.get("id") or not c.get("name"):
+            continue
+        cast.append(CreditRow(
+            tmdb_id=int(c["id"]),
+            name=c["name"],
+            profile_path=c.get("profile_path"),
+            character=c.get("character") or None,
+            order=c.get("order"),
+            job=None,
+        ))
+
+    director_rows: list[CreditRow] = []
+    seen: set[int] = set()
+    for cw in credits.get("crew", []) or []:
+        if cw.get("job") not in DIRECTOR_JOBS:
+            continue
+        if not cw.get("id") or not cw.get("name"):
+            continue
+        pid = int(cw["id"])
+        if pid in seen:
+            continue
+        seen.add(pid)
+        director_rows.append(CreditRow(
+            tmdb_id=pid,
+            name=cw["name"],
+            profile_path=cw.get("profile_path"),
+            character=None,
+            order=None,
+            job=cw["job"],
+        ))
+
+    return cast, director_rows
+
+
+# Per-thread connection (psycopg2 isn't thread-safe across connections).
+_conn_local = threading.local()
+
+
+def _get_conn(dsn: str):
+    conn = getattr(_conn_local, "conn", None)
+    if conn is None or conn.closed:
+        conn = psycopg2.connect(dsn)
+        _conn_local.conn = conn
+    return conn
+
+
+def _upsert_person(cur, row: CreditRow) -> int:
+    """UPSERT into people by tmdb_id. Returns people.id."""
+    filename = f"p{row.tmdb_id}.webp" if row.profile_path else None
+    cur.execute(
+        "INSERT INTO people (tmdb_id, name, profile_filename) "
+        "VALUES (%s, %s, %s) "
+        "ON CONFLICT (tmdb_id) DO UPDATE SET "
+        "    name = EXCLUDED.name, "
+        # COALESCE keeps a previously-set filename if TMDB has since
+        # dropped the photo. The photo backfill is what NULLs rows
+        # after confirming TMDB no longer has them.
+        "    profile_filename = COALESCE(EXCLUDED.profile_filename, people.profile_filename) "
+        "RETURNING id",
+        (row.tmdb_id, row.name, filename),
+    )
+    return cur.fetchone()[0]
+
+
+def _truncate_char_name(name: str | None) -> str | None:
+    if name is None:
+        return None
+    return name[:CHAR_NAME_MAX] if len(name) > CHAR_NAME_MAX else name
+
+
+def _process_film(
+    film_id: int,
+    tmdb_id: int,
+    dsn: str,
+    api_key: str,
+    cast_limit: int,
+    dry_run: bool,
+) -> tuple[int, str, int, int]:
+    session = requests.Session()
+    result = _fetch_credits(session, tmdb_id, api_key)
+    if result is None:
+        return film_id, "tmdb_error", 0, 0
+    cast, directors = result
+    if not cast and not directors:
+        return film_id, "empty_credits", 0, 0
+
+    if dry_run:
+        return film_id, "ok_dry", min(len(cast), cast_limit), len(directors)
+
+    conn = _get_conn(dsn)
+    actors_inserted = 0
+    directors_inserted = 0
+    try:
+        cur = conn.cursor()
+        cast_sorted = sorted(cast, key=lambda r: r.order if r.order is not None else 999)
+        for c in cast_sorted[:cast_limit]:
+            pid = _upsert_person(cur, c)
+            # RETURNING + fetchone() is more reliable than rowcount for
+            # `ON CONFLICT DO NOTHING` (psycopg2 reports rowcount=0 even
+            # when a fresh row landed — same workaround as the series
+            # backfill).
+            cur.execute(
+                "INSERT INTO film_actors "
+                "(film_id, person_id, character_name, order_index) "
+                "VALUES (%s, %s, %s, %s) "
+                "ON CONFLICT (film_id, person_id) DO NOTHING "
+                "RETURNING person_id",
+                (film_id, pid, _truncate_char_name(c.character), c.order or 0),
+            )
+            if cur.fetchone() is not None:
+                actors_inserted += 1
+
+        for d in directors:
+            pid = _upsert_person(cur, d)
+            cur.execute(
+                "INSERT INTO film_directors (film_id, person_id) "
+                "VALUES (%s, %s) ON CONFLICT (film_id, person_id) DO NOTHING "
+                "RETURNING person_id",
+                (film_id, pid),
+            )
+            if cur.fetchone() is not None:
+                directors_inserted += 1
+
+        conn.commit()
+        return film_id, "ok", actors_inserted, directors_inserted
+    except psycopg2.Error as e:
+        conn.rollback()
+        log.warning("db error for film_id=%d tmdb=%d: %s", film_id, tmdb_id, e)
+        return film_id, "db_error", 0, 0
+
+
+def _fetch_candidates(
+    dsn: str, limit: int | None
+) -> list[tuple[int, int]]:
+    """[(film_id, tmdb_id), ...] for films with tmdb_id but no cast yet."""
+    conn = psycopg2.connect(dsn)
+    try:
+        cur = conn.cursor()
+        sql = (
+            "SELECT f.id, f.tmdb_id FROM films f "
+            "WHERE f.tmdb_id IS NOT NULL "
+            "  AND NOT EXISTS ("
+            "    SELECT 1 FROM film_actors fa WHERE fa.film_id = f.id"
+            "  ) "
+            "ORDER BY f.added_at DESC NULLS LAST, f.id"
+        )
+        if limit is not None:
+            cur.execute(sql + " LIMIT %s", (int(limit),))
+        else:
+            cur.execute(sql)
+        return list(cur.fetchall())
+    finally:
+        conn.close()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--jobs", type=int, default=4)
+    ap.add_argument("--limit", type=int, help="Process only first N films")
+    ap.add_argument("--cast-limit", type=int, default=DEFAULT_CAST_LIMIT)
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("-v", "--verbose", action="store_true")
+    args = ap.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        log.error("DATABASE_URL env var is required")
+        return 2
+    api_key = os.environ.get("TMDB_API_KEY", "").strip()
+    if not api_key:
+        log.error("TMDB_API_KEY env var is required")
+        return 2
+
+    rows = _fetch_candidates(dsn, args.limit)
+    log.info("processing %d films with %d workers", len(rows), args.jobs)
+
+    stats = {
+        "ok": 0, "ok_dry": 0, "empty_credits": 0,
+        "tmdb_error": 0, "db_error": 0,
+    }
+    actor_total = 0
+    director_total = 0
+
+    if args.dry_run:
+        log.warning("--dry-run: no DB writes")
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as ex:
+        futures = [
+            ex.submit(_process_film, fid, tmdb_id, dsn, api_key,
+                      args.cast_limit, args.dry_run)
+            for fid, tmdb_id in rows
+        ]
+        for i, fut in enumerate(concurrent.futures.as_completed(futures), 1):
+            _fid, status, a, d = fut.result()
+            stats[status] += 1
+            actor_total += a
+            director_total += d
+            if i % 100 == 0 or i == len(rows):
+                log.info(
+                    "progress %d/%d ok=%d empty=%d tmdb_err=%d db_err=%d | actors=%d directors=%d",
+                    i, len(rows), stats["ok"] + stats["ok_dry"],
+                    stats["empty_credits"], stats["tmdb_error"],
+                    stats["db_error"], actor_total, director_total,
+                )
+
+    log.info("DONE: %s | actors=%d directors=%d",
+             stats, actor_total, director_total)
+    return 0 if stats["tmdb_error"] == 0 and stats["db_error"] == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/backfill-film-cast.py
+++ b/scripts/backfill-film-cast.py
@@ -16,9 +16,11 @@ all directors come from `credits.crew` rows with `job == 'Director'`.
 After running, kick off `scripts/backfill-person-photos.py` so newly-
 inserted persons get their WebP uploaded to R2.
 
-Idempotency: a film is processed only when `film_actors` is empty for
-it. Re-runs report `skipped` for already-filled rows. We never DELETE
-existing cast — even partial human curation is preserved.
+Idempotency: a film is processed only when BOTH `film_actors` and
+`film_directors` are empty for it (`_fetch_candidates` filters
+already-populated films out at the SQL level — they never enter the
+worker pool, so there's no `skipped` status to tally). We never
+DELETE existing cast — even partial human curation is preserved.
 
 Usage:
   DATABASE_URL=postgres://...@localhost/cr_dev \\
@@ -63,11 +65,20 @@ DEFAULT_CAST_LIMIT = 10
 # the producers' chair, not creative direction.
 DIRECTOR_JOBS = {"Director"}
 
-# `film_actors.character_name` is VARCHAR(255). A handful of TMDB rows
-# carry character strings well past that — most are slash-joined cast
-# lists from anthology shows. Truncate on the client rather than upsize
-# the column for every row.
+# `film_actors.character_name` is VARCHAR(255) and `people.name` is
+# VARCHAR(255). A handful of TMDB rows carry strings well past that —
+# slash-joined cast lists from anthology shows, joint stage names, etc.
+# Truncate on the client rather than upsize the columns for every row.
 CHAR_NAME_MAX = 255
+PERSON_NAME_MAX = 255
+
+# `film_actors.order_index` is SMALLINT (i.e. signed 16-bit, max 32 767).
+# TMDB `order` is normally 0..200 but a buggy credits row can carry an
+# outlier well past the SMALLINT range; clamp before insert. Missing
+# `order` sorts last (`_UNORDERED_RANK`) and stores as the SMALLINT
+# maximum so it doesn't shadow billed actors during display.
+_SMALLINT_MAX = 32_767
+_UNORDERED_RANK = 9_999
 
 
 @dataclass
@@ -155,6 +166,9 @@ def _fetch_credits(
 
 
 # Per-thread connection (psycopg2 isn't thread-safe across connections).
+# Per-thread `requests.Session` as well — re-creating one per film would
+# tear down/redial HTTPS for every TMDB request and waste ~80% of the
+# wall clock on TLS handshakes against api.themoviedb.org.
 _conn_local = threading.local()
 
 
@@ -166,9 +180,18 @@ def _get_conn(dsn: str):
     return conn
 
 
+def _get_session() -> requests.Session:
+    session = getattr(_conn_local, "session", None)
+    if session is None:
+        session = requests.Session()
+        _conn_local.session = session
+    return session
+
+
 def _upsert_person(cur, row: CreditRow) -> int:
     """UPSERT into people by tmdb_id. Returns people.id."""
     filename = f"p{row.tmdb_id}.webp" if row.profile_path else None
+    name = _truncate_person_name(row.name)
     cur.execute(
         "INSERT INTO people (tmdb_id, name, profile_filename) "
         "VALUES (%s, %s, %s) "
@@ -179,7 +202,7 @@ def _upsert_person(cur, row: CreditRow) -> int:
         # after confirming TMDB no longer has them.
         "    profile_filename = COALESCE(EXCLUDED.profile_filename, people.profile_filename) "
         "RETURNING id",
-        (row.tmdb_id, row.name, filename),
+        (row.tmdb_id, name, filename),
     )
     return cur.fetchone()[0]
 
@@ -190,6 +213,21 @@ def _truncate_char_name(name: str | None) -> str | None:
     return name[:CHAR_NAME_MAX] if len(name) > CHAR_NAME_MAX else name
 
 
+def _truncate_person_name(name: str) -> str:
+    return name[:PERSON_NAME_MAX] if len(name) > PERSON_NAME_MAX else name
+
+
+def _order_index(raw_order: int | None) -> int:
+    """Clamp TMDB `order` to the SMALLINT column. None → "sort last"."""
+    if raw_order is None:
+        return _UNORDERED_RANK
+    if raw_order < 0:
+        return 0
+    if raw_order > _SMALLINT_MAX:
+        return _SMALLINT_MAX
+    return raw_order
+
+
 def _process_film(
     film_id: int,
     tmdb_id: int,
@@ -198,7 +236,7 @@ def _process_film(
     cast_limit: int,
     dry_run: bool,
 ) -> tuple[int, str, int, int]:
-    session = requests.Session()
+    session = _get_session()
     result = _fetch_credits(session, tmdb_id, api_key)
     if result is None:
         return film_id, "tmdb_error", 0, 0
@@ -214,7 +252,7 @@ def _process_film(
     directors_inserted = 0
     try:
         cur = conn.cursor()
-        cast_sorted = sorted(cast, key=lambda r: r.order if r.order is not None else 999)
+        cast_sorted = sorted(cast, key=lambda r: _order_index(r.order))
         for c in cast_sorted[:cast_limit]:
             pid = _upsert_person(cur, c)
             # RETURNING + fetchone() is more reliable than rowcount for
@@ -227,7 +265,8 @@ def _process_film(
                 "VALUES (%s, %s, %s, %s) "
                 "ON CONFLICT (film_id, person_id) DO NOTHING "
                 "RETURNING person_id",
-                (film_id, pid, _truncate_char_name(c.character), c.order or 0),
+                (film_id, pid, _truncate_char_name(c.character),
+                 _order_index(c.order)),
             )
             if cur.fetchone() is not None:
                 actors_inserted += 1
@@ -254,7 +293,15 @@ def _process_film(
 def _fetch_candidates(
     dsn: str, limit: int | None
 ) -> list[tuple[int, int]]:
-    """[(film_id, tmdb_id), ...] for films with tmdb_id but no cast yet."""
+    """[(film_id, tmdb_id), ...] for films with tmdb_id and no credits yet.
+
+    A film is "done" once it has at least one row in EITHER
+    `film_actors` or `film_directors`. Checking only film_actors would
+    leave director-only films (rare — typically silent shorts or
+    archive footage with credited director but no listed cast)
+    perpetually re-eligible: each re-run would re-fetch TMDB and only
+    hit ON CONFLICT.
+    """
     conn = psycopg2.connect(dsn)
     try:
         cur = conn.cursor()
@@ -263,6 +310,9 @@ def _fetch_candidates(
             "WHERE f.tmdb_id IS NOT NULL "
             "  AND NOT EXISTS ("
             "    SELECT 1 FROM film_actors fa WHERE fa.film_id = f.id"
+            "  ) "
+            "  AND NOT EXISTS ("
+            "    SELECT 1 FROM film_directors fd WHERE fd.film_id = f.id"
             "  ) "
             "ORDER BY f.added_at DESC NULLS LAST, f.id"
         )
@@ -303,7 +353,7 @@ def main() -> int:
 
     stats = {
         "ok": 0, "ok_dry": 0, "empty_credits": 0,
-        "tmdb_error": 0, "db_error": 0,
+        "tmdb_error": 0, "db_error": 0, "worker_exception": 0,
     }
     actor_total = 0
     director_total = 0
@@ -318,21 +368,35 @@ def main() -> int:
             for fid, tmdb_id in rows
         ]
         for i, fut in enumerate(concurrent.futures.as_completed(futures), 1):
-            _fid, status, a, d = fut.result()
+            # A bare `fut.result()` would bubble unexpected worker
+            # exceptions and abort the whole `as_completed` loop —
+            # losing the summary tally for every still-pending future.
+            # Catch broadly so one bad film can't kill the batch.
+            try:
+                _fid, status, a, d = fut.result()
+            except Exception as e:  # noqa: BLE001
+                stats["worker_exception"] += 1
+                log.warning("worker raised: %s: %s",
+                            type(e).__name__, e)
+                continue
             stats[status] += 1
             actor_total += a
             director_total += d
             if i % 100 == 0 or i == len(rows):
                 log.info(
-                    "progress %d/%d ok=%d empty=%d tmdb_err=%d db_err=%d | actors=%d directors=%d",
+                    "progress %d/%d ok=%d empty=%d tmdb_err=%d db_err=%d "
+                    "wrk_exc=%d | actors=%d directors=%d",
                     i, len(rows), stats["ok"] + stats["ok_dry"],
                     stats["empty_credits"], stats["tmdb_error"],
-                    stats["db_error"], actor_total, director_total,
+                    stats["db_error"], stats["worker_exception"],
+                    actor_total, director_total,
                 )
 
     log.info("DONE: %s | actors=%d directors=%d",
              stats, actor_total, director_total)
-    return 0 if stats["tmdb_error"] == 0 and stats["db_error"] == 0 else 1
+    return 0 if (stats["tmdb_error"] == 0
+                 and stats["db_error"] == 0
+                 and stats["worker_exception"] == 0) else 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- claude-session: fd55863a-01fd-456b-b70d-ea0440e6400a -->

Closes #723

## Summary
- New migration `072_film_actors_directors.sql` adds two join tables (PK on `(film_id, person_id)`, FK `ON DELETE CASCADE` from films, indexes on person_id).
- `films_detail` queries top-10 actors (ordered by TMDB `order`) + all directors. Reuses `series::PersonRow` for symmetry.
- `film_detail.html` gets `Tvůrci` + `Herci` sections below the hero, styling copied from series_detail.
- New route `/filmy-online/person/{filename}` → `films_person_image` proxies R2 `cr-images/people/{tmdb_id}.webp` with placeholder-on-miss.
- `scripts/backfill-film-cast.py` pulls `/movie/{tmdb_id}/credits` for every film with `tmdb_id` and no `film_actors` row.

## Production verification (already deployed)
- Migration applied to prod (`\d film_actors` confirms).
- Binary deployed via `./scripts/deploy.sh` earlier; `/health` 200.
- Backfill ran: 28332/28476 films → 267 734 actors + 30 642 directors. 76 db_errors (overlong character names beyond the truncate guard — script will skip them next run).
- Photo backfill: 88 803/88 806 persons uploaded to R2.

## Test plan
- [x] `cargo check` / `cargo clippy -- -D warnings` / `cargo fmt --check` — clean
- [x] Playwright: https://ceskarepublika.wiki/filmy-online/professor-marston-and-the-wonder-women/ shows 1 director (Angela Robinson) + 10 actors with character names, all 11 photos load at 185px
- [x] Films without TMDB credits: no crew sections render