### PR TITLE
feat(auto-import): opportunistic csfd_id resolution on insert (#730)

### DIFF
--- a/scripts/auto_import/csfd_lookup.py
+++ b/scripts/auto_import/csfd_lookup.py
@@ -104,7 +104,7 @@ def _build_query(*, imdb_id: str | None, tmdb_id: int | None,
                  tmdb_prop: str | None) -> str | None:
     if imdb_id:
         return f"""
-SELECT ?csfd ?labelCs ?labelEn ?p1476
+SELECT ?item ?csfd ?labelCs ?labelEn ?p1476
        (GROUP_CONCAT(DISTINCT ?altCs; separator="|") AS ?altCsList)
        (GROUP_CONCAT(DISTINCT ?altEn; separator="|") AS ?altEnList)
 WHERE {{
@@ -116,11 +116,11 @@ WHERE {{
   OPTIONAL {{ ?item skos:altLabel ?altCs . FILTER(LANG(?altCs) = "cs") }}
   OPTIONAL {{ ?item skos:altLabel ?altEn . FILTER(LANG(?altEn) = "en") }}
 }}
-GROUP BY ?csfd ?labelCs ?labelEn ?p1476
+GROUP BY ?item ?csfd ?labelCs ?labelEn ?p1476
 """
     if tmdb_id and tmdb_prop:
         return f"""
-SELECT ?csfd ?labelCs ?labelEn ?p1476
+SELECT ?item ?csfd ?labelCs ?labelEn ?p1476
        (GROUP_CONCAT(DISTINCT ?altCs; separator="|") AS ?altCsList)
        (GROUP_CONCAT(DISTINCT ?altEn; separator="|") AS ?altEnList)
 WHERE {{
@@ -132,18 +132,29 @@ WHERE {{
   OPTIONAL {{ ?item skos:altLabel ?altCs . FILTER(LANG(?altCs) = "cs") }}
   OPTIONAL {{ ?item skos:altLabel ?altEn . FILTER(LANG(?altEn) = "en") }}
 }}
-GROUP BY ?csfd ?labelCs ?labelEn ?p1476
+GROUP BY ?item ?csfd ?labelCs ?labelEn ?p1476
 """
     return None
 
 
+# Tri-state outcome of a single Wikidata lookup. The caller distinguishes
+# `miss` (no Wikidata mapping → try fallback path) from `vetoed` (Wikidata
+# returned a candidate that failed sanity / duplicate checks → do NOT try
+# the fallback, the bulk resolver owns this row). Conflating the two would
+# let the TMDB fallback overwrite a row that the IMDb pass explicitly
+# rejected on label mismatch.
+_MISS = "miss"
+_VETOED = "vetoed"
+
+
 def _query_csfd(*, imdb_id: str | None, tmdb_id: int | None,
-                tmdb_prop: str | None, title: str | None) -> int | None:
-    """Run one SPARQL query and return a sane csfd_id, or None on miss /
-    sanity rejection / any error."""
+                tmdb_prop: str | None, title: str | None) -> int | str:
+    """Run one SPARQL query. Returns a csfd_id (int) on success, or one
+    of the sentinels `_MISS` / `_VETOED`. The caller decides whether to
+    fall through to a second path based on which sentinel comes back."""
     query = _build_query(imdb_id=imdb_id, tmdb_id=tmdb_id, tmdb_prop=tmdb_prop)
     if not query:
-        return None
+        return _MISS
     try:
         r = _session().post(
             SPARQL_ENDPOINT,
@@ -154,32 +165,41 @@ def _query_csfd(*, imdb_id: str | None, tmdb_id: int | None,
     except requests.RequestException as e:
         log.debug("csfd lookup network error for imdb=%s tmdb=%s: %s",
                   imdb_id, tmdb_id, e)
-        return None
+        return _MISS
     if r.status_code != 200:
         log.debug("csfd lookup HTTP %s for imdb=%s tmdb=%s",
                   r.status_code, imdb_id, tmdb_id)
-        return None
+        return _MISS
     try:
         bindings = r.json().get("results", {}).get("bindings", [])
     except ValueError:
-        return None
+        return _MISS
     if not bindings:
-        return None
-    if len(bindings) > 1:
-        # Duplicate Wikidata entities for the same external ID — skip
-        # silently; the bulk resolver will log this to the review queue
-        # on its next sweep.
+        return _MISS
+    # Detect duplicate Wikidata entities by counting distinct `?item` URIs.
+    # GROUP_CONCAT on labels can otherwise collapse two entities into one
+    # binding row when their selected scalar fields happen to match — same
+    # pre-#732 bug the bulk resolver had.
+    distinct_items = {b.get("item", {}).get("value") for b in bindings
+                      if b.get("item", {}).get("value")}
+    if len(distinct_items) > 1 or len(bindings) > 1:
+        # Skip silently and VETO — the bulk resolver logs this to the
+        # review queue on its next sweep and the fallback path must not
+        # paper over the ambiguity by writing a different ID.
         log.info("csfd lookup ambiguous (%d Wikidata entities) for "
-                 "imdb=%s tmdb=%s", len(bindings), imdb_id, tmdb_id)
-        return None
+                 "imdb=%s tmdb=%s", len(distinct_items) or len(bindings),
+                 imdb_id, tmdb_id)
+        return _VETOED
     row = bindings[0]
     csfd_raw = row.get("csfd", {}).get("value")
     if not csfd_raw:
-        return None
+        # Wikidata knows the item but it has no P2529 yet — that's a
+        # plain miss, the fallback path is still legitimate.
+        return _MISS
     try:
         csfd_id = int(csfd_raw)
     except ValueError:
-        return None
+        return _VETOED
     if not _labels_agree(
         row.get("labelCs", {}).get("value"),
         row.get("labelEn", {}).get("value"),
@@ -192,7 +212,7 @@ def _query_csfd(*, imdb_id: str | None, tmdb_id: int | None,
                  "labelCs=%r — skipping, will be flagged on weekly resolver",
                  imdb_id, tmdb_id, title,
                  row.get("labelCs", {}).get("value"))
-        return None
+        return _VETOED
     return csfd_id
 
 
@@ -218,21 +238,47 @@ def lookup_and_write_csfd(
     if not (imdb_id or tmdb_id):
         return None
     try:
-        csfd_id = _query_csfd(
+        # Cheap DB-side guard BEFORE the network call. The existing-row
+        # callers (enricher's "updated_film", ensure_series's lookup
+        # branches) rely on this helper to no-op when csfd_id is already
+        # populated. After the bulk backfill that's the common case, so
+        # skipping the SPARQL request when the column is non-NULL saves
+        # ~150 ms per row AND avoids burning Wikidata quota on rows that
+        # cannot be updated.
+        with conn.cursor() as cur:
+            cur.execute(
+                f"SELECT csfd_id FROM {table} WHERE id = %s", (row_id,))
+            row = cur.fetchone()
+            if row is None or row[0] is not None:
+                return None
+
+        # IMDb path is the strict authority — a `_VETOED` here (label
+        # mismatch / duplicate Wikidata entity) means we must NOT fall
+        # back to TMDB, because the bulk resolver would mark the row as
+        # resolved/rejected and the TMDB path could otherwise paper over
+        # a real disagreement by writing a different ID.
+        result = _query_csfd(
             imdb_id=imdb_id,
             tmdb_id=tmdb_id,
             tmdb_prop=_TMDB_PROP[table],
             title=title,
         )
-        # Fall back to TMDB path only if IMDb path missed AND the table
-        # / id permits it. The bulk resolver does the same two-pass.
-        if csfd_id is None and imdb_id and tmdb_id:
-            csfd_id = _query_csfd(
+        if result == _VETOED:
+            return None
+        csfd_id: int | None = None
+        if isinstance(result, int):
+            csfd_id = result
+        elif result == _MISS and imdb_id and tmdb_id:
+            # Plain miss → try TMDB path. Same two-pass as the bulk
+            # resolver (`scripts/resolve-csfd-via-wikidata.py`).
+            result = _query_csfd(
                 imdb_id=None,
                 tmdb_id=tmdb_id,
                 tmdb_prop=_TMDB_PROP[table],
                 title=title,
             )
+            if isinstance(result, int):
+                csfd_id = result
         if csfd_id is None:
             return None
         with conn.cursor() as cur:

--- a/scripts/auto_import/csfd_lookup.py
+++ b/scripts/auto_import/csfd_lookup.py
@@ -1,0 +1,262 @@
+"""Single-row Wikidata SPARQL lookup for `csfd_id` (epic #730).
+
+The bulk resolver (scripts/resolve-csfd-via-wikidata.py) runs weekly via
+systemd timer and clears the backlog. This module is the *immediate*
+path used during auto-import: after a new film/series/tv_show row is
+INSERTed, the enricher calls `lookup_and_write_csfd` with the freshly
+created row's (imdb_id, tmdb_id, title) and we try to fill `csfd_id`
+right away, so the row shows the ČSFD badge on its first appearance
+in the UI rather than waiting up to a week for the next batch run.
+
+The helper is intentionally tolerant: any Wikidata error, network
+timeout, sanity-check mismatch, or duplicate entity returns silently
+without raising. The weekly resolver will pick the row up on its next
+sweep and either resolve it or log it to `csfd_id_resolution_review`,
+so we never block the import path on Wikidata availability.
+
+Single-row queries are cheap for Wikidata (~150 ms each) and the
+auto-import only adds a few dozen new rows per day, so we don't bother
+with batching here — that's the bulk resolver's job.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import threading
+import unicodedata
+
+import psycopg2
+import requests
+
+log = logging.getLogger(__name__)
+
+SPARQL_ENDPOINT = "https://query.wikidata.org/sparql"
+SPARQL_TIMEOUT_SECONDS = 15
+
+USER_AGENT = os.environ.get(
+    "CR_CSFD_RESOLVER_USER_AGENT",
+    "cr-csfd-resolver/0.1 (https://ceskarepublika.wiki; "
+    "noreply@ceskarepublika.wiki)",
+)
+
+# Maps cr table → Wikidata TMDB property. Films use P4947 (movie ID),
+# series + tv_shows both use P4983 (TV ID) — same as the bulk resolver.
+_TMDB_PROP = {
+    "films": "P4947",
+    "series": "P4983",
+    "tv_shows": "P4983",
+}
+
+# Per-thread session so concurrent enrichers don't share a connection.
+# auto-import is single-threaded today but the prehraj.to discover path
+# uses a per-cluster thread pool, so play it safe.
+_tls = threading.local()
+
+
+def _session() -> requests.Session:
+    s = getattr(_tls, "session", None)
+    if s is None:
+        s = requests.Session()
+        s.headers["User-Agent"] = USER_AGENT
+        _tls.session = s
+    return s
+
+
+def _normalise(s: str | None) -> str:
+    if not s:
+        return ""
+    decomposed = unicodedata.normalize("NFKD", s.lower())
+    no_diacritics = "".join(c for c in decomposed if not unicodedata.combining(c))
+    return re.sub(r"[^a-z0-9]+", "", no_diacritics)
+
+
+def _one_match(label: str | None, n_title: str) -> bool:
+    if not label:
+        return False
+    n_label = _normalise(label)
+    if len(n_label) < 3:
+        return False
+    return n_label == n_title or n_label in n_title or n_title in n_label
+
+
+def _labels_agree(label_cs: str | None,
+                  label_en: str | None,
+                  p1476: str | None,
+                  alt_cs: list[str],
+                  alt_en: list[str],
+                  title: str | None) -> bool:
+    """Same veto/positive logic as the bulk resolver: labelCs is the
+    only signal that can VETO; everything else is positive-only."""
+    n_title = _normalise(title)
+    if len(n_title) < 3:
+        return True
+    if label_cs and not _one_match(label_cs, n_title):
+        return False
+    for candidate in (label_cs, label_en, p1476, *alt_cs, *alt_en):
+        if _one_match(candidate, n_title):
+            return True
+    return not label_cs
+
+
+def _build_query(*, imdb_id: str | None, tmdb_id: int | None,
+                 tmdb_prop: str | None) -> str | None:
+    if imdb_id:
+        return f"""
+SELECT ?csfd ?labelCs ?labelEn ?p1476
+       (GROUP_CONCAT(DISTINCT ?altCs; separator="|") AS ?altCsList)
+       (GROUP_CONCAT(DISTINCT ?altEn; separator="|") AS ?altEnList)
+WHERE {{
+  ?item wdt:P345 "{imdb_id}" .
+  OPTIONAL {{ ?item wdt:P2529 ?csfd . }}
+  OPTIONAL {{ ?item rdfs:label ?labelCs . FILTER(LANG(?labelCs) = "cs") }}
+  OPTIONAL {{ ?item rdfs:label ?labelEn . FILTER(LANG(?labelEn) = "en") }}
+  OPTIONAL {{ ?item wdt:P1476 ?p1476 . }}
+  OPTIONAL {{ ?item skos:altLabel ?altCs . FILTER(LANG(?altCs) = "cs") }}
+  OPTIONAL {{ ?item skos:altLabel ?altEn . FILTER(LANG(?altEn) = "en") }}
+}}
+GROUP BY ?csfd ?labelCs ?labelEn ?p1476
+"""
+    if tmdb_id and tmdb_prop:
+        return f"""
+SELECT ?csfd ?labelCs ?labelEn ?p1476
+       (GROUP_CONCAT(DISTINCT ?altCs; separator="|") AS ?altCsList)
+       (GROUP_CONCAT(DISTINCT ?altEn; separator="|") AS ?altEnList)
+WHERE {{
+  ?item wdt:{tmdb_prop} "{tmdb_id}" .
+  OPTIONAL {{ ?item wdt:P2529 ?csfd . }}
+  OPTIONAL {{ ?item rdfs:label ?labelCs . FILTER(LANG(?labelCs) = "cs") }}
+  OPTIONAL {{ ?item rdfs:label ?labelEn . FILTER(LANG(?labelEn) = "en") }}
+  OPTIONAL {{ ?item wdt:P1476 ?p1476 . }}
+  OPTIONAL {{ ?item skos:altLabel ?altCs . FILTER(LANG(?altCs) = "cs") }}
+  OPTIONAL {{ ?item skos:altLabel ?altEn . FILTER(LANG(?altEn) = "en") }}
+}}
+GROUP BY ?csfd ?labelCs ?labelEn ?p1476
+"""
+    return None
+
+
+def _query_csfd(*, imdb_id: str | None, tmdb_id: int | None,
+                tmdb_prop: str | None, title: str | None) -> int | None:
+    """Run one SPARQL query and return a sane csfd_id, or None on miss /
+    sanity rejection / any error."""
+    query = _build_query(imdb_id=imdb_id, tmdb_id=tmdb_id, tmdb_prop=tmdb_prop)
+    if not query:
+        return None
+    try:
+        r = _session().post(
+            SPARQL_ENDPOINT,
+            data={"query": query, "format": "json"},
+            headers={"Accept": "application/sparql-results+json"},
+            timeout=SPARQL_TIMEOUT_SECONDS,
+        )
+    except requests.RequestException as e:
+        log.debug("csfd lookup network error for imdb=%s tmdb=%s: %s",
+                  imdb_id, tmdb_id, e)
+        return None
+    if r.status_code != 200:
+        log.debug("csfd lookup HTTP %s for imdb=%s tmdb=%s",
+                  r.status_code, imdb_id, tmdb_id)
+        return None
+    try:
+        bindings = r.json().get("results", {}).get("bindings", [])
+    except ValueError:
+        return None
+    if not bindings:
+        return None
+    if len(bindings) > 1:
+        # Duplicate Wikidata entities for the same external ID — skip
+        # silently; the bulk resolver will log this to the review queue
+        # on its next sweep.
+        log.info("csfd lookup ambiguous (%d Wikidata entities) for "
+                 "imdb=%s tmdb=%s", len(bindings), imdb_id, tmdb_id)
+        return None
+    row = bindings[0]
+    csfd_raw = row.get("csfd", {}).get("value")
+    if not csfd_raw:
+        return None
+    try:
+        csfd_id = int(csfd_raw)
+    except ValueError:
+        return None
+    if not _labels_agree(
+        row.get("labelCs", {}).get("value"),
+        row.get("labelEn", {}).get("value"),
+        row.get("p1476", {}).get("value"),
+        [p for p in (row.get("altCsList", {}).get("value") or "").split("|") if p],
+        [p for p in (row.get("altEnList", {}).get("value") or "").split("|") if p],
+        title,
+    ):
+        log.info("csfd lookup label-mismatch for imdb=%s tmdb=%s title=%r "
+                 "labelCs=%r — skipping, will be flagged on weekly resolver",
+                 imdb_id, tmdb_id, title,
+                 row.get("labelCs", {}).get("value"))
+        return None
+    return csfd_id
+
+
+def lookup_and_write_csfd(
+    conn: psycopg2.extensions.connection,
+    *,
+    table: str,
+    row_id: int,
+    imdb_id: str | None,
+    tmdb_id: int | None,
+    title: str | None,
+) -> int | None:
+    """Resolve `csfd_id` via Wikidata for a single freshly-inserted row
+    and UPDATE it. Never raises — Wikidata being slow / down / wrong
+    must not break the import path. Returns the written csfd_id, or
+    None if nothing was written.
+
+    Idempotent: the UPDATE filters on `csfd_id IS NULL`, so calling
+    this after a manual fix is a no-op."""
+    if table not in _TMDB_PROP:
+        log.warning("lookup_and_write_csfd: unsupported table %r", table)
+        return None
+    if not (imdb_id or tmdb_id):
+        return None
+    try:
+        csfd_id = _query_csfd(
+            imdb_id=imdb_id,
+            tmdb_id=tmdb_id,
+            tmdb_prop=_TMDB_PROP[table],
+            title=title,
+        )
+        # Fall back to TMDB path only if IMDb path missed AND the table
+        # / id permits it. The bulk resolver does the same two-pass.
+        if csfd_id is None and imdb_id and tmdb_id:
+            csfd_id = _query_csfd(
+                imdb_id=None,
+                tmdb_id=tmdb_id,
+                tmdb_prop=_TMDB_PROP[table],
+                title=title,
+            )
+        if csfd_id is None:
+            return None
+        with conn.cursor() as cur:
+            # `csfd_id IS NULL` guards against double-writes if the row
+            # was filled by the weekly resolver between INSERT and now.
+            # Sibling-collision check uses the same NOT EXISTS shape as
+            # the bulk resolver — a different row already owning that
+            # csfd_id means the proposal is suspicious; leave it for
+            # manual review.
+            cur.execute(
+                f"UPDATE {table} SET csfd_id = %s "
+                f"WHERE id = %s AND csfd_id IS NULL "
+                f"  AND NOT EXISTS (SELECT 1 FROM {table} t2 "
+                f"                  WHERE t2.csfd_id = %s AND t2.id <> %s)",
+                (csfd_id, row_id, csfd_id, row_id),
+            )
+            if cur.rowcount:
+                log.info("csfd lookup wrote csfd_id=%d for %s.id=%d "
+                         "(imdb=%s tmdb=%s)",
+                         csfd_id, table, row_id, imdb_id, tmdb_id)
+                return csfd_id
+        return None
+    except Exception as e:  # noqa: BLE001 — must never bubble to import path
+        log.warning("csfd lookup unexpected error for %s.id=%d "
+                    "imdb=%s tmdb=%s: %s",
+                    table, row_id, imdb_id, tmdb_id, e)
+        return None

--- a/scripts/auto_import/enricher.py
+++ b/scripts/auto_import/enricher.py
@@ -19,6 +19,7 @@ from pathlib import Path
 import psycopg2
 
 from scripts.auto_import.cover_downloader import download_cover, download_sktorrent_thumb
+from scripts.auto_import.csfd_lookup import lookup_and_write_csfd
 from scripts.auto_import.gemma_writer import generate_unique_cs
 from scripts.auto_import.tmdb_resolver import MovieResolution
 from scripts.video_sources_helper import (
@@ -193,6 +194,15 @@ def upsert_film(
             has_dub=has_dub,
             has_subtitles=has_subtitles,
         )
+        # Opportunistic csfd_id fill via Wikidata (#730). Cheap (~150 ms)
+        # single-row lookup; never raises — see scripts/auto_import/csfd_lookup.py.
+        # Skipped silently if the existing row already has csfd_id.
+        lookup_and_write_csfd(
+            conn,
+            table="films", row_id=film_id,
+            imdb_id=movie.imdb_id, tmdb_id=movie.tmdb_id,
+            title=movie.title_cs or movie.title_en or movie.original_title,
+        )
         log.info("upserted SKT into existing film %d (imdb=%s)", film_id, movie.imdb_id)
         return "updated_film", film_id
 
@@ -282,5 +292,14 @@ def upsert_film(
                 (film_id, slug_to_id[slug]),
             )
 
+    # Opportunistic csfd_id fill via Wikidata (#730). Runs after INSERT
+    # so the row exists; never raises. Bulk resolver picks up anything
+    # that misses (Wikidata down, label mismatch, etc.) on the weekly tick.
+    lookup_and_write_csfd(
+        conn,
+        table="films", row_id=film_id,
+        imdb_id=movie.imdb_id, tmdb_id=movie.tmdb_id,
+        title=title_cs,
+    )
     log.info("added film %d (imdb=%s, slug=%s)", film_id, movie.imdb_id, slug)
     return "added_film", film_id

--- a/scripts/auto_import/series_enricher.py
+++ b/scripts/auto_import/series_enricher.py
@@ -25,6 +25,7 @@ from pathlib import Path
 import psycopg2
 
 from scripts.auto_import.cover_downloader import download_cover
+from scripts.auto_import.csfd_lookup import lookup_and_write_csfd
 from scripts.auto_import.gemma_writer import generate_unique_cs
 from scripts.auto_import.tmdb_resolver import (
     EpisodeResolution,
@@ -111,12 +112,29 @@ def ensure_series(
         cur.execute("SELECT id FROM series WHERE imdb_id = %s", (tv.imdb_id,))
         row = cur.fetchone()
         if row:
-            return False, row[0]
+            series_id = row[0]
+            # Existing series may pre-date the csfd-resolution work (#730);
+            # try to fill csfd_id opportunistically — the helper no-ops if
+            # the column is already populated.
+            lookup_and_write_csfd(
+                conn,
+                table="series", row_id=series_id,
+                imdb_id=tv.imdb_id, tmdb_id=tv.tmdb_id,
+                title=tv.name_cs or tv.name_en or tv.original_name,
+            )
+            return False, series_id
     if tv.tmdb_id:
         cur.execute("SELECT id FROM series WHERE tmdb_id = %s", (tv.tmdb_id,))
         row = cur.fetchone()
         if row:
-            return False, row[0]
+            series_id = row[0]
+            lookup_and_write_csfd(
+                conn,
+                table="series", row_id=series_id,
+                imdb_id=tv.imdb_id, tmdb_id=tv.tmdb_id,
+                title=tv.name_cs or tv.name_en or tv.original_name,
+            )
+            return False, series_id
 
     # New series — create row
     name_cs = tv.name_cs or tv.name_en or tv.original_name or "Seriál"
@@ -178,6 +196,16 @@ def ensure_series(
                 "VALUES (%s, %s) ON CONFLICT DO NOTHING",
                 (series_id, slug_to_id[slug]),
             )
+
+    # Opportunistic csfd_id fill via Wikidata (#730). Same pattern as
+    # enricher.upsert_film — never raises; weekly bulk resolver mops
+    # up anything that didn't resolve here.
+    lookup_and_write_csfd(
+        conn,
+        table="series", row_id=series_id,
+        imdb_id=tv.imdb_id, tmdb_id=tv.tmdb_id,
+        title=name_cs,
+    )
 
     log.info("created series %d (imdb=%s, tmdb=%d, slug=%s)",
              series_id, tv.imdb_id, tv.tmdb_id, slug)

--- a/scripts/auto_import/tv_show_enricher.py
+++ b/scripts/auto_import/tv_show_enricher.py
@@ -27,6 +27,7 @@ import re
 import unicodedata
 from dataclasses import dataclass
 
+from scripts.auto_import.csfd_lookup import lookup_and_write_csfd
 from scripts.auto_import.gemma_writer import generate_unique_cs
 from scripts.video_sources_helper import (
     dual_write_sktorrent,
@@ -156,6 +157,13 @@ def process_tv_show_episode(
             )
             tv_show_id = cur.fetchone()[0]
             created_show = True
+            # Opportunistic csfd_id fill via Wikidata (#730).
+            lookup_and_write_csfd(
+                conn,
+                table="tv_shows", row_id=tv_show_id,
+                imdb_id=tv.imdb_id, tmdb_id=tv.tmdb_id,
+                title=title,
+            )
             log.info("created tv_show id=%d slug='%s' (tmdb=%d)",
                      tv_show_id, slug, tv.tmdb_id)
         except Exception:


### PR DESCRIPTION
<!-- claude-session: fd55863a-01fd-456b-b70d-ea0440e6400a -->

Part of epic #730. Builds on the resolver merged in #737 (sub-issue #732).

## Summary
Adds `scripts/auto_import/csfd_lookup.py` — a single-row Wikidata SPARQL helper — and wires it into the three enrichers so freshly-imported rows get their `csfd_id` filled immediately rather than waiting up to a week for the next bulk-resolver tick (Mon 06:00 UTC).

- **`enricher.upsert_film`** (SK Torrent films) — both `updated_film` and `added_film` paths.
- **`series_enricher.ensure_series`** (SK Torrent series + **prehraj.to series discovery**, which reuses this same function) — existing AND new-row paths.
- **`tv_show_enricher.process_tv_show_episode`** — new-show INSERT path only.

The helper is **strictly tolerant** — any Wikidata error, network timeout, sanity-check mismatch, or duplicate entity returns silently and the row stays with `csfd_id = NULL`. The bulk resolver picks those up next Monday and either resolves them or logs them to `csfd_id_resolution_review` for manual triage. **Import paths must not fail because Wikidata is slow or rate-limited.**

Sanity-check logic mirrors the bulk resolver verbatim: `labelCs` is the only signal allowed to VETO; `labelEn` / P1476 / aliases are positive-only signals that can confirm an acceptance but never override a Czech-label disagreement.

## Out of scope (separate follow-ups)
- The three vendored film importers (`import-prehrajto-new-films.py`, `import-prehrajto-tmdb-as-film.py`, `import-sledujteto-films.py`) that bypass `upsert_film` with their own INSERT logic.

## Test plan
- [x] **Mock-based unit test** (local cr_dev): label match → csfd_id written; label mismatch → not written, DB unchanged; network error → silently None.
- [x] **Round-trip on prod**: cleared `csfd_id` on three already-resolved rows (id=37256 / 37269 / 37270), called the helper, got the original csfd_id back. Restored values after the test.
- [x] **Wikidata rate-limit case**: helper returns None silently, DB unchanged.
- [x] Deployed to `/opt/cr/scripts/auto_import/` via rsync. cr-web doesn't import `auto_import` directly so no binary rebuild needed; the next auto-import run (tomorrow ~05:00 UTC) exercises the new code path in earnest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)