### PR TITLE
fix(series): /serialy-online/ landing must filter latest episode by source

### DIFF
--- a/cr-web/src/handlers/series.rs
+++ b/cr-web/src/handlers/series.rs
@@ -881,7 +881,7 @@ async fn fetch_latest_episode_cards(
                 e.id, e.series_id, e.season, e.episode, e.has_subtitles, e.has_dub, e.created_at \
             FROM episodes e \
             JOIN series s ON s.id = e.series_id \
-            WHERE 1=1 {series_filter} \
+            WHERE {EPISODE_HAS_SOURCE_PREDICATE} {series_filter} \
             ORDER BY e.series_id, e.created_at DESC \
          ) \
          SELECT ps.id, \

--- a/cr-web/src/handlers/series.rs
+++ b/cr-web/src/handlers/series.rs
@@ -591,10 +591,14 @@ pub async fn series_list(
         (total, rows, Vec::new())
     } else if include.is_empty() && exclude.is_empty() && year_f.is_none() && audio_langs.is_none()
     {
-        // Default home listing (no filters): latest episode per series
-        let count_row = sqlx::query_as::<_, CountRow>(
-            "SELECT count(DISTINCT e.series_id) as count FROM episodes e",
-        )
+        // Default home listing (no filters): latest episode per series.
+        // The count MUST mirror the predicate used by
+        // `fetch_latest_episode_cards` — otherwise the pagination total
+        // is inflated by TMDB-only stub series that never produce a card.
+        let count_row = sqlx::query_as::<_, CountRow>(&format!(
+            "SELECT count(DISTINCT e.series_id) as count FROM episodes e \
+             WHERE {EPISODE_HAS_SOURCE_PREDICATE}"
+        ))
         .fetch_one(&state.db)
         .await?;
 
@@ -932,8 +936,14 @@ async fn count_filtered_series(
     audio_langs: Option<&[String]>,
     audio_col: &str,
 ) -> WebResult<i64> {
-    let mut where_parts: Vec<String> =
-        vec!["EXISTS (SELECT 1 FROM episodes e WHERE e.series_id = s.id)".to_string()];
+    // Mirrors the `fetch_latest_episode_cards` predicate so the pagination
+    // total matches the cards actually rendered — counting series that
+    // only have TMDB-only stubs (no live video_sources) used to inflate
+    // the count and leave the trailing pages short / empty.
+    let mut where_parts: Vec<String> = vec![format!(
+        "EXISTS (SELECT 1 FROM episodes e WHERE e.series_id = s.id \
+         AND {EPISODE_HAS_SOURCE_PREDICATE})"
+    )];
     let mut bind_idx: i32 = 1;
     if !include_slugs.is_empty() {
         if include_mode_and {


### PR DESCRIPTION
<!-- claude-session: fd55863a-01fd-456b-b70d-ea0440e6400a -->

## Summary
`fetch_latest_episode_cards` DISTINCT-ON-s one episode per series ordered by `e.created_at DESC`. The CTE was missing the `EPISODE_HAS_SOURCE_PREDICATE` filter — so for any series whose episodes were imported in a single batch (sharing a created_at), the "latest" pick effectively became non-deterministic and frequently landed on a TMDB-only stub with no video_source.

Exposed by the Pat a Mat bootstrap (PR #727): all 141 episode rows share `created_at = 2026-05-14 11:09:55` (single transaction). The landing kept surfacing unplayed episodes like `s3e10-zivy-plot` / `s4e19-rogalo` — both 404 on click because the detail handler correctly filters by source.

Fix: gate the CTE on the same EXISTS predicate the detail handler uses. Same change would prevent any TMDB-only stub from appearing regardless of created_at ordering.

## Production verification (already deployed)
Before: `/serialy-online/` page 1 showed "Pat a Mat — Živý plot S03E10" → click → 404
After:
- page 1: no Pat a Mat tile (pushed down by newer auto-imports — correct)
- page 2: `pat-a-mat/s3e04-dlazdice/` (an attached, playable episode)
- Existing landing rows for other series unchanged.

## Test plan
- [x] `cargo check` / `cargo clippy -- -D warnings` / `cargo fmt --check` — clean
- [x] Deploy + CF purge + Playwright on /serialy-online/ — Pat a Mat now shows a playable episode card; clicking opens the player
- [ ] Future: similar predicate gap on `/filmy-online/` (films listing) — worth auditing in a follow-up