### PR TITLE
perf(films): index (added_at DESC, id DESC) — listing query 119ms → 13ms

### DIFF
--- a/cr-infra/migrations/20260614_074_idx_films_added_at.sql
+++ b/cr-infra/migrations/20260614_074_idx_films_added_at.sql
@@ -1,0 +1,19 @@
+-- =============================================================================
+-- idx_films_added_at_id — covers the default `/filmy-online/` listing sort.
+--
+-- The "podle přidání" (default) sort is `ORDER BY f.added_at DESC NULLS LAST,
+-- f.id DESC` and the page also gates on `EXISTS (video_sources is_alive)`.
+-- Without this index the planner Parallel-Seq-Scans all ~28 k films + sorts
+-- by added_at, costing ~120 ms for the SELECT alone. With the index the
+-- planner does an indexed range scan in added_at order and pairs each
+-- candidate with the (fast) `idx_vs_film_alive` lookup — total query time
+-- drops to ~2 ms.
+--
+-- The `id DESC` second column is a tiebreaker for films with identical
+-- added_at (which is common after a bulk import). Keeping it in the index
+-- lets the index ordering match `ORDER BY` exactly so no extra sort is
+-- needed.
+-- =============================================================================
+
+CREATE INDEX IF NOT EXISTS idx_films_added_at_id
+    ON films (added_at DESC NULLS LAST, id DESC);

--- a/cr-infra/migrations/20260614_074_idx_films_added_at.sql
+++ b/cr-infra/migrations/20260614_074_idx_films_added_at.sql
@@ -13,7 +13,16 @@
 -- added_at (which is common after a bulk import). Keeping it in the index
 -- lets the index ordering match `ORDER BY` exactly so no extra sort is
 -- needed.
+--
+-- `films.added_at` was historically a prod-only manual ALTER (no committed
+-- migration created it). The `ADD COLUMN IF NOT EXISTS` here is a no-op on
+-- prod (column already exists) but lets CI/staging/fresh dev DBs apply
+-- this migration cleanly. After this edit lands, prod's `_sqlx_migrations`
+-- row for version 20260614 needs its SHA-384 checksum updated to the new
+-- file content (see CLAUDE.md "SQLx Migration Checksum Rules").
 -- =============================================================================
+
+ALTER TABLE films ADD COLUMN IF NOT EXISTS added_at TIMESTAMP WITH TIME ZONE;
 
 CREATE INDEX IF NOT EXISTS idx_films_added_at_id
     ON films (added_at DESC NULLS LAST, id DESC);


### PR DESCRIPTION
<!-- claude-session: fd55863a-01fd-456b-b70d-ea0440e6400a -->

## Summary
Follow-up to PR #729 (`/serialy-online/` 3.2 s → 50 ms). The films listing was less dramatic but still leaky — `/filmy-online/?strana=50` clocked 250–450 ms because the default `ORDER BY f.added_at DESC NULLS LAST, f.id DESC` query had no matching index and the planner Parallel-Seq-Scanned all ~28 k films + sorted in memory before applying LIMIT/OFFSET.

Migration 074 adds `idx_films_added_at_id (added_at DESC NULLS LAST, id DESC)`. The planner now does an indexed range scan in added_at order and pairs each candidate with the existing `idx_vs_film_alive` lookup, stopping once LIMIT is satisfied. The other sort modes (`razeni=imdb` / `tmdb` / `rok`) already had dedicated indexes — only the default `pridano` was uncovered.

## Production measurements

DB queries (EXPLAIN ANALYZE):

|              | before | after  |
|--------------|--------|--------|
| page 1 SELECT      | ~120 ms (Parallel Seq Scan + sort) | 0.3 ms |
| page 50 SELECT     | ~120 ms              | 13 ms |
| akční / strana=5   | ~80 ms               | 65 ms (genre IN-list dominates) |
| count(*) (unfiltered) | ~60 ms — unchanged (no index can help count) |

End-to-end TTFB (curl inside the VPS, post-deploy):
- `/filmy-online/` 0.22 s
- `/filmy-online/?strana=4` 0.09 s
- `/filmy-online/?strana=50` 0.17 s (steady-state; first hit 0.4 s due to JIT)
- `/filmy-online/akcni/?strana=5` 0.05 s

## Test plan
- [x] `cargo check` / `cargo clippy -- -D warnings` / `cargo fmt --check` — clean (Rust unchanged)
- [x] Migration re-embedded with `cargo clean` so SHA-384 lands fresh
- [x] curl measurements on prod — see table above
- [ ] Long-tail: count query at ~60 ms is the next bottleneck. Hard to fix without materializing — separate issue if it becomes pressing