### PR TITLE
fix(title-parser): detect SK Torrent's '/ E32 /' shorthand as episode

### DIFF
--- a/scripts/auto_import/title_parser.py
+++ b/scripts/auto_import/title_parser.py
@@ -29,6 +29,15 @@ from dataclasses import dataclass, asdict, field
 _EPISODE_RE = re.compile(r"\bS(\d{1,2})E(\d{1,2})\b", re.IGNORECASE)
 _EPISODE_X_RE = re.compile(r"\b(\d{1,2})x(\d{1,2})\b")
 
+# SK Torrent's CZ-series convention: `Title / E32 / Subtitle / CZ`. No
+# season number — uploads use a single continuous episode count across
+# the whole series (Pat a Mat, Krtek, etc.). We treat these as season 1
+# so `is_episode=True` and the auto-import routes to the series
+# enricher instead of fabricating a film row from a spurious TMDB
+# match. Slash-bounded on BOTH sides so a stray "E32" inside a title
+# like "Final Frontier E32" doesn't accidentally match.
+_SLASH_EPISODE_RE = re.compile(r"/\s*E(\d{1,3})\s*/", re.IGNORECASE)
+
 # Year in parentheses or anywhere as standalone 4-digit
 _YEAR_PAREN_RE = re.compile(r"\((19|20)\d{2}\)")
 _YEAR_BARE_RE = re.compile(r"\b(19|20)\d{2}\b")
@@ -90,6 +99,12 @@ def _detect_episode(title: str) -> tuple[int | None, int | None]:
     m = _EPISODE_X_RE.search(title)
     if m:
         return int(m.group(1)), int(m.group(2))
+    # SK Torrent's `/ E32 /` shorthand — no season annotation. Default
+    # to season 1 so downstream code can treat it as an episode of an
+    # un-seasoned series.
+    m = _SLASH_EPISODE_RE.search(title)
+    if m:
+        return 1, int(m.group(1))
     return None, None
 
 


### PR DESCRIPTION
<!-- claude-session: fd55863a-01fd-456b-b70d-ea0440e6400a -->

## Summary
- SK Torrent uploads of CZ animated shorts (Pat a Mat, Krtek, …) use a slash-delimited episode marker without a season number — e.g. `Pat a Mat / E32 / Sekacka / CZ`. The previous regexes (`SxxExx` / `NxM`) didn't match, so `parse_sktorrent_title` returned `is_episode=False` and the film pipeline took the title to TMDB.
- TMDB then matched the cleaned-up title against random unrelated movies — today's auto-import (2026-05-14 05:09 UTC) inserted **ten bogus films** (37258–37267, all Doraemon-titled but actually Pat a Mat episodes) and overwrote `sktorrent_video_id` on two preexisting films (32188 "18. růže", 25151 "Tři mušketýři: Mickey, Donald a Goofy") with Pat a Mat video ids.
- New `_SLASH_EPISODE_RE` catches `/ E<N> /` with slash required on both sides — a stray "E32" inside an otherwise free-form title won't match. No season number on the wire → default to 1 (SK Torrent's CZ-series uploads use a single continuous episode count).

## Production cleanup (already done)
- Deleted films 37258–37267 (`DELETE FROM films WHERE id BETWEEN 37258 AND 37267` — cascade clears film_actors / film_directors / film_genres).
- NULLed `sktorrent_video_id` + cdn + qualities + added_at on 32188 and 25151.
- Removed 14 video_sources rows for sktorrent external_ids in 60920–60945 with `created_at::date = '2026-05-14'`.
- CF cache purged for the 13 affected URLs.

## Test plan
- [x] `python3 -m py_compile` — clean
- [x] Unit test (inline REPL):
  ```
  'Pat a Mat / E32 / Sekacka / CZ' → is_episode=True season=1 episode=32
  'Euforie / S03E01 / CZ'          → is_episode=True season=3 episode=1
  'Final Frontier E32'             → is_episode=False  (no slash → no match)
  'Some Movie (2022) CZ'           → is_episode=False
  ```
- [ ] Tomorrow's 05:09 UTC auto-import: verify any `/ E\d+ /` titles are routed to the series enricher (will log "no series found" for Pat a Mat until that series exists in DB — separate follow-up).

## Follow-up
Pat a Mat needs to be bootstrapped as a `series` row (no auto-discover for a series that doesn't yet exist in our DB) — will track separately.