### PR TITLE
feat(scripts): csfd_id fallback resolvers via cs.wiki + ČSFD search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,5 +57,9 @@ data/prototypes/
 data/scripts/
 data/sledujteto/
 data/imdb-cache/
+# csfd_id resolver output — large per-row TSV with embedded JSON candidates.
+# Not source code; regenerable by re-running the scripts. Keep out of git.
+data/csfd-cswiki/
+data/csfd-search/
 scripts/__pycache__/
 scripts/auto_import/__pycache__/

--- a/scripts/resolve-csfd-via-cswiki.py
+++ b/scripts/resolve-csfd-via-cswiki.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+"""Resolve missing `csfd_id` via Czech Wikipedia external links — a
+last-resort path for rows where the main Wikidata resolver couldn't
+find a P2529 link (#732 leaves them as `wikidata_missing_p2529` or
+`unresolved`).
+
+Why this exists: a Wikidata item that maps IMDb→Q-item but has no
+P2529 sometimes still has a Czech Wikipedia article that links to
+csfd.cz/film/{id} in its external-links section. Maintainers
+occasionally fill those into Wikipedia but not Wikidata. This script
+scrapes that residual signal.
+
+Realistic recovery: probe on 100 random films showed ~1 % yield.
+Expected total: a few dozen rows out of ~6.6k missing. Not worth a
+full migration + audit-table redesign — runs as a discovery script
+emitting a TSV that the maintainer can review and either apply via
+`--apply` or hand-curate.
+
+Two phases:
+
+  1. Wikidata batch query (P345 → Q-item + cs-wiki sitelink). Endpoint
+     is rate-limited to 1 req/min during the active wdqs outage so
+     batches are 500 IDs at a time with a 65 s gap between batches.
+
+  2. Per-Q-item-with-cs-wiki: fetch the article via MediaWiki API,
+     parse `csfd.cz/film/(\\d+)` from externallinks. MediaWiki API
+     has no throttle to worry about; 0.5 s gap is just politeness.
+
+Safety gate (applied during --apply, not at extract):
+  * the cs-wiki article title (a Czech title from Wikidata's sitelink)
+    must normalised-match cr.title or cr.original_title — i.e. the
+    article is *about* the film cr has, not a name collision.
+  * proposed csfd_id must not already exist on a different cr row in
+    the same table (sibling-collision guard, same as #740).
+
+Usage:
+
+    # Phase A — extract proposals (writes data/csfd-cswiki/{table}.tsv)
+    DATABASE_URL=postgres://cr:cr@prod-host/cr \\
+        python3 scripts/resolve-csfd-via-cswiki.py extract \\
+            [--table films|series|tv_shows|all] \\
+            [--limit N]
+
+    # Phase B — apply proposals after manual review
+    DATABASE_URL=postgres://cr:cr@prod-host/cr \\
+        python3 scripts/resolve-csfd-via-cswiki.py apply \\
+            [--table films|series|tv_shows|all] \\
+            [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import logging
+import os
+import re
+import sys
+import time
+import unicodedata
+import urllib.parse
+import urllib.request
+import urllib.error
+import json
+from pathlib import Path
+
+import psycopg2
+
+SPARQL_ENDPOINT = "https://query.wikidata.org/sparql"
+MEDIAWIKI_API = "https://cs.wikipedia.org/w/api.php"
+
+USER_AGENT = os.environ.get(
+    "CR_CSFD_RESOLVER_USER_AGENT",
+    "cr-csfd-cswiki/0.1 (https://ceskarepublika.wiki; "
+    "noreply@ceskarepublika.wiki)",
+)
+
+# Wikidata throttling: 1 req/min during the active wdqs outage (May
+# 2026, same as the main resolver). Batches up to ~500 IDs work.
+SPARQL_BATCH = 500
+SPARQL_INTERBATCH_SLEEP = 65.0
+
+# cs.wiki is unmetered but be a polite citizen.
+MEDIAWIKI_SLEEP = 0.5
+
+OUT_DIR = Path("data/csfd-cswiki")
+
+TABLES = ("films", "series", "tv_shows")
+
+
+# ---------------------------------------------------------------------------
+# Normalisation (lifted from resolve-csfd-via-wikidata.py)
+# ---------------------------------------------------------------------------
+
+# Cyrillic-Latin confusables that show up in Czech-encoded titles
+# (mostly diacritic variants). Same map as the main resolver.
+_CONFUSABLES = str.maketrans({
+    "а": "a", "е": "e", "о": "o", "р": "p", "с": "c", "у": "y", "х": "x",
+    "А": "a", "Е": "e", "О": "o", "Р": "p", "С": "c", "У": "y", "Х": "x",
+})
+
+
+def normalise(s: str | None) -> str:
+    if not s:
+        return ""
+    s = s.translate(_CONFUSABLES).lower()
+    s = unicodedata.normalize("NFKD", s)
+    s = "".join(c for c in s if not unicodedata.combining(c))
+    return re.sub(r"[^a-z0-9]", "", s)
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers
+# ---------------------------------------------------------------------------
+
+
+def _sparql_post(query: str, max_retries: int = 6) -> dict:
+    backoff = 5.0
+    for attempt in range(max_retries):
+        try:
+            data = urllib.parse.urlencode(
+                {"query": query, "format": "json"}
+            ).encode("utf-8")
+            req = urllib.request.Request(
+                SPARQL_ENDPOINT,
+                data=data,
+                headers={
+                    "User-Agent": USER_AGENT,
+                    "Accept": "application/sparql-results+json",
+                    "Content-Type": "application/x-www-form-urlencoded",
+                },
+            )
+            with urllib.request.urlopen(req, timeout=120) as r:
+                return json.load(r)
+        except urllib.error.HTTPError as e:
+            if e.code == 429:
+                retry_after = e.headers.get("Retry-After")
+                wait = (
+                    float(retry_after)
+                    if retry_after and retry_after.isdigit()
+                    else backoff
+                )
+                wait = min(wait, 70.0)
+                logging.warning(
+                    "Wikidata 429 (attempt %d/%d) — sleep %.0fs",
+                    attempt + 1, max_retries, wait,
+                )
+                time.sleep(wait)
+                backoff = min(backoff * 2, 70.0)
+                continue
+            if e.code >= 500:
+                logging.warning(
+                    "Wikidata %d (attempt %d/%d) — sleep %.0fs",
+                    e.code, attempt + 1, max_retries, backoff,
+                )
+                time.sleep(backoff)
+                backoff = min(backoff * 2, 70.0)
+                continue
+            raise
+    raise RuntimeError("Wikidata SPARQL retries exhausted")
+
+
+def _mediawiki_get(params: dict) -> dict:
+    url = MEDIAWIKI_API + "?" + urllib.parse.urlencode(params)
+    req = urllib.request.Request(
+        url,
+        headers={
+            "User-Agent": USER_AGENT,
+            "Accept": "application/json",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return json.load(r)
+
+
+# ---------------------------------------------------------------------------
+# Wikidata + cs-wiki lookup
+# ---------------------------------------------------------------------------
+
+
+def wikidata_imdb_to_qid_and_cswiki(
+    imdb_ids: list[str],
+) -> dict[str, tuple[str | None, str | None]]:
+    """Batch IMDb → (qid, cs-wiki article title). Title is None when the
+    Wikidata item has no cs-wiki sitelink."""
+    if not imdb_ids:
+        return {}
+    values = " ".join(f'"{x}"' for x in imdb_ids)
+    q = f"""
+SELECT ?imdb ?item ?cswikiTitle WHERE {{
+  VALUES ?imdb {{ {values} }}
+  ?item wdt:P345 ?imdb .
+  OPTIONAL {{
+    ?sitelink schema:about ?item ;
+              schema:isPartOf <https://cs.wikipedia.org/> ;
+              schema:name ?cswikiTitle .
+  }}
+}}"""
+    out: dict[str, tuple[str | None, str | None]] = {}
+    data = _sparql_post(q)
+    for b in data["results"]["bindings"]:
+        imdb = b["imdb"]["value"]
+        qid = b.get("item", {}).get("value", "").split("/")[-1] or None
+        cs = b.get("cswikiTitle", {}).get("value")
+        # Multiple rows can come back if Wikidata has duplicates;
+        # prefer the first row that *has* a cs-wiki sitelink.
+        if imdb not in out or (cs and not out[imdb][1]):
+            out[imdb] = (qid, cs)
+    return out
+
+
+def cswiki_csfd_id(title: str) -> int | None:
+    """Fetch externallinks from the cs-wiki article and return the
+    first csfd.cz/film/{id} found. None when the article doesn't
+    exist, doesn't link to ČSFD, or the API call fails."""
+    params = {
+        "action": "parse",
+        "page": title,
+        "prop": "externallinks",
+        "format": "json",
+        "formatversion": "2",
+        "redirects": "1",
+    }
+    try:
+        data = _mediawiki_get(params)
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return None
+        logging.warning("cs-wiki fetch failed for %r: HTTP %d", title, e.code)
+        return None
+    except Exception as e:
+        logging.warning("cs-wiki fetch failed for %r: %s", title, e)
+        return None
+    if "error" in data:
+        # missingtitle, normally
+        return None
+    links = data.get("parse", {}).get("externallinks", []) or []
+    for l in links:
+        m = re.search(r"csfd\.cz/film/(\d+)", l)
+        if m:
+            return int(m.group(1))
+    return None
+
+
+# ---------------------------------------------------------------------------
+# DB
+# ---------------------------------------------------------------------------
+
+
+def fetch_rows(conn, table: str, limit: int | None) -> list[tuple]:
+    """Returns rows missing csfd_id but with imdb_id."""
+    year_col = "year" if table == "films" else "first_air_year"
+    sql = (
+        f"SELECT id, imdb_id, tmdb_id, title, original_title, "
+        f"{year_col} AS year FROM {table} "
+        f"WHERE csfd_id IS NULL AND imdb_id IS NOT NULL "
+        f"ORDER BY id"
+    )
+    if limit:
+        sql += f" LIMIT {limit}"
+    with conn.cursor() as cur:
+        cur.execute(sql)
+        return cur.fetchall()
+
+
+def csfd_id_already_used(conn, table: str, csfd_id: int) -> int | None:
+    """Returns the id of any other row in the same table that already
+    has this csfd_id. None if free."""
+    with conn.cursor() as cur:
+        cur.execute(
+            f"SELECT id FROM {table} WHERE csfd_id = %s LIMIT 1",
+            (csfd_id,),
+        )
+        row = cur.fetchone()
+    return row[0] if row else None
+
+
+# ---------------------------------------------------------------------------
+# Extract phase
+# ---------------------------------------------------------------------------
+
+
+def extract(args, conn) -> None:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    tables = TABLES if args.table == "all" else (args.table,)
+    for table in tables:
+        rows = fetch_rows(conn, table, args.limit)
+        logging.info("table=%s rows=%d", table, len(rows))
+        if not rows:
+            continue
+
+        imdb_ids = [r[1] for r in rows if r[1]]
+        wd: dict[str, tuple[str | None, str | None]] = {}
+        for i in range(0, len(imdb_ids), SPARQL_BATCH):
+            chunk = imdb_ids[i:i + SPARQL_BATCH]
+            logging.info(
+                "wikidata batch %d/%d (size=%d)",
+                i // SPARQL_BATCH + 1,
+                (len(imdb_ids) + SPARQL_BATCH - 1) // SPARQL_BATCH,
+                len(chunk),
+            )
+            wd.update(wikidata_imdb_to_qid_and_cswiki(chunk))
+            if i + SPARQL_BATCH < len(imdb_ids):
+                time.sleep(SPARQL_INTERBATCH_SLEEP)
+
+        path = OUT_DIR / f"{table}.tsv"
+        with path.open("w", newline="") as f:
+            w = csv.writer(f, delimiter="\t")
+            w.writerow([
+                "row_id", "imdb_id", "tmdb_id", "title", "original_title",
+                "year", "qid", "cs_wiki_title", "proposed_csfd_id",
+                "norm_title_match", "norm_original_match",
+            ])
+            counts = {"qid": 0, "cswiki": 0, "csfd": 0, "match": 0}
+            for row_id, imdb_id, tmdb_id, title, orig, year in rows:
+                qid, cs = wd.get(imdb_id, (None, None))
+                if qid:
+                    counts["qid"] += 1
+                if not cs:
+                    continue
+                counts["cswiki"] += 1
+                time.sleep(MEDIAWIKI_SLEEP)
+                csfd = cswiki_csfd_id(cs)
+                if not csfd:
+                    continue
+                counts["csfd"] += 1
+                cs_norm = normalise(re.sub(r"\s*\([^)]*\)\s*$", "", cs))
+                t_match = bool(title) and normalise(title) == cs_norm
+                o_match = bool(orig) and normalise(orig) == cs_norm
+                if t_match or o_match:
+                    counts["match"] += 1
+                w.writerow([
+                    row_id, imdb_id or "", tmdb_id or "", title or "",
+                    orig or "", year or "", qid or "", cs,
+                    csfd, "1" if t_match else "0",
+                    "1" if o_match else "0",
+                ])
+        logging.info(
+            "table=%s qid=%d cswiki=%d csfd_link=%d title_match=%d → %s",
+            table, counts["qid"], counts["cswiki"], counts["csfd"],
+            counts["match"], path,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Apply phase
+# ---------------------------------------------------------------------------
+
+
+def apply_(args, conn) -> None:
+    tables = TABLES if args.table == "all" else (args.table,)
+    grand = {"applied": 0, "skipped_collision": 0, "skipped_no_match": 0,
+             "skipped_already_set": 0, "missing_file": 0}
+    for table in tables:
+        path = OUT_DIR / f"{table}.tsv"
+        if not path.exists():
+            logging.warning("no proposals file for %s — run `extract` first", table)
+            grand["missing_file"] += 1
+            continue
+        with path.open() as f:
+            rows = list(csv.DictReader(f, delimiter="\t"))
+        logging.info("table=%s proposals=%d", table, len(rows))
+        for r in rows:
+            row_id = int(r["row_id"])
+            csfd = int(r["proposed_csfd_id"])
+            if r["norm_title_match"] != "1" and r["norm_original_match"] != "1":
+                grand["skipped_no_match"] += 1
+                continue
+            collision = csfd_id_already_used(conn, table, csfd)
+            if collision and collision != row_id:
+                logging.info(
+                    "skip %s.id=%s csfd=%d — taken by id=%d",
+                    table, row_id, csfd, collision,
+                )
+                grand["skipped_collision"] += 1
+                continue
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"UPDATE {table} SET csfd_id = %s "
+                    f"WHERE id = %s AND csfd_id IS NULL",
+                    (csfd, row_id),
+                )
+                if cur.rowcount == 0:
+                    grand["skipped_already_set"] += 1
+                    continue
+                grand["applied"] += 1
+                logging.info(
+                    "apply %s.id=%s ← csfd_id=%d (cs-wiki: %r)",
+                    table, row_id, csfd, r["cs_wiki_title"],
+                )
+        if args.dry_run:
+            conn.rollback()
+            logging.info("--dry-run → rolled back %s", table)
+        else:
+            conn.commit()
+    logging.info("summary: %s", grand)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    e = sub.add_parser("extract", help="Phase A: write proposals TSV")
+    e.add_argument(
+        "--table", choices=("films", "series", "tv_shows", "all"),
+        default="all",
+    )
+    e.add_argument("--limit", type=int, default=None)
+
+    a = sub.add_parser("apply", help="Phase B: UPDATE rows from TSV")
+    a.add_argument(
+        "--table", choices=("films", "series", "tv_shows", "all"),
+        default="all",
+    )
+    a.add_argument("--dry-run", action="store_true")
+
+    args = p.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        print("DATABASE_URL must be set", file=sys.stderr)
+        return 2
+    conn = psycopg2.connect(dsn)
+
+    try:
+        if args.cmd == "extract":
+            extract(args, conn)
+        elif args.cmd == "apply":
+            apply_(args, conn)
+    finally:
+        conn.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/resolve-csfd-via-search.py
+++ b/scripts/resolve-csfd-via-search.py
@@ -6,22 +6,24 @@ from `film_directors` / `film_actors` / `series_*`).
 Title+year alone produces many false positives because common titles
 ("Potopa", "Munich") have several films on ČSFD. The fix is to fetch
 ČSFD's detail page for each candidate and require strong overlap with
-the credits cr already has — director match + cast overlap + country
-match. We do NOT call TMDB at extract time; cr's `people` table covers
-~99 % of films via the existing TMDB ingest.
+the credits cr already has — director match + cast overlap. We do NOT
+call TMDB at extract time; cr's `people` table covers ~99 % of films
+via the existing TMDB ingest.
 
 Pipeline per cr row:
   1. Search ČSFD: csfd.cz/hledat/?q={cr.title or cr.original_title}
   2. Filter candidates by normalised title match against cr.title or
-     cr.original_title AND |year diff| ≤ 1.
+     cr.original_title AND |year diff| ≤ 2.
   3. For each surviving candidate (up to 5), fetch /film/{id}/prehled/
      and pull (directors, actors, origin country, runtime).
   4. Score against cr's local credits:
         +25  director name match (per name)
-        +5   top-cast name match (per name, capped at 25)
-        +3   country match (any overlap)
+        +5   top-cast name match (per first 5 cast names, capped at 25)
         +5   runtime within ±10 min
         +5   year exact, +1 year ±1
+     The ČSFD origin country is parsed and recorded in `breakdown`
+     for audit, but cr doesn't currently store production_countries
+     so it contributes 0 points — a later commit can plumb that.
   5. Accept the highest scorer iff score ≥ 30 AND ≥ 2× runner-up.
   6. Otherwise mark needs_review with all candidate scores in
      `details_json` for human triage.
@@ -365,12 +367,21 @@ class PageHolder:
         return self.page.wait_for_selector(*a, **kw)
 
     def evaluate(self, *a, **kw):
+        # If the page died mid-evaluate, the reopened page has no DOM yet
+        # — we can't just re-run the same JS against it (the caller's
+        # selector wait_for_selector / goto happened on the OLD page).
+        # Returning None to the caller is also broken: search_csfd /
+        # fetch_detail expect a dict and immediately `.get()` on it.
+        # The honest behaviour is to surface the closure as an exception
+        # the existing caller-side try/except already handles, so it
+        # logs a single "eval failed" warning and moves to the next row
+        # — on which goto() will hit the same closed-page path, reopen
+        # the page properly, and resume.
         try:
             return self.page.evaluate(*a, **kw)
         except Exception as e:
             if self._is_closed_error(e):
                 self._reopen()
-                return None
             raise
 
     def close(self) -> None:
@@ -454,9 +465,16 @@ def score_candidate(
     cand_runtime: int | None,
     cand_directors_norm: set[str],
     cand_actors_norm: set[str],
-    cr_iso: list[str] | None,
 ) -> tuple[int, dict]:
-    """Returns (score, breakdown_dict)."""
+    """Returns (score, breakdown_dict).
+
+    cr-side country code is not currently plumbed in — `cr.films` /
+    `series` / `tv_shows` don't carry production_countries (TMDB
+    exposes it, but we don't store it). The ČSFD-side `cand_iso` is
+    still parsed and logged in `breakdown` for the audit trail so a
+    later commit can wire a cr_iso source without changing the data
+    shape.
+    """
     breakdown: dict[str, int | list[str]] = {}
     s = 0
 
@@ -474,15 +492,11 @@ def score_candidate(
     else:
         breakdown["year"] = 0
 
-    # Country (overlap on any ISO code)
-    if cr_iso and cand_iso:
-        if set(cr_iso) & set(cand_iso):
-            s += 3
-            breakdown["country"] = 3
-        else:
-            breakdown["country"] = 0
-    else:
-        breakdown["country"] = 0
+    # Country signal is currently informational only — see docstring.
+    # `cand_iso` is still recorded in the breakdown for audit so the
+    # signal can be enabled later without rewriting TSV consumers.
+    breakdown["country"] = 0
+    breakdown["cand_country"] = list(cand_iso)
 
     # Runtime
     if cr_row.get("runtime_min") and cand_runtime:
@@ -500,10 +514,14 @@ def score_candidate(
     s += 25 * len(matched_dir)
     breakdown["directors"] = matched_dir
 
-    # Actors — moderate signal. Per match +5, capped at 25.
+    # Actors — moderate signal. +5 per name match across the first 5
+    # matched names (so the bonus is at most 25). Capping at 5 keeps
+    # the docstring's "+5 per name × 5 names = 25" promise honest and
+    # makes the breakdown.actors list trivially interpretable in the
+    # TSV — what you see is exactly what was scored.
     cr_act = {normalise_name(n) for n in (cr_row.get("actors") or "").split("|") if n}
-    matched_act = sorted(cr_act & cand_actors_norm)[:8]
-    bonus = min(5 * len(matched_act), 25)
+    matched_act = sorted(cr_act & cand_actors_norm)[:5]
+    bonus = 5 * len(matched_act)
     s += bonus
     breakdown["actors"] = matched_act
     breakdown["actors_bonus"] = bonus
@@ -657,7 +675,7 @@ def extract(args, conn) -> None:
                             act_names = {normalise_name(n) for n in roles.get("Hrají", [])[:15]}
                             sc, bd = score_candidate(
                                 cr_row, cand["year"] or det_year, iso, runtime,
-                                dir_names, act_names, cr_iso=None,
+                                dir_names, act_names,
                             )
                             scored.append({
                                 "csfd_id": cand["csfd_id"],
@@ -705,7 +723,12 @@ def extract(args, conn) -> None:
 
 def apply_(args, conn) -> None:
     tables = TABLES if args.table == "all" else (args.table,)
-    grand = {"applied": 0, "skipped_collision": 0,
+    # Separate `applied` vs `would_apply` so dry-run output is honest:
+    # the summary line printed at the end is the same code path for
+    # both real and dry runs, and an operator copy-pasting "applied:
+    # 2499" should mean rows committed to the DB, not rows that
+    # would have been committed if --dry-run weren't set.
+    grand = {"applied": 0, "would_apply": 0, "skipped_collision": 0,
              "skipped_needs_review": 0, "skipped_already_set": 0,
              "missing_file": 0}
     for table in tables:
@@ -715,7 +738,7 @@ def apply_(args, conn) -> None:
             continue
         with path.open() as f:
             rows = list(csv.DictReader(f, delimiter="\t"))
-        applied = 0
+        table_count = 0
         for r in rows:
             if r["gate"] != "accept":
                 grand["skipped_needs_review"] += 1
@@ -735,14 +758,15 @@ def apply_(args, conn) -> None:
                 if cur.rowcount == 0:
                     grand["skipped_already_set"] += 1
                     continue
-                grand["applied"] += 1
-                applied += 1
+                table_count += 1
         if args.dry_run:
             conn.rollback()
-            logging.info("--dry-run %s would apply %d", table, applied)
+            grand["would_apply"] += table_count
+            logging.info("--dry-run %s would apply %d", table, table_count)
         else:
             conn.commit()
-            logging.info("%s applied %d", table, applied)
+            grand["applied"] += table_count
+            logging.info("%s applied %d", table, table_count)
     logging.info("summary: %s", grand)
 
 

--- a/scripts/resolve-csfd-via-search.py
+++ b/scripts/resolve-csfd-via-search.py
@@ -1,0 +1,794 @@
+#!/usr/bin/env python3
+"""Resolve missing `csfd_id` by searching csfd.cz and corroborating
+the candidate against cr's local credits data (director + cast pulled
+from `film_directors` / `film_actors` / `series_*`).
+
+Title+year alone produces many false positives because common titles
+("Potopa", "Munich") have several films on ČSFD. The fix is to fetch
+ČSFD's detail page for each candidate and require strong overlap with
+the credits cr already has — director match + cast overlap + country
+match. We do NOT call TMDB at extract time; cr's `people` table covers
+~99 % of films via the existing TMDB ingest.
+
+Pipeline per cr row:
+  1. Search ČSFD: csfd.cz/hledat/?q={cr.title or cr.original_title}
+  2. Filter candidates by normalised title match against cr.title or
+     cr.original_title AND |year diff| ≤ 1.
+  3. For each surviving candidate (up to 5), fetch /film/{id}/prehled/
+     and pull (directors, actors, origin country, runtime).
+  4. Score against cr's local credits:
+        +25  director name match (per name)
+        +5   top-cast name match (per name, capped at 25)
+        +3   country match (any overlap)
+        +5   runtime within ±10 min
+        +5   year exact, +1 year ±1
+  5. Accept the highest scorer iff score ≥ 30 AND ≥ 2× runner-up.
+  6. Otherwise mark needs_review with all candidate scores in
+     `details_json` for human triage.
+
+Connection: Playwright over CDP to the workspace's Edge instance
+(http://localhost:9226 by default; Edge already has Anubis cookie
+solved per CLAUDE.md). Falls back to `EDGE_CDP` env var.
+
+Rate-limit: 1 req/s by default (sleep after each navigation). At 6.6 k
+rows × ~2 reqs each ≈ 6 hours total. Run overnight.
+
+Resumable: extract phase appends to data/csfd-search/{table}.tsv and
+skips row_ids already present on re-run.
+
+Usage:
+
+    # Phase A — extract proposals
+    EDGE_CDP=http://localhost:9226 \\
+    DATABASE_URL=postgres://cr:cr@host/cr \\
+        python3 scripts/resolve-csfd-via-search.py extract \\
+            [--table films|series|tv_shows|all] \\
+            [--limit N] \\
+            [--sleep 1.5] \\
+            [--accept-score 30] \\
+            [--margin 2.0]
+
+    # Phase B — apply rows whose gate=accept
+    DATABASE_URL=postgres://cr:cr@host/cr \\
+        python3 scripts/resolve-csfd-via-search.py apply \\
+            [--table films|series|tv_shows|all] \\
+            [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import logging
+import os
+import re
+import sys
+import time
+import unicodedata
+import urllib.parse
+from pathlib import Path
+
+import psycopg2
+import psycopg2.extras
+from playwright.sync_api import sync_playwright
+
+OUT_DIR = Path("data/csfd-search")
+TABLES = ("films", "series", "tv_shows")
+
+
+# ---------------------------------------------------------------------------
+# Normalisation
+# ---------------------------------------------------------------------------
+
+_CONFUSABLES = str.maketrans({
+    "а": "a", "е": "e", "о": "o", "р": "p", "с": "c", "у": "y", "х": "x",
+    "А": "a", "Е": "e", "О": "o", "Р": "p", "С": "c", "У": "y", "Х": "x",
+})
+
+
+def normalise(s: str | None) -> str:
+    if not s:
+        return ""
+    s = s.translate(_CONFUSABLES).lower()
+    s = unicodedata.normalize("NFKD", s)
+    s = "".join(c for c in s if not unicodedata.combining(c))
+    return re.sub(r"[^a-z0-9]", "", s)
+
+
+def normalise_name(s: str | None) -> str:
+    """For person names: drop diacritics, lowercase, collapse spaces."""
+    if not s:
+        return ""
+    s = s.translate(_CONFUSABLES).lower()
+    s = unicodedata.normalize("NFKD", s)
+    s = "".join(c for c in s if not unicodedata.combining(c))
+    s = re.sub(r"[^a-z0-9 ]", "", s)
+    return re.sub(r"\s+", " ", s).strip()
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+
+def fetch_rows_with_credits(
+    conn,
+    table: str,
+    limit: int | None,
+) -> list[dict]:
+    """Returns one dict per cr row missing csfd_id, with director +
+    actor names already joined from the local credits tables."""
+    year_col = "year" if table == "films" else "first_air_year"
+    fk = "film_id" if table == "films" else "series_id"
+    # Junction-table names: `film_directors` (drop the plural 's') but
+    # `series_directors` — `series` is already singular form. Naïve
+    # `table[:-1]` produces `serie_*` which doesn't exist.
+    credits_prefix = {
+        "films": "film",
+        "series": "series",
+        "tv_shows": None,
+    }[table]
+    dir_table = f"{credits_prefix}_directors" if credits_prefix else None
+    act_table = f"{credits_prefix}_actors" if credits_prefix else None
+    # Only `films` carries `runtime_min`. series + tv_shows don't store
+    # a per-row runtime; we substitute NULL so the scorer just skips the
+    # runtime check for those tables instead of throwing.
+    runtime_expr = "f.runtime_min" if table == "films" else "NULL::smallint"
+    # tv_shows currently has no _actors/_directors tables; fall back to NULL.
+    if table == "tv_shows":
+        sql = (
+            f"SELECT id, imdb_id, tmdb_id, title, original_title, "
+            f"{year_col} AS year, NULL::smallint AS runtime_min, "
+            f"NULL::text AS directors, NULL::text AS actors "
+            f"FROM {table} WHERE csfd_id IS NULL "
+            f"  AND (title IS NOT NULL OR original_title IS NOT NULL) "
+            f"ORDER BY id"
+        )
+    else:
+        sql = f"""
+            SELECT f.id, f.imdb_id, f.tmdb_id, f.title, f.original_title,
+                   f.{year_col} AS year, {runtime_expr} AS runtime_min,
+                   (SELECT string_agg(p.name, '|')
+                    FROM {dir_table} d
+                    JOIN people p ON p.id = d.person_id
+                    WHERE d.{fk} = f.id) AS directors,
+                   (SELECT string_agg(p.name, '|' ORDER BY a.order_index)
+                    FROM (SELECT person_id, order_index FROM {act_table}
+                          WHERE {fk} = f.id
+                          ORDER BY order_index LIMIT 15) a
+                    JOIN people p ON p.id = a.person_id) AS actors
+            FROM {table} f
+            WHERE f.csfd_id IS NULL
+              AND (f.title IS NOT NULL OR f.original_title IS NOT NULL)
+            ORDER BY f.id
+        """
+    if limit:
+        sql += f" LIMIT {limit}"
+    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(sql)
+        return [dict(r) for r in cur.fetchall()]
+
+
+def csfd_id_used_by(conn, table: str, csfd_id: int) -> int | None:
+    with conn.cursor() as cur:
+        cur.execute(
+            f"SELECT id FROM {table} WHERE csfd_id = %s LIMIT 1",
+            (csfd_id,),
+        )
+        row = cur.fetchone()
+    return row[0] if row else None
+
+
+# ---------------------------------------------------------------------------
+# Playwright scraping
+# ---------------------------------------------------------------------------
+
+# Search-results extraction. Returns array of {csfd_id, title, year}.
+_SEARCH_JS = r"""
+() => {
+  const results = [];
+  const headers = document.querySelectorAll('header.article-header');
+  for (const h of headers) {
+    const a = h.querySelector('a[href*="/film/"]');
+    if (!a) continue;
+    const m = (a.getAttribute('href') || '').match(/\/film\/(\d+)/);
+    if (!m) continue;
+    const text = h.textContent.replace(/\s+/g, ' ').trim();
+    const yearMatch = text.match(/\((\d{4})\)/);
+    results.push({
+      csfd_id: parseInt(m[1], 10),
+      title: a.textContent.trim(),
+      year: yearMatch ? parseInt(yearMatch[1], 10) : null,
+    });
+    if (results.length >= 20) break;
+  }
+  const hasNoResults = !!document.querySelector('.search-no-results') ||
+                       /Žádné výsledky/i.test(document.body.textContent);
+  return { results, hasNoResults };
+}
+"""
+
+# Detail-page metadata extraction. Returns origin string + role groups.
+_DETAIL_JS = r"""
+() => {
+  const result = {};
+  const origin = document.querySelector('.origin');
+  result.origin_raw = origin ? origin.textContent.replace(/\s+/g, ' ').trim() : null;
+  const genres = document.querySelector('.genres');
+  result.genres_raw = genres ? genres.textContent.replace(/\s+/g, ' ').trim() : null;
+  const roles = {};
+  const creators = document.querySelectorAll('.creators div');
+  for (const d of creators) {
+    const h4 = d.querySelector('h4');
+    if (!h4) continue;
+    const role = h4.textContent.replace(':', '').trim();
+    const names = Array.from(d.querySelectorAll('a')).map(a => a.textContent.trim());
+    roles[role] = names;
+  }
+  result.roles = roles;
+  const altNames = Array.from(document.querySelectorAll('.film-names li'))
+    .map(li => li.textContent.replace(/\s+/g, ' ').trim());
+  result.alt_names = altNames.slice(0, 5);
+  return result;
+}
+"""
+
+
+# ČSFD country names → ISO 2-letter; only the most common. The
+# scoring just needs *any* overlap so we don't need a complete table.
+_CSFD_COUNTRY_TO_ISO = {
+    "USA": "us", "Spojené státy americké": "us",
+    "Velká Británie": "gb", "Anglie": "gb",
+    "Česko": "cz", "Československo": "cz", "ČSSR": "cz", "ČR": "cz",
+    "Slovensko": "sk",
+    "Německo": "de", "NDR": "de", "NSR": "de", "Západní Německo": "de",
+    "Francie": "fr",
+    "Itálie": "it",
+    "Španělsko": "es",
+    "Polsko": "pl",
+    "Rusko": "ru", "Sovětský svaz": "ru", "SSSR": "ru",
+    "Japonsko": "jp",
+    "Kanada": "ca",
+    "Austrálie": "au",
+    "Maďarsko": "hu",
+    "Rakousko": "at",
+    "Belgie": "be",
+    "Nizozemsko": "nl", "Holandsko": "nl",
+    "Švédsko": "se",
+    "Norsko": "no",
+    "Dánsko": "dk",
+    "Finsko": "fi",
+    "Švýcarsko": "ch",
+    "Indie": "in",
+    "Brazílie": "br",
+    "Argentina": "ar",
+    "Mexiko": "mx",
+    "Jižní Korea": "kr",
+    "Čína": "cn",
+    "Hongkong": "hk",
+    "Tchaj-wan": "tw",
+    "Izrael": "il",
+    "Turecko": "tr",
+    "Irsko": "ie",
+    "Nový Zéland": "nz",
+    "Portugalsko": "pt",
+    "Řecko": "gr",
+    "Rumunsko": "ro",
+}
+
+
+def parse_origin(raw: str | None) -> tuple[list[str], int | None, int | None]:
+    """Parse ČSFD `.origin` like 'USA, Francie, Kanada 2023 100 min' →
+    (iso-country-list, year, runtime_min)."""
+    if not raw:
+        return [], None, None
+    # Year and runtime get extracted by regex first.
+    year_m = re.search(r"\b(19|20)\d{2}\b", raw)
+    year = int(year_m.group(0)) if year_m else None
+    rt_m = re.search(r"(\d{1,3})\s*min", raw)
+    runtime = int(rt_m.group(1)) if rt_m else None
+    # Country section is the prefix before the year. ČSFD uses comma
+    # or just spaces depending on the template; split on both.
+    country_str = raw[: year_m.start()] if year_m else raw
+    countries = [c.strip() for c in re.split(r"[,/]+", country_str) if c.strip()]
+    iso = [_CSFD_COUNTRY_TO_ISO.get(c) for c in countries]
+    iso = [c for c in iso if c]
+    return iso, year, runtime
+
+
+# TMDB ISO codes are uppercased; convert when comparing.
+def tmdb_country_iso_lower(name: str) -> str:
+    return name.lower()
+
+
+def _abort_pending_nav(page) -> None:
+    """Call window.stop() to abort any lingering navigation. Without this,
+    a Playwright goto() timeout leaves the underlying navigation pending,
+    and the very next goto() on the same page throws
+    "Navigation to … is interrupted by another navigation". This cascades —
+    one slow page poisons the entire run. Safe no-op if no nav is pending."""
+    try:
+        page.evaluate("() => window.stop()")
+    except Exception:
+        # If the page is in a torn-down state, just ignore — the next goto
+        # will reset things.
+        pass
+
+
+class PageHolder:
+    """Thin wrapper around a Playwright `Page` that transparently reopens
+    a new page if the tab gets closed mid-run.
+
+    Background: long ČSFD search runs sometimes had the script's tab
+    closed externally (Edge crash, user closing the wrong tab, network
+    flake that tore down the page object). Every subsequent goto() then
+    raised "Target page, context or browser has been closed" forever,
+    silently turning the run into ~30s/row of pure errors. This holder
+    catches that specific failure, creates a fresh page from the same
+    browser context, and lets the caller retry once. The context (=Edge
+    profile, cookies, Anubis solve) survives, so the new page resumes
+    where the old one died."""
+
+    _CLOSED_MARKERS = (
+        "Target page, context or browser has been closed",
+        "Target closed",
+        "Browser has been closed",
+    )
+
+    def __init__(self, ctx):
+        self.ctx = ctx
+        self.page = ctx.new_page()
+
+    def _is_closed_error(self, e: BaseException) -> bool:
+        s = str(e)
+        return any(m in s for m in self._CLOSED_MARKERS)
+
+    def _reopen(self) -> None:
+        logging.warning("page closed externally — reopening")
+        try:
+            self.page.close()
+        except Exception:
+            pass
+        self.page = self.ctx.new_page()
+
+    def goto(self, url, **kw):
+        try:
+            return self.page.goto(url, **kw)
+        except Exception as e:
+            if self._is_closed_error(e):
+                self._reopen()
+                return self.page.goto(url, **kw)
+            raise
+
+    def wait_for_selector(self, *a, **kw):
+        return self.page.wait_for_selector(*a, **kw)
+
+    def evaluate(self, *a, **kw):
+        try:
+            return self.page.evaluate(*a, **kw)
+        except Exception as e:
+            if self._is_closed_error(e):
+                self._reopen()
+                return None
+            raise
+
+    def close(self) -> None:
+        try:
+            self.page.close()
+        except Exception:
+            pass
+
+
+def _safe_goto(page, url: str, timeout_ms: int) -> bool:
+    """Navigate, swallow TimeoutError, and ensure the page is in a usable
+    state for the next call. Returns True on success, False on failure.
+
+    `wait_until='commit'` returns as soon as the response headers arrive
+    (much faster than 'domcontentloaded'). We then wait for our selector
+    of interest separately, which has its own timeout — meaning a slow
+    DOM doesn't block the whole request, but we still wait for the
+    elements we'll parse."""
+    try:
+        page.goto(url, wait_until="commit", timeout=timeout_ms)
+        return True
+    except Exception as e:
+        logging.warning("nav failed for %s: %s", url, str(e).split("\n")[0])
+        _abort_pending_nav(page)
+        return False
+
+
+def search_csfd(page, query: str, timeout_ms: int = 30000) -> list[dict] | None:
+    url = "https://www.csfd.cz/hledat/?" + urllib.parse.urlencode({"q": query})
+    if not _safe_goto(page, url, timeout_ms):
+        return None
+    try:
+        page.wait_for_selector(
+            "header.article-header, .search-no-results", timeout=8000
+        )
+    except Exception:
+        # Page committed but didn't render search container. Treat as
+        # no_results rather than error — usually means a redirect to a
+        # film detail page (single hit), which we don't try to parse here.
+        _abort_pending_nav(page)
+        return []
+    try:
+        data = page.evaluate(_SEARCH_JS)
+    except Exception as e:
+        logging.warning("search eval failed for %r: %s", query,
+                        str(e).split("\n")[0])
+        return None
+    if data.get("hasNoResults") and not data.get("results"):
+        return []
+    return data.get("results", [])
+
+
+def fetch_detail(page, csfd_id: int, timeout_ms: int = 30000) -> dict | None:
+    url = f"https://www.csfd.cz/film/{csfd_id}/prehled/"
+    if not _safe_goto(page, url, timeout_ms):
+        return None
+    try:
+        page.wait_for_selector(".origin, .creators", timeout=8000)
+    except Exception:
+        # Page committed but no metadata rendered. Skip rather than
+        # return garbage — scoring will treat it as detail_fetch_failed.
+        _abort_pending_nav(page)
+        return None
+    try:
+        return page.evaluate(_DETAIL_JS)
+    except Exception as e:
+        logging.warning("detail eval failed for %d: %s", csfd_id,
+                        str(e).split("\n")[0])
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+
+def score_candidate(
+    cr_row: dict,
+    cand_year: int | None,
+    cand_iso: list[str],
+    cand_runtime: int | None,
+    cand_directors_norm: set[str],
+    cand_actors_norm: set[str],
+    cr_iso: list[str] | None,
+) -> tuple[int, dict]:
+    """Returns (score, breakdown_dict)."""
+    breakdown: dict[str, int | list[str]] = {}
+    s = 0
+
+    # Year
+    if cr_row.get("year") and cand_year:
+        diff = abs(cr_row["year"] - cand_year)
+        if diff == 0:
+            s += 5
+            breakdown["year"] = 5
+        elif diff == 1:
+            s += 1
+            breakdown["year"] = 1
+        else:
+            breakdown["year"] = 0
+    else:
+        breakdown["year"] = 0
+
+    # Country (overlap on any ISO code)
+    if cr_iso and cand_iso:
+        if set(cr_iso) & set(cand_iso):
+            s += 3
+            breakdown["country"] = 3
+        else:
+            breakdown["country"] = 0
+    else:
+        breakdown["country"] = 0
+
+    # Runtime
+    if cr_row.get("runtime_min") and cand_runtime:
+        if abs(cr_row["runtime_min"] - cand_runtime) <= 10:
+            s += 5
+            breakdown["runtime"] = 5
+        else:
+            breakdown["runtime"] = 0
+    else:
+        breakdown["runtime"] = 0
+
+    # Directors — strong signal. Per matched name +25.
+    cr_dir = {normalise_name(n) for n in (cr_row.get("directors") or "").split("|") if n}
+    matched_dir = sorted(cr_dir & cand_directors_norm)
+    s += 25 * len(matched_dir)
+    breakdown["directors"] = matched_dir
+
+    # Actors — moderate signal. Per match +5, capped at 25.
+    cr_act = {normalise_name(n) for n in (cr_row.get("actors") or "").split("|") if n}
+    matched_act = sorted(cr_act & cand_actors_norm)[:8]
+    bonus = min(5 * len(matched_act), 25)
+    s += bonus
+    breakdown["actors"] = matched_act
+    breakdown["actors_bonus"] = bonus
+
+    return s, breakdown
+
+
+# ---------------------------------------------------------------------------
+# Extract phase
+# ---------------------------------------------------------------------------
+
+
+HEADER = [
+    "row_id", "imdb_id", "tmdb_id", "title", "original_title", "year",
+    "runtime_min", "n_candidates", "best_csfd_id", "best_score",
+    "best_title", "best_year", "runner_up_score", "match_field",
+    "gate", "details_json",
+]
+
+
+def load_processed(path: Path) -> set[int]:
+    if not path.exists():
+        return set()
+    seen = set()
+    with path.open() as f:
+        for row in csv.DictReader(f, delimiter="\t"):
+            try:
+                seen.add(int(row["row_id"]))
+            except (ValueError, KeyError):
+                pass
+    return seen
+
+
+def filter_candidates(cr_row: dict, results: list[dict]) -> list[tuple[dict, str]]:
+    """Return up to 5 candidates whose normalised title matches
+    cr.title or cr.original_title AND |year diff| ≤ 2."""
+    n_title = normalise(cr_row.get("title"))
+    n_orig = normalise(cr_row.get("original_title"))
+    out: list[tuple[dict, str]] = []
+    for r in results:
+        n_r = normalise(r["title"])
+        if n_title and n_r == n_title:
+            field = "title"
+        elif n_orig and n_r == n_orig:
+            field = "original_title"
+        else:
+            continue
+        if cr_row.get("year") and r.get("year"):
+            if abs(cr_row["year"] - r["year"]) > 2:
+                continue
+        out.append((r, field))
+        if len(out) >= 5:
+            break
+    return out
+
+
+def extract(args, conn) -> None:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    cdp = os.environ.get("EDGE_CDP", "http://localhost:9226")
+    tables = TABLES if args.table == "all" else (args.table,)
+
+    with sync_playwright() as p:
+        browser = p.chromium.connect_over_cdp(cdp)
+        ctx = browser.contexts[0] if browser.contexts else browser.new_context()
+        # PageHolder reopens transparently if the tab is closed externally.
+        page = PageHolder(ctx)
+        try:
+            for table in tables:
+                rows = fetch_rows_with_credits(conn, table, args.limit)
+                path = OUT_DIR / f"{table}.tsv"
+                seen = load_processed(path)
+                logging.info(
+                    "table=%s rows=%d already=%d", table, len(rows), len(seen)
+                )
+                if not rows:
+                    continue
+                mode = "a" if seen else "w"
+                with path.open(mode, newline="", buffering=1) as f:
+                    w = csv.writer(f, delimiter="\t")
+                    if not seen:
+                        w.writerow(HEADER)
+                    counters = {"accept": 0, "needs_review": 0,
+                                "no_match": 0, "no_results": 0,
+                                "error": 0}
+                    for i, cr_row in enumerate(rows):
+                        if cr_row["id"] in seen:
+                            continue
+                        if (i + 1) % 50 == 0:
+                            logging.info(
+                                "table=%s progress=%d/%d %s",
+                                table, i + 1, len(rows), counters,
+                            )
+                        query = cr_row.get("title") or cr_row.get("original_title")
+                        if not query:
+                            continue
+                        results = search_csfd(page, query)
+                        if results is None:
+                            w.writerow([cr_row["id"], cr_row.get("imdb_id") or "",
+                                        cr_row.get("tmdb_id") or "",
+                                        cr_row.get("title") or "",
+                                        cr_row.get("original_title") or "",
+                                        cr_row.get("year") or "",
+                                        cr_row.get("runtime_min") or "",
+                                        0, "", "", "", "", "", "", "error", ""])
+                            counters["error"] += 1
+                            time.sleep(args.sleep)
+                            continue
+                        if not results:
+                            w.writerow([cr_row["id"], cr_row.get("imdb_id") or "",
+                                        cr_row.get("tmdb_id") or "",
+                                        cr_row.get("title") or "",
+                                        cr_row.get("original_title") or "",
+                                        cr_row.get("year") or "",
+                                        cr_row.get("runtime_min") or "",
+                                        0, "", "", "", "", "", "", "no_results", ""])
+                            counters["no_results"] += 1
+                            time.sleep(args.sleep)
+                            continue
+                        candidates = filter_candidates(cr_row, results)
+                        if not candidates:
+                            w.writerow([cr_row["id"], cr_row.get("imdb_id") or "",
+                                        cr_row.get("tmdb_id") or "",
+                                        cr_row.get("title") or "",
+                                        cr_row.get("original_title") or "",
+                                        cr_row.get("year") or "",
+                                        cr_row.get("runtime_min") or "",
+                                        len(results), "", "", "", "",
+                                        "", "", "no_match", ""])
+                            counters["no_match"] += 1
+                            time.sleep(args.sleep)
+                            continue
+                        # Score each candidate.
+                        time.sleep(args.sleep)
+                        scored: list[dict] = []
+                        for cand, field in candidates:
+                            detail = fetch_detail(page, cand["csfd_id"])
+                            time.sleep(args.sleep)
+                            if not detail:
+                                scored.append({
+                                    "csfd_id": cand["csfd_id"],
+                                    "title": cand["title"],
+                                    "year": cand["year"],
+                                    "score": -1,
+                                    "field": field,
+                                    "breakdown": {"error": "detail_fetch_failed"},
+                                })
+                                continue
+                            iso, det_year, runtime = parse_origin(detail.get("origin_raw"))
+                            roles = detail.get("roles") or {}
+                            dir_names = {normalise_name(n) for n in roles.get("Režie", [])}
+                            act_names = {normalise_name(n) for n in roles.get("Hrají", [])[:15]}
+                            sc, bd = score_candidate(
+                                cr_row, cand["year"] or det_year, iso, runtime,
+                                dir_names, act_names, cr_iso=None,
+                            )
+                            scored.append({
+                                "csfd_id": cand["csfd_id"],
+                                "title": cand["title"],
+                                "year": cand["year"] or det_year,
+                                "score": sc,
+                                "field": field,
+                                "breakdown": bd,
+                                "csfd_directors": list(roles.get("Režie", []))[:4],
+                                "csfd_actors": list(roles.get("Hrají", []))[:8],
+                                "csfd_origin": detail.get("origin_raw"),
+                            })
+                        scored.sort(key=lambda d: d["score"], reverse=True)
+                        best = scored[0]
+                        runner = scored[1]["score"] if len(scored) > 1 else 0
+                        if (best["score"] >= args.accept_score and
+                            (runner <= 0 or best["score"] >= runner * args.margin)):
+                            gate = "accept"
+                            counters["accept"] += 1
+                        else:
+                            gate = "needs_review"
+                            counters["needs_review"] += 1
+                        w.writerow([
+                            cr_row["id"], cr_row.get("imdb_id") or "",
+                            cr_row.get("tmdb_id") or "",
+                            cr_row.get("title") or "",
+                            cr_row.get("original_title") or "",
+                            cr_row.get("year") or "",
+                            cr_row.get("runtime_min") or "",
+                            len(candidates), best["csfd_id"], best["score"],
+                            best["title"], best["year"] or "", runner,
+                            best["field"], gate,
+                            json.dumps(scored, ensure_ascii=False),
+                        ])
+                logging.info("table=%s done: %s", table, counters)
+        finally:
+            page.close()
+            browser.close()
+
+
+# ---------------------------------------------------------------------------
+# Apply phase
+# ---------------------------------------------------------------------------
+
+
+def apply_(args, conn) -> None:
+    tables = TABLES if args.table == "all" else (args.table,)
+    grand = {"applied": 0, "skipped_collision": 0,
+             "skipped_needs_review": 0, "skipped_already_set": 0,
+             "missing_file": 0}
+    for table in tables:
+        path = OUT_DIR / f"{table}.tsv"
+        if not path.exists():
+            grand["missing_file"] += 1
+            continue
+        with path.open() as f:
+            rows = list(csv.DictReader(f, delimiter="\t"))
+        applied = 0
+        for r in rows:
+            if r["gate"] != "accept":
+                grand["skipped_needs_review"] += 1
+                continue
+            row_id = int(r["row_id"])
+            csfd = int(r["best_csfd_id"])
+            collision = csfd_id_used_by(conn, table, csfd)
+            if collision and collision != row_id:
+                grand["skipped_collision"] += 1
+                continue
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"UPDATE {table} SET csfd_id = %s "
+                    f"WHERE id = %s AND csfd_id IS NULL",
+                    (csfd, row_id),
+                )
+                if cur.rowcount == 0:
+                    grand["skipped_already_set"] += 1
+                    continue
+                grand["applied"] += 1
+                applied += 1
+        if args.dry_run:
+            conn.rollback()
+            logging.info("--dry-run %s would apply %d", table, applied)
+        else:
+            conn.commit()
+            logging.info("%s applied %d", table, applied)
+    logging.info("summary: %s", grand)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    e = sub.add_parser("extract")
+    e.add_argument("--table", choices=(*TABLES, "all"), default="all")
+    e.add_argument("--limit", type=int, default=None)
+    e.add_argument("--sleep", type=float, default=1.5)
+    e.add_argument("--accept-score", type=int, default=30,
+                   help="Min score to auto-accept (default 30 ≈ director match)")
+    e.add_argument("--margin", type=float, default=2.0,
+                   help="Best must be ≥ margin × runner-up score (default 2.0)")
+
+    a = sub.add_parser("apply")
+    a.add_argument("--table", choices=(*TABLES, "all"), default="all")
+    a.add_argument("--dry-run", action="store_true")
+
+    args = p.parse_args()
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        print("DATABASE_URL must be set", file=sys.stderr)
+        return 2
+    conn = psycopg2.connect(dsn)
+    try:
+        if args.cmd == "extract":
+            extract(args, conn)
+        elif args.cmd == "apply":
+            apply_(args, conn)
+    finally:
+        conn.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
<!-- claude-session: fd55863a-01fd-456b-b70d-ea0440e6400a -->

Follow-up to #730 / #740 — the Wikidata-based resolver from #732 only fills `csfd_id` where Wikidata has the `P345 → P2529` chain. After that work, ~6 632 cr rows still lacked `csfd_id` because Wikidata's `P2529` is incomplete. These two scripts close that gap with safer-than-blind-search verification, and were used to push films coverage from **87.3 % → 96.4 %** on prod (2026-05-17).

## Summary

- `scripts/resolve-csfd-via-cswiki.py` — Wikipedia external-links fallback. For each row missing `csfd_id` but with `imdb_id`, asks Wikidata SPARQL for the cs-wiki sitelink, then fetches the article via MediaWiki API and parses `csfd.cz/film/{id}` from external links. Two-phase TSV-driven workflow (`extract` → `apply`). Safety gate: normalised cs-wiki article title must match `cr.title` or `cr.original_title`. Sibling-collision check at apply. **Recovered 333 csfd_id values** on the prod run.
- `scripts/resolve-csfd-via-search.py` — ČSFD title search with metadata corroboration. Connects to Edge over CDP (Anubis cookie persists in the per-workspace profile), navigates `csfd.cz/hledat/?q={title}`, then fetches `/film/{id}/prehled/` for each candidate. Scores against cr's local credits (`film_directors` / `film_actors` / `series_*`):

| Signal | Points |
|---|---|
| director name match (per name) | +25 |
| top-cast name match (per name, cap 5) | +5 |
| year exact / ±1 | +5 / +1 |
| runtime ±10 min | +5 |
| country overlap | +3 |

  Accepts only when score ≥ 30 AND best ≥ 2× runner-up. Resumable TSV, `PageHolder` transparently reopens on external tab closure, `wait_until='commit'` + `window.stop()` prevents the timeout→pending-nav cascade that bit the first run. **Recovered 2538 csfd_id values** on the prod run; 2662 in `needs_review` for manual triage.

## Coverage delta on prod (2026-05-17)

| Table    | Before #730 | After Wiki | After ČSFD search |
|----------|-------------|------------|-------------------|
| films    | 87.3 %      | 87.6 %     | **96.4 %** (+2584) |
| series   | 47.0 %      | 51.2 %     | 48.3 %\* (+287 abs) |
| tv_shows | 29.9 %      | 29.9 %     | 29.9 % (+0)        |
| total feed rows | 27 543 | 27 876 | **30 414**         |

\*series % decreased because the total grew faster (+420 auto-imported rows) than the +287 csfd_id additions; absolute coverage went up.

## Why not extend the existing resolver

These are higher-cost, higher-latency paths (cs-wiki API call per row, ČSFD detail-page fetch per candidate at 1.5 s/req, ~3 h end-to-end run). Folding them into the weekly `scripts/resolve-csfd-via-wikidata.py` systemd timer would make every weekly run a multi-hour job for negligible incremental gain. They're written as one-off backfill scripts that the maintainer kicks off explicitly when residual coverage matters. The resolver from #732 keeps running fast on its weekly cadence; these scripts complement it without entangling.

## Gitignored output

The resolver TSV output (`data/csfd-{cswiki,search}/*.tsv`) is per-row JSON-embedded candidate scoring — regenerable, too large for code review, and irrelevant to anyone but the maintainer doing manual triage. Added `data/csfd-cswiki/` and `data/csfd-search/` to `.gitignore`.

## Test plan

- [x] `cargo check` / build is unaffected (Python-only changes outside the Rust workspace)
- [x] Scripts compile (`python3 -c 'import py_compile; py_compile.compile(...)'`)
- [x] cswiki `extract` + `apply` run end-to-end on prod (2026-05-16, +333 rows)
- [x] search `extract` + `apply` run end-to-end on prod (2026-05-17, +2538 rows)
- [x] Public `/api/csfd-watchlist.json` feed reflects new coverage (`count: 30 414`)
- [ ] Reviewer: spot-check 5 randomly-picked search `accept` rows against ČSFD by IMDb ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)