### PR TITLE
fix(series): allow Kids genre — Pokémon Horizonty + LEGO + 8 others discover-attached

### DIFF
--- a/scripts/import-prehrajto-series.py
+++ b/scripts/import-prehrajto-series.py
@@ -458,8 +458,15 @@ def enrich_one_series(
 #
 # Genres skipped (out of scope for the IMDB-backed `series` table —
 # they belong to `tv_shows`/`tv_episodes`):
-#   10764 Reality, 10767 Talk, 10763 News, 10762 Kids
-TV_SHOWS_GENRES: frozenset[int] = frozenset({10764, 10767, 10763, 10762})
+#   10764 Reality, 10767 Talk, 10763 News
+#
+# 10762 Kids USED to be in this set, but #747 found that legitimate
+# IMDB-backed series with full TMDB metadata also carry the Kids tag
+# (Pokémon Horizonty, LEGO Ninjago: Dračí povstání, Jednorožčí
+# akademie, etc.). Excluding them left those shows uncatalogued in
+# either table. Kids stays in `series`; only the genuinely-non-series
+# Reality/Talk/News categories belong in `tv_shows`.
+TV_SHOWS_GENRES: frozenset[int] = frozenset({10764, 10767, 10763})
 
 
 # IMDB ratings index — loaded once per run from the cached TSV that
@@ -895,9 +902,9 @@ def discover_one_cluster(
     stats.tmdb_id = tv.tmdb_id
     stats.tmdb_name = tv.name_cs or tv.name_en or tv.original_name
 
-    # 2. Genre filter — Reality / Talk / News / Kids belong to tv_shows
-    # not series. Skip those clusters here; if the user wants them, a
-    # separate tv_shows importer is the right home.
+    # 2. Genre filter — Reality / Talk / News belong to tv_shows, not
+    # series. Kids was dropped from this filter in #747 (see comment on
+    # TV_SHOWS_GENRES above).
     blocked = TV_SHOWS_GENRES & set(tv.genre_ids or ())
     if blocked:
         stats.status = f"blocked_genre: {sorted(blocked)}"


### PR DESCRIPTION
<!-- claude-session: e5713c88-75a7-4380-8c08-7327c983587b -->

Closes #747

## Summary
Drop `10762 Kids` from `TV_SHOWS_GENRES` in `scripts/import-prehrajto-series.py`. Reality / Talk / News stay filtered (those genuinely belong to the `tv_shows` table), but Kids covers legitimate IMDB-backed series with full TMDB metadata (Pokémon Horizonty, LEGO Ninjago: Dračí povstání, Jednorožčí akademie, …) that were falling between two tables — discover skipped them, no `tv_shows` importer existed for them.

## Verification on production (already deployed locally)

Ran targeted re-discover after the fix:
```
$ python3 scripts/import-prehrajto-series.py --mode discover --match Pokemon --limit 5

| # | cluster              |   upl |  eps | tmdb_id | series_id | new | +ep | +src |
|--:|----------------------|------:|-----:|--------:|----------:|----:|----:|-----:|
|  3 | Pokémon Horizonty    |   124 |   84 |  220150 |      9663 |  Y  |  44 |   84 |
```

Series #9663 created with cover, Gemma description, 44 episodes, 84 prehraj.to sources.

A separate full re-run (`--mode discover --limit 0`) is in progress and will pick up LEGO Ninjago: Dračí povstání, Jednorožčí akademie, and all other previously-blocked Kids clusters.

## Test plan
- [x] Local syntax check: `python3 -m py_compile scripts/import-prehrajto-series.py`
- [x] rsync to prod, run `--match Pokemon --limit 5` → Pokémon Horizonty created
- [x] DB check: `SELECT id,title,(SELECT COUNT(*) FROM episodes WHERE series_id=9663) FROM series WHERE id=9663` → 44 eps, 84 sources
- [x] Playwright on https://ceskarepublika.wiki/serialy-online/pokemon-horizonty-serial/ → page renders, cover loads, 44 episodes listed, 0 console errors
- [x] Playwright on https://ceskarepublika.wiki/serialy-online/pokemon-horizonty-serial/1x1/ → video player resolves prehraj.to source via /api/movies/video-url proxy, 0 console errors
- [ ] Full discover re-run completes — will create remaining Kids clusters