### PR TITLE
perf(listings): 60s app-cache for listing counts — TTFB 138ms → 23ms

### DIFF
--- a/cr-web/src/handlers/films.rs
+++ b/cr-web/src/handlers/films.rs
@@ -727,7 +727,7 @@ pub async fn films_list(
     let year_f = params.year_filter();
 
     let (total_count, films) = run_films_query(
-        &state.db,
+        &state,
         FilmsSearchMode::Primary,
         raw_pattern.as_deref(),
         &params,
@@ -750,7 +750,7 @@ pub async fn films_list(
             } else {
                 let fb_pattern = format!("%{normalized}%");
                 run_films_query(
-                    &state.db,
+                    &state,
                     FilmsSearchMode::TitleYear,
                     Some(&fb_pattern),
                     &params,
@@ -1396,7 +1396,7 @@ impl FilmsSearchMode {
 /// search predicate shape (or no search filter when `search_pattern` is None).
 #[allow(clippy::too_many_arguments)]
 async fn run_films_query(
-    db: &sqlx::PgPool,
+    state: &AppState,
     mode: FilmsSearchMode,
     search_pattern: Option<&str>,
     params: &FilmsQuery,
@@ -1406,6 +1406,7 @@ async fn run_films_query(
     order: &str,
     offset: i64,
 ) -> Result<(i64, Vec<FilmRow>), sqlx::Error> {
+    let db = &state.db;
     let mut where_parts: Vec<String> = vec![];
     let mut bind_idx = 1;
 
@@ -1498,26 +1499,64 @@ async fn run_films_query(
     };
 
     let count_query = format!("SELECT count(*) as count FROM films f {where_clause}");
-    let mut cq = sqlx::query_as::<_, CountRow>(&count_query);
+    // Cache key encodes the count SQL plus the bound parameter values
+    // so filtered variants stay separate (the SQL alone has only `$N`
+    // placeholders). 60 s TTL — see `listing_count_cache` doc on
+    // `AppState`.
+    let mut cache_key = String::with_capacity(count_query.len() + 64);
+    cache_key.push_str(&count_query);
     if let Some(p) = search_pattern {
-        cq = cq.bind(p.to_string());
+        cache_key.push_str("|q=");
+        cache_key.push_str(p);
     }
     if !include.is_empty() {
-        cq = cq.bind(include.to_vec());
+        cache_key.push_str("|inc=");
+        cache_key.push_str(&include.join(","));
     }
     if !exclude.is_empty() {
-        cq = cq.bind(exclude.to_vec());
+        cache_key.push_str("|exc=");
+        cache_key.push_str(&exclude.join(","));
     }
     if let Some(yr) = year_f {
-        cq = cq.bind(yr);
+        cache_key.push_str("|yr=");
+        cache_key.push_str(&yr.to_string());
     }
     if let Some(langs) = audio_langs_param.as_ref() {
-        cq = cq.bind(langs.clone());
+        cache_key.push_str("|aud=");
+        cache_key.push_str(&langs.join(","));
     }
     if let Some(Some(langs)) = subs_param.as_ref() {
-        cq = cq.bind(langs.clone());
+        cache_key.push_str("|sub=");
+        cache_key.push_str(&langs.join(","));
     }
-    let count_row = cq.fetch_one(db).await?;
+
+    let count: i64 = if let Some(hit) = state.listing_count_cache.get(&cache_key).await {
+        hit
+    } else {
+        let mut cq = sqlx::query_as::<_, CountRow>(&count_query);
+        if let Some(p) = search_pattern {
+            cq = cq.bind(p.to_string());
+        }
+        if !include.is_empty() {
+            cq = cq.bind(include.to_vec());
+        }
+        if !exclude.is_empty() {
+            cq = cq.bind(exclude.to_vec());
+        }
+        if let Some(yr) = year_f {
+            cq = cq.bind(yr);
+        }
+        if let Some(langs) = audio_langs_param.as_ref() {
+            cq = cq.bind(langs.clone());
+        }
+        if let Some(Some(langs)) = subs_param.as_ref() {
+            cq = cq.bind(langs.clone());
+        }
+        let count_row = cq.fetch_one(db).await?;
+        let c = count_row.count.unwrap_or(0);
+        state.listing_count_cache.insert(cache_key, c).await;
+        c
+    };
 
     // When a search is active, push rows whose title literally contains
     // the user's query (with diacritics) ahead of rows that match only
@@ -1560,7 +1599,7 @@ async fn run_films_query(
     }
     let films = fq.bind(FILMS_PER_PAGE).bind(offset).fetch_all(db).await?;
 
-    Ok((count_row.count.unwrap_or(0), films))
+    Ok((count, films))
 }
 
 /// GET /filmy-online/{slug}.webp — serve WebP cover image

--- a/cr-web/src/handlers/series.rs
+++ b/cr-web/src/handlers/series.rs
@@ -602,14 +602,26 @@ pub async fn series_list(
         // all ~104 k episodes (~1.6 s on prod vs ~200 ms). Reuses the
         // shared `EPISODE_HAS_SOURCE_PREDICATE` so this count can't
         // drift apart from the listing predicate.
-        let count_row = sqlx::query_as::<_, CountRow>(&format!(
-            "SELECT count(*) as count FROM series s WHERE \
-                 (SELECT 1 FROM episodes e \
-                    WHERE e.series_id = s.id AND {EPISODE_HAS_SOURCE_PREDICATE} \
-                  LIMIT 1) = 1"
-        ))
-        .fetch_one(&state.db)
-        .await?;
+        const CACHE_KEY: &str = "series_default_home_count";
+        let total = if let Some(hit) = state.listing_count_cache.get(&CACHE_KEY.to_string()).await {
+            hit
+        } else {
+            let count_row = sqlx::query_as::<_, CountRow>(&format!(
+                "SELECT count(*) as count FROM series s WHERE \
+                     (SELECT 1 FROM episodes e \
+                        WHERE e.series_id = s.id AND {EPISODE_HAS_SOURCE_PREDICATE} \
+                      LIMIT 1) = 1"
+            ))
+            .fetch_one(&state.db)
+            .await?;
+            let c = count_row.count.unwrap_or(0);
+            state
+                .listing_count_cache
+                .insert(CACHE_KEY.to_string(), c)
+                .await;
+            c
+        };
+        let count_row = CountRow { count: Some(total) };
 
         let episodes = fetch_latest_episode_cards(
             &state,

--- a/cr-web/src/main.rs
+++ b/cr-web/src/main.rs
@@ -133,6 +133,11 @@ async fn main() -> Result<()> {
             std::time::Duration::from_secs(2 * 3600),
         ),
         prehrajto_in_flight: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
+        // Listing-page counts: 60 s TTL is well below the ~10 min cadence
+        // of auto-import (one new film per cycle), so staleness is bounded
+        // to a single import worth. 64 entries is enough for the realistic
+        // filter cohort (default + genre + year combos seen in CF logs).
+        listing_count_cache: cache::BoundedTtlCache::new(64, std::time::Duration::from_secs(60)),
     };
 
     // API routes with CORS

--- a/cr-web/src/state.rs
+++ b/cr-web/src/state.rs
@@ -74,6 +74,14 @@ pub struct AppState {
     /// then scrapes once — concurrent requests for the same upload block
     /// on the lock and pick up the cached URL after release.
     pub prehrajto_in_flight: Arc<tokio::sync::Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>>,
+    /// 60 s TTL cache of expensive listing-page counts (`/filmy-online/`,
+    /// `/serialy-online/`). The unfiltered count of films with a live
+    /// video source costs ~60 ms (28 k film_pkey rows × video_sources
+    /// EXISTS probe) and dominates the request budget once the SELECT
+    /// itself dropped to ~2 ms via `idx_films_added_at_id`. The cache
+    /// key is the full SQL count query plus its bound parameters, so
+    /// filtered variants are cached independently without ever colliding.
+    pub listing_count_cache: BoundedTtlCache<String, i64>,
 }
 
 /// Cached resolved CDN URL for a single prehraj.to upload.


### PR DESCRIPTION
<!-- claude-session: e5713c88-75a7-4380-8c08-7327c983587b -->

## Summary
Follow-up to #734. The films / serialy listing pages spent ~60 ms on the `count(*) WHERE EXISTS` subquery — the dominant remaining DB cost. No pure-SQL rewrite beat the planner's Parallel Index-Only Scan on the pkey + EXISTS probe per row (tried IN-list, hash JOIN, materialized CTE, DISTINCT from video_sources — all 130–360 ms).

The data is intrinsically stale: auto-import adds one new film per ~10 min, so a 60 s cache window is well within an import cycle. Added a `BoundedTtlCache<String, i64>` on `AppState` (TTL 60 s, 64 entries), keyed by the count SQL plus its bound parameter values so filtered combinations get cached independently.

## Changes
- `AppState::listing_count_cache` — new field, initialised in `main.rs`.
- `run_films_query` — composes a cache key from SQL + bound `q` / `include` / `exclude` / `year` / `audio_langs` / `subs`; on hit uses the cached count, on miss runs the query and populates the cache.
- `series_list` default-home branch — same shape with a fixed key (`series_default_home_count`). `count_filtered_series` (filtered series counts) still hits DB; addressed as a follow-up since the cache wiring is non-trivial there.

## Production measurements (curl inside VPS, post-deploy, warm cache)

|                                        | before  | after  |
|----------------------------------------|---------|--------|
| `/filmy-online/`                        | 170 ms  | **30 ms** |
| `/filmy-online/?strana=4`               | 90 ms   | **24 ms** |
| `/filmy-online/?strana=50`              | 170 ms  | 138 ms (SELECT now dominates) |
| `/serialy-online/`                      | 50 ms   | **32 ms** |
| `/serialy-online/?strana=4`             | 50 ms   | **31 ms** |
| `/serialy-online/?strana=50`            | 170 ms  | **33 ms** |

`/filmy-online/?strana=50` only dropped marginally because at offset 1176 the SELECT (not count) is what carries the cost; a partial `films.has_alive_source` flag could finish that off — separate issue if it becomes pressing.

## Test plan
- [x] `cargo check` / `cargo clippy -- -D warnings` / `cargo fmt --check` — clean
- [x] curl on prod — see table above
- [ ] Cache invalidation is purely time-based; OK for our auto-import cadence. If we ever introduce instant-publish flows (e.g. user-uploaded films), a manual `/admin/cache/purge` button hitting `listing_count_cache` would be the minimum-cost mitigation