### PR TITLE
perf(series): /serialy-online/ from 3.2s to 50ms via LATERAL + new index

### DIFF
--- a/cr-infra/migrations/20260613_073_idx_episodes_series_created.sql
+++ b/cr-infra/migrations/20260613_073_idx_episodes_series_created.sql
@@ -1,0 +1,13 @@
+-- =============================================================================
+-- idx_episodes_series_created — covers the per-series "latest episode" lookup
+-- used by `fetch_latest_episode_cards` (cr-web/src/handlers/series.rs) and the
+-- count-of-listable-series subqueries on `/serialy-online/`.
+--
+-- Without it the planner falls back to a Parallel Seq Scan + sort across all
+-- ~104k episodes for every page load, costing ~3s/request. After the index,
+-- the LATERAL subquery does a single index range read per series — total
+-- listing query drops to ~300 ms.
+-- =============================================================================
+
+CREATE INDEX IF NOT EXISTS idx_episodes_series_created
+    ON episodes (series_id, created_at DESC);

--- a/cr-web/src/handlers/series.rs
+++ b/cr-web/src/handlers/series.rs
@@ -595,10 +595,19 @@ pub async fn series_list(
         // The count MUST mirror the predicate used by
         // `fetch_latest_episode_cards` — otherwise the pagination total
         // is inflated by TMDB-only stub series that never produce a card.
-        let count_row = sqlx::query_as::<_, CountRow>(&format!(
-            "SELECT count(DISTINCT e.series_id) as count FROM episodes e \
-             WHERE {EPISODE_HAS_SOURCE_PREDICATE}"
-        ))
+        //
+        // Scalar-subquery (LIMIT 1) form so the planner uses
+        // `idx_episodes_series_created` for an index range read per
+        // series instead of falling back to a Parallel Seq Scan over
+        // all ~104 k episodes (~1.6 s on prod vs ~200 ms).
+        let count_row = sqlx::query_as::<_, CountRow>(
+            "SELECT count(*) as count FROM series s WHERE \
+                 (SELECT 1 FROM episodes e \
+                    WHERE e.series_id = s.id \
+                      AND EXISTS (SELECT 1 FROM video_sources vs \
+                                  WHERE vs.episode_id = e.id AND vs.is_alive) \
+                  LIMIT 1) = 1",
+        )
         .fetch_one(&state.db)
         .await?;
 
@@ -879,16 +888,14 @@ async fn fetch_latest_episode_cards(
     // ORDER BY was hardcoded DESC, so `?smer=asc` toggled the chip but the
     // grid stayed the same.
     let direction = if desc { "DESC" } else { "ASC" };
+    // LATERAL JOIN drives from series (2.7k rows) and uses
+    // `idx_episodes_series_created` to index-scan the latest sourced
+    // episode per series. Replaces a CTE that DISTINCT-ON-ed over the
+    // entire `episodes` table (~104k rows, ~1.8 s on prod) — the new
+    // shape runs in ~300 ms because each per-series lookup walks the
+    // index and stops at the first sourced episode (median = 1 row).
     let sql = format!(
-        "WITH per_series AS ( \
-            SELECT DISTINCT ON (e.series_id) \
-                e.id, e.series_id, e.season, e.episode, e.has_subtitles, e.has_dub, e.created_at \
-            FROM episodes e \
-            JOIN series s ON s.id = e.series_id \
-            WHERE {EPISODE_HAS_SOURCE_PREDICATE} {series_filter} \
-            ORDER BY e.series_id, e.created_at DESC \
-         ) \
-         SELECT ps.id, \
+        "SELECT latest.id, \
             s.id AS series_id, \
             s.slug AS series_slug, \
             s.title AS series_title, \
@@ -898,12 +905,22 @@ async fn fetch_latest_episode_cards(
             s.imdb_rating AS series_imdb_rating, \
             s.csfd_rating AS series_csfd_rating, \
             s.description AS series_description, \
-            ps.season, ps.episode, ps.has_subtitles, ps.has_dub, ps.created_at, \
-            (SELECT e2.slug FROM episodes e2 WHERE e2.id = ps.id) AS episode_slug, \
-            (SELECT e2.episode_name FROM episodes e2 WHERE e2.id = ps.id) AS episode_name \
-         FROM per_series ps \
-         JOIN series s ON s.id = ps.series_id \
-         ORDER BY ps.created_at {direction} NULLS LAST \
+            latest.season, latest.episode, latest.has_subtitles, \
+            latest.has_dub, latest.created_at, \
+            latest.slug AS episode_slug, \
+            latest.episode_name \
+         FROM series s \
+         JOIN LATERAL ( \
+            SELECT e.id, e.season, e.episode, e.has_subtitles, e.has_dub, \
+                   e.created_at, e.slug, e.episode_name \
+            FROM episodes e \
+            WHERE e.series_id = s.id \
+              AND {EPISODE_HAS_SOURCE_PREDICATE} \
+            ORDER BY e.created_at DESC \
+            LIMIT 1 \
+         ) latest ON true \
+         WHERE 1=1 {series_filter} \
+         ORDER BY latest.created_at {direction} NULLS LAST \
          LIMIT $1 OFFSET $2"
     );
 
@@ -940,9 +957,15 @@ async fn count_filtered_series(
     // total matches the cards actually rendered — counting series that
     // only have TMDB-only stubs (no live video_sources) used to inflate
     // the count and leave the trailing pages short / empty.
+    //
+    // Wrapped as `(SELECT 1 … LIMIT 1) = 1` so the planner uses
+    // `idx_episodes_series_created` for each per-series probe rather
+    // than promoting the EXISTS to a hash-join + Parallel Seq Scan
+    // across all ~104 k episodes.
     let mut where_parts: Vec<String> = vec![format!(
-        "EXISTS (SELECT 1 FROM episodes e WHERE e.series_id = s.id \
-         AND {EPISODE_HAS_SOURCE_PREDICATE})"
+        "(SELECT 1 FROM episodes e \
+            WHERE e.series_id = s.id AND {EPISODE_HAS_SOURCE_PREDICATE} \
+            LIMIT 1) = 1"
     )];
     let mut bind_idx: i32 = 1;
     if !include_slugs.is_empty() {

--- a/cr-web/src/handlers/series.rs
+++ b/cr-web/src/handlers/series.rs
@@ -599,15 +599,15 @@ pub async fn series_list(
         // Scalar-subquery (LIMIT 1) form so the planner uses
         // `idx_episodes_series_created` for an index range read per
         // series instead of falling back to a Parallel Seq Scan over
-        // all ~104 k episodes (~1.6 s on prod vs ~200 ms).
-        let count_row = sqlx::query_as::<_, CountRow>(
+        // all ~104 k episodes (~1.6 s on prod vs ~200 ms). Reuses the
+        // shared `EPISODE_HAS_SOURCE_PREDICATE` so this count can't
+        // drift apart from the listing predicate.
+        let count_row = sqlx::query_as::<_, CountRow>(&format!(
             "SELECT count(*) as count FROM series s WHERE \
                  (SELECT 1 FROM episodes e \
-                    WHERE e.series_id = s.id \
-                      AND EXISTS (SELECT 1 FROM video_sources vs \
-                                  WHERE vs.episode_id = e.id AND vs.is_alive) \
-                  LIMIT 1) = 1",
-        )
+                    WHERE e.series_id = s.id AND {EPISODE_HAS_SOURCE_PREDICATE} \
+                  LIMIT 1) = 1"
+        ))
         .fetch_one(&state.db)
         .await?;
 


### PR DESCRIPTION
<!-- claude-session: fd55863a-01fd-456b-b70d-ea0440e6400a -->

## Summary
Reported: `/serialy-online/?strana=4` and equivalents took ~3 s to first byte (homepage and region pages are sub-100 ms). Two queries shared the bill — both forcing a Parallel Seq Scan + sort across all ~104 k episodes:

1. `fetch_latest_episode_cards` — CTE `DISTINCT ON (series_id) ORDER BY created_at DESC` → ~1.85 s on prod.
2. Default home-listing count `SELECT count(DISTINCT e.series_id) FROM episodes WHERE EPISODE_HAS_SOURCE_PREDICATE` → ~1.65 s.

## Fix
- **Migration 073** adds `idx_episodes_series_created (series_id, created_at DESC)`. `CREATE INDEX IF NOT EXISTS` keeps it idempotent.
- **`fetch_latest_episode_cards`** rewritten as a LATERAL JOIN driven from `series` (~2.8 k rows). Per-series subquery walks the new index, stops at the first sourced episode (median = 1 row). `series_filter` still applies on the outer rows so genre / year / audio pages keep their semantics.
- **Both counts** (home + filtered) switched to scalar-subquery form `(SELECT 1 FROM episodes … LIMIT 1) = 1` so the planner uses the new index per-series instead of promoting EXISTS to a hash-join + Parallel Seq Scan.

## Production verification (already deployed)
TTFB measured via curl from inside the VPS:

|             | before | after  |
|-------------|--------|--------|
| `/serialy-online/`         | 3.23 s | 0.35 s (first hit, JIT warmup) |
| `/serialy-online/?strana=4`  | 3.27 s | 0.05 s |
| `/serialy-online/?strana=10` | 3.27 s | 0.05 s |
| `/serialy-online/?strana=50` | 3.52 s | 0.05 s |

Pagination count stayed at 2748 (matches the predicate-filtered value).

## Test plan
- [x] `cargo check` / `cargo clippy -- -D warnings` / `cargo fmt --check` — clean
- [x] Migration re-embedded with `cargo clean` so the SHA-384 lands fresh
- [x] Playwright /serialy-online/?strana=4 — 38 cards, count "z 2748 seriálů online"
- [ ] Filtered listing (e.g. /serialy-online/animovany/?strana=2) — same speedup applies; only spot-checked, full sweep open as follow-up
- [ ] /filmy-online/ has a separate code path (count uses films + simple WHERE, not the episodes/video_sources join) — separately profiled at ~1 s and not addressed here