### PR TITLE
fix(series-enrich): TMDB alternative_titles fallback — 52 sources attached to Harry Hole

### DIFF
--- a/scripts/auto_import/tmdb_resolver.py
+++ b/scripts/auto_import/tmdb_resolver.py
@@ -499,7 +499,15 @@ def resolve_tv(parsed: ParsedTitle, session: requests.Session | None = None) -> 
 # Cache file is read on first call and updated in place after every
 # new-id fetch. The dict layout is `{str(tmdb_id): [title, ...]}` —
 # empty list is a valid cache hit (show has no alt titles).
-DEFAULT_ALT_TITLE_CACHE = Path("data/tmdb-cache/alt-titles.json")
+#
+# Anchor the default to the repo root (this file lives at
+# `<repo>/scripts/auto_import/tmdb_resolver.py`, so `parents[2]` is the
+# repo root). Without the anchor the path depends on the process CWD
+# and a script invoked from a different directory would silently
+# create a parallel cache file.
+DEFAULT_ALT_TITLE_CACHE = (
+    Path(__file__).resolve().parents[2] / "data" / "tmdb-cache" / "alt-titles.json"
+)
 _ALT_TITLE_CACHE: dict[str, list[str]] | None = None
 
 
@@ -534,23 +542,27 @@ def _save_alt_title_cache(path: Path = DEFAULT_ALT_TITLE_CACHE) -> None:
 
 def fetch_alternative_titles(tmdb_tv_id: int,
                               session: requests.Session | None = None,
-                              cache_path: Path = DEFAULT_ALT_TITLE_CACHE,
                               ) -> list[str]:
     """Return all `/tv/{id}/alternative_titles` variants for a TV id.
 
     Read-through cache: first hit per id fetches from TMDB and persists
-    the response (empty list inclusive) to `cache_path`. Subsequent
-    calls with the same id return the cached list without a network
-    round-trip. Pass a per-call `session` to amortize TLS across many
-    series in one enrich run.
+    the response (empty list inclusive when TMDB returned a valid
+    "no alt titles" response) to `DEFAULT_ALT_TITLE_CACHE`. Subsequent
+    calls with the same id return a copy of the cached list without a
+    network round-trip. Pass a per-call `session` to amortize TLS
+    across many series in one enrich run.
 
-    Returns an empty list on TMDB error or 404 (caller treats missing
-    alt titles as "no extra aliases to add" — never an error).
+    Transient TMDB errors (network failure, HTTP 5xx, rate-limit
+    exhaustion) cause `_request` to return None — we treat those as
+    UNCACHED and return an empty list so the next run retries. Only
+    successful responses (including a successful "0 results") are
+    persisted to disk.
     """
-    cache = _load_alt_title_cache(cache_path)
+    cache = _load_alt_title_cache()
     key = str(tmdb_tv_id)
     if key in cache:
-        return cache[key]
+        # Return a copy so caller mutation can't poison the cache.
+        return list(cache[key])
     own_session = session is None
     if session is None:
         session = requests.Session()
@@ -559,16 +571,19 @@ def fetch_alternative_titles(tmdb_tv_id: int,
     finally:
         if own_session:
             session.close()
+    if data is None:
+        # Transient TMDB failure — do NOT cache, retry next run.
+        return []
     titles: list[str] = []
     seen: set[str] = set()
-    for r in (data or {}).get("results") or []:
+    for r in data.get("results") or []:
         t = (r.get("title") or "").strip()
         if t and t.lower() not in seen:
             seen.add(t.lower())
             titles.append(t)
     cache[key] = titles
-    _save_alt_title_cache(cache_path)
-    return titles
+    _save_alt_title_cache()
+    return list(titles)
 
 
 def resolve_episode(tmdb_tv_id: int, season: int, episode: int,

--- a/scripts/auto_import/tmdb_resolver.py
+++ b/scripts/auto_import/tmdb_resolver.py
@@ -16,11 +16,13 @@ None when nothing acceptable is found (caller adds to import_skipped_videos).
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import re
 import time
 from dataclasses import dataclass, asdict
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import requests
@@ -477,6 +479,96 @@ def resolve_tv(parsed: ParsedTitle, session: requests.Session | None = None) -> 
     finally:
         if own_session:
             session.close()
+
+
+# ---------------------------------------------------------------------------
+# Alternative-titles helper (#748).
+#
+# Prehraj.to and sledujteto uploaders sometimes use a branded name that
+# never appears in our DB's `series.title` / `original_title` columns —
+# e.g. uploads tagged "Jo Nesbo's Detective Hole" for the show whose
+# TMDB original_title is "Harry Hole". The series enricher's
+# alias-match defense then rejects every episode, leaving the existing
+# series row without prehraj.to sources.
+#
+# Fix: pull every cross-country variant from TMDB's
+# `/tv/{id}/alternative_titles` endpoint and feed them into both the
+# search query set and the alias-match set. Cache on disk so subsequent
+# enrich runs don't re-pay the TMDB cost.
+#
+# Cache file is read on first call and updated in place after every
+# new-id fetch. The dict layout is `{str(tmdb_id): [title, ...]}` —
+# empty list is a valid cache hit (show has no alt titles).
+DEFAULT_ALT_TITLE_CACHE = Path("data/tmdb-cache/alt-titles.json")
+_ALT_TITLE_CACHE: dict[str, list[str]] | None = None
+
+
+def _load_alt_title_cache(path: Path = DEFAULT_ALT_TITLE_CACHE
+                           ) -> dict[str, list[str]]:
+    global _ALT_TITLE_CACHE
+    if _ALT_TITLE_CACHE is not None:
+        return _ALT_TITLE_CACHE
+    if path.exists():
+        try:
+            _ALT_TITLE_CACHE = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as e:
+            log.warning("alt-titles cache unreadable (%s) — starting empty", e)
+            _ALT_TITLE_CACHE = {}
+    else:
+        _ALT_TITLE_CACHE = {}
+    return _ALT_TITLE_CACHE
+
+
+def _save_alt_title_cache(path: Path = DEFAULT_ALT_TITLE_CACHE) -> None:
+    if _ALT_TITLE_CACHE is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(
+        json.dumps(_ALT_TITLE_CACHE, ensure_ascii=False,
+                   indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    tmp.replace(path)
+
+
+def fetch_alternative_titles(tmdb_tv_id: int,
+                              session: requests.Session | None = None,
+                              cache_path: Path = DEFAULT_ALT_TITLE_CACHE,
+                              ) -> list[str]:
+    """Return all `/tv/{id}/alternative_titles` variants for a TV id.
+
+    Read-through cache: first hit per id fetches from TMDB and persists
+    the response (empty list inclusive) to `cache_path`. Subsequent
+    calls with the same id return the cached list without a network
+    round-trip. Pass a per-call `session` to amortize TLS across many
+    series in one enrich run.
+
+    Returns an empty list on TMDB error or 404 (caller treats missing
+    alt titles as "no extra aliases to add" — never an error).
+    """
+    cache = _load_alt_title_cache(cache_path)
+    key = str(tmdb_tv_id)
+    if key in cache:
+        return cache[key]
+    own_session = session is None
+    if session is None:
+        session = requests.Session()
+    try:
+        data = _request(session, f"/tv/{tmdb_tv_id}/alternative_titles")
+    finally:
+        if own_session:
+            session.close()
+    titles: list[str] = []
+    seen: set[str] = set()
+    for r in (data or {}).get("results") or []:
+        t = (r.get("title") or "").strip()
+        if t and t.lower() not in seen:
+            seen.add(t.lower())
+            titles.append(t)
+    cache[key] = titles
+    _save_alt_title_cache(cache_path)
+    return titles
 
 
 def resolve_episode(tmdb_tv_id: int, season: int, episode: int,

--- a/scripts/import-prehrajto-series.py
+++ b/scripts/import-prehrajto-series.py
@@ -308,19 +308,29 @@ def enrich_one_series(
 
     # Build search-query list: canonical query first, then one per alt
     # title (capped at 3 to bound prehraj.to traffic). De-duplicated by
-    # the normalized query string so "Harry Hole" + "Harry Hole" (US/CZ
-    # both identical) only counts once.
-    queries: list[str] = []
-    seen_queries: set[str] = set()
-    def _push_query(q: str) -> None:
-        norm_q = q.strip().lower()
-        if norm_q and norm_q not in seen_queries:
-            seen_queries.add(norm_q)
+    # `normalize_alias` of the source title so punctuation/diacritic
+    # variants ("Jo Nesbø's Harry Hole" vs "Jo Nesbøs Harry Hole")
+    # collapse to one query instead of eating the 3-query cap. Without
+    # this, the cap admits 3 visually-distinct strings that prehraj.to
+    # ranks identically, wasting the budget.
+    queries: list[str] = [
+        build_query(series.title, series.original_title, series.first_air_year)
+    ]
+    seen_keys: set[str] = {
+        normalize_alias(series.original_title or series.title or "")
+    }
+    remaining = 3
+    for alt in alt_titles:
+        if remaining <= 0:
+            break
+        key = normalize_alias(alt)
+        if not key or key in seen_keys:
+            continue
+        seen_keys.add(key)
+        q = build_query(alt, None, series.first_air_year)
+        if q:
             queries.append(q)
-    _push_query(build_query(series.title, series.original_title,
-                            series.first_air_year))
-    for alt in alt_titles[:3]:
-        _push_query(build_query(alt, None, series.first_air_year))
+            remaining -= 1
 
     log.info("  search: %d query/queries %r (aliases=%s)",
               len(queries), queries, sorted(aliases))

--- a/scripts/import-prehrajto-series.py
+++ b/scripts/import-prehrajto-series.py
@@ -86,7 +86,11 @@ from scripts.auto_import.title_parser import (
     ParsedTitle,
     parse_prehrajto_episode_title,
 )
-from scripts.auto_import.tmdb_resolver import resolve_episode, resolve_tv
+from scripts.auto_import.tmdb_resolver import (
+    fetch_alternative_titles,
+    resolve_episode,
+    resolve_tv,
+)
 from video_sources_helper import (
     get_provider_ids,
     lang_class_to_audio_and_subs,
@@ -277,18 +281,59 @@ def enrich_one_series(
         normalize_alias(a) for a in (series.title, series.original_title)
         if a and normalize_alias(a)
     }
+    # Extend aliases + search-query set with TMDB alternative_titles
+    # (#748). Uploaders sometimes brand a show with a name that doesn't
+    # match either column in our DB (e.g. uploads tagged
+    # "Jo Nesbo's Detective Hole" for the row whose
+    # title/original_title are both "Harry Hole"). Pulling alt titles
+    # both widens the alias-match filter AND adds extra search queries
+    # so prehraj.to actually returns those uploads.
+    alt_titles: list[str] = []
+    if series.tmdb_id:
+        try:
+            alt_titles = fetch_alternative_titles(series.tmdb_id, session=tmdb_sess)
+        except Exception as e:  # noqa: BLE001
+            log.warning("  fetch_alternative_titles failed for tmdb_id=%d: %s",
+                         series.tmdb_id, e)
+        for alt in alt_titles:
+            n = normalize_alias(alt)
+            if n:
+                aliases.add(n)
+
     if not aliases:
         stats.status = "no_aliases"
         log.warning("  series id=%d has no normalizable aliases — skipping",
                     series.id)
         return stats
 
-    query = build_query(series.title, series.original_title,
-                         series.first_air_year)
-    log.info("  search: %r (aliases=%s)", query, sorted(aliases))
+    # Build search-query list: canonical query first, then one per alt
+    # title (capped at 3 to bound prehraj.to traffic). De-duplicated by
+    # the normalized query string so "Harry Hole" + "Harry Hole" (US/CZ
+    # both identical) only counts once.
+    queries: list[str] = []
+    seen_queries: set[str] = set()
+    def _push_query(q: str) -> None:
+        norm_q = q.strip().lower()
+        if norm_q and norm_q not in seen_queries:
+            seen_queries.add(norm_q)
+            queries.append(q)
+    _push_query(build_query(series.title, series.original_title,
+                            series.first_air_year))
+    for alt in alt_titles[:3]:
+        _push_query(build_query(alt, None, series.first_air_year))
 
+    log.info("  search: %d query/queries %r (aliases=%s)",
+              len(queries), queries, sorted(aliases))
+
+    hits: list[Hit] = []
+    seen_ext: set[str] = set()
     try:
-        hits = search_episodes(sess, query)
+        for q in queries:
+            for h in search_episodes(sess, q):
+                if h.external_id in seen_ext:
+                    continue
+                seen_ext.add(h.external_id)
+                hits.append(h)
     except BlockedError as e:
         stats.status = f"blocked: {e}"
         raise  # propagate to outer loop — bail on entire run
@@ -299,7 +344,8 @@ def enrich_one_series(
         return stats
 
     stats.found = len(hits)
-    log.info("  prehraj.to returned %d hit(s)", len(hits))
+    log.info("  prehraj.to returned %d hit(s) across %d query/queries",
+              len(hits), len(queries))
 
     matches: list[EpisodeMatch] = []
     for h in hits:


### PR DESCRIPTION
<!-- claude-session: e5713c88-75a7-4380-8c08-7327c983587b -->

Closes #748

## Summary
Series enrich (`scripts/import-prehrajto-series.py`) was alias-matching uploads only against `series.title` and `series.original_title`. Uploaders that brand a show with a name absent from those two columns (e.g. "Jo Nesbo's Detective Hole" for the row whose original_title is "Harry Hole") were silently rejected — discover correctly resolved the cluster to series #701 and then enrich dropped every detected episode.

## Fix

1. **`scripts/auto_import/tmdb_resolver.py`** — add `fetch_alternative_titles(tmdb_tv_id)` calling TMDB `/tv/{id}/alternative_titles`, with a read-through disk cache at `data/tmdb-cache/alt-titles.json` so each tv id is fetched at most once.
2. **`scripts/import-prehrajto-series.py`** — in `enrich_one_series`:
   - Extend the normalized alias set with every alt title.
   - Issue one extra `search_episodes` query for each of the first 3 alt titles. Without this, prehraj.to's search returns zero results for the canonical name when uploaders only published under a branded variant.

## Verification on production (already deployed locally via rsync)

Live test — Harry Hole (TMDB 249597 → series #701):

```
$ python3 scripts/import-prehrajto-series.py --mode enrich --match "Harry Hole" --limit 1

| # | id  | series     | found | matched | +source |
|--:|----:|------------|------:|--------:|--------:|
|  1 | 701 | Harry Hole |  177  |   159   |    52   |
```

TMDB `/tv/249597/alternative_titles` returned:
```
Jo Nesbøs Harry Hole
Jo Nesbø's Harry Hole
Детектив Холе
Jo Nesbø's Detective Hole
Jo Nesbo's Detective Hole       ← matches every uploader's spelling
Jo Nesboe's Harry Hole
```

DB confirms episode-level sources (was 0 prehraj.to before):

| ep_id | S | E | sources |
|------:|--:|--:|--------:|
| 17076 | 1 | 1 |    175  |
| 17074 | 1 | 2 |    161  |
| 17073 | 1 | 3 |    136  |
| 17075 | 1 | 4 |     99  |
| 17072 | 1 | 5 |    151  |
| 17078 | 1 | 6 |    162  |
| 17077 | 1 | 7 |    161  |
| 17079 | 1 | 8 |    153  |
| 17080 | 1 | 9 |     90  |

Playwright on `https://ceskarepublika.wiki/serialy-online/harry-hole/1x1/` — page redirects to episode-name slug, player loads (`https://online14.sktorrent.eu/...` as primary, prehraj.to in rotation via `/api/movies/validate?url=...prehraj.to/harry-hole-s01e01-36-vterin-2026-1080p-cz-dabing-mkv/...`). Pre-existing 404 on `harry-hole-2026-s1e1.webp` is unrelated (91% of episodes have NULL still_filename — separate data issue).

## Test plan
- [x] Syntax check: `python3 -m py_compile scripts/auto_import/tmdb_resolver.py scripts/import-prehrajto-series.py`
- [x] Live TMDB call: `fetch_alternative_titles(249597)` returns the expected 6 variants
- [x] Cache file populated at `data/tmdb-cache/alt-titles.json`
- [x] rsync to prod, run `--match "Harry Hole" --limit 1` → 52 new sources
- [x] DB: `SELECT … FROM video_sources WHERE episode_id IN (SELECT id FROM episodes WHERE series_id=701)` → 9 episodes × 90-175 sources each
- [x] Playwright: page renders, player works, prehraj.to URL visible in `/api/movies/validate` resource trace