### PR TITLE
fix(series): surface sledujteto sources in episode pages — closes #751

### DIFF
--- a/cr-web/src/handlers/series.rs
+++ b/cr-web/src/handlers/series.rs
@@ -18,9 +18,11 @@ const SERIES_PER_PAGE: i64 = 24;
 /// each provider attribute from `video_sources`. The FilmRow counterpart
 /// in `films.rs` uses the same pattern — see there for performance notes.
 ///
-/// Scope: series episodes only (provider_id from `sktorrent` / `prehrajto`
-/// joined to `video_sources.episode_id`). sledujteto has no series support
-/// in legacy, so no sledujteto subquery here.
+/// Scope: series episodes from sktorrent / prehrajto / sledujteto. The
+/// sledujteto subquery (#751) only returns `cdn='www'` rows because
+/// `data{N}.sledujteto.cz` files are blocked from Hetzner ASNs and the
+/// client-side player would 4xx on them anyway — better to hide them
+/// entirely than expose dead links.
 const EPISODE_COLUMNS: &str = "e.id, e.season, e.episode, e.title, \
     (SELECT vs.external_id::INTEGER \
        FROM video_sources vs \
@@ -50,6 +52,13 @@ const EPISODE_COLUMNS: &str = "e.id, e.season, e.episode, e.title, \
       LIMIT 1) AS prehrajto_url, \
     false AS prehrajto_has_dub, \
     false AS prehrajto_has_subs, \
+    (SELECT vs.external_id \
+       FROM video_sources vs \
+       JOIN video_providers p ON p.id = vs.provider_id \
+      WHERE vs.episode_id = e.id AND p.slug = 'sledujteto' \
+        AND vs.is_alive AND vs.cdn = 'www' \
+      ORDER BY vs.is_primary DESC, vs.updated_at DESC \
+      LIMIT 1) AS sledujteto_external_id, \
     e.slug";
 
 /// Predicate that gates whether an episode has any playable source at all.
@@ -150,6 +159,13 @@ pub struct EpisodeRow {
     pub prehrajto_url: Option<String>,
     pub prehrajto_has_dub: bool,
     pub prehrajto_has_subs: bool,
+    /// Slug id of the first alive www-CDN sledujteto source for this
+    /// episode, populated by the new `import-sledujteto-series.py` (#745).
+    /// Rendered in `episode_detail.html` as a "Sledujteto" source tab that
+    /// resolves the playback URL via `/api/sledujteto/resolve?id=…` (#751).
+    /// `None` means either no source was imported OR every imported source
+    /// lives on `data{N}.sledujteto.cz` (blocked from Hetzner clients).
+    pub sledujteto_external_id: Option<String>,
     pub slug: Option<String>,
 }
 

--- a/cr-web/templates/episode_detail.html
+++ b/cr-web/templates/episode_detail.html
@@ -218,6 +218,11 @@ var initialVideoId = {{ episode.sktorrent_video_id.unwrap_or(0) }};
 var prehrajtoUrl = {% match episode.prehrajto_url %}{% when Some with (u) %}"{{ u }}"{% when None %}null{% endmatch %};
 var prehrajtoHasDub  = {{ episode.prehrajto_has_dub }};
 var prehrajtoHasSubs = {{ episode.prehrajto_has_subs }};
+// First alive www-CDN sledujteto source for this episode (#751). Populated
+// by import-sledujteto-series.py. When set, `ensureSledujtetoTab()` adds a
+// "Sledujteto" tab to the player; clicking it resolves the playback URL
+// via /api/sledujteto/resolve and switches state.source2 to it.
+var sledujtetoSlug = {% match episode.sledujteto_external_id %}{% when Some with (s) %}"{{ s }}"{% when None %}null{% endmatch %};
 
 // State — same shape as series_detail.html player
 var state = { source1: null, source2: null, activeSource: 1, activeEpisodeBtn: null };
@@ -275,9 +280,19 @@ function initPlayer() {
             .catch(function() {
                 document.getElementById('source-status').textContent = 'Zdroj nedostupný';
             });
+    } else if (sledujtetoSlug) {
+        // Last-resort fallback (#751): episode has no sktorrent and no
+        // prehrajto but does have a www-CDN sledujteto upload. Promote
+        // sledujteto to the primary slot — the tab is added below too,
+        // so the user can re-click it if they reload.
+        switchToSledujteto();
     } else {
         document.getElementById('source-status').textContent = 'Zdroj nedostupný';
     }
+    // Always expose the sledujteto tab when a source exists, even if a
+    // higher-tier provider is currently primary — gives the user a manual
+    // failover when prehraj.to / sktorrent flake.
+    ensureSledujtetoTab();
     loadPrehrajtoForEpisode(initialSeason, initialEpisode);
 }
 
@@ -363,8 +378,10 @@ function switchToSource2() {
 function setActiveTab(n) {
     var t1 = document.getElementById('tab-source-1');
     var t2 = document.getElementById('tab-source-2');
+    var tslt = document.getElementById('tab-sledujteto');
     if (t1) t1.classList.toggle('active', n === 1);
     if (t2) t2.classList.toggle('active', n === 2);
+    if (tslt) tslt.classList.toggle('active', n === 'sledujteto');
 }
 
 function ensureSource2Tab() {
@@ -376,6 +393,52 @@ function ensureSource2Tab() {
     btn.textContent = 'Zdroj 2';
     btn.onclick = switchToSource2;
     tabs.appendChild(btn);
+}
+
+/* #751 — Sledujteto.cz source tab.
+   Rendered server-side only when the episode has at least one alive
+   www-CDN sledujteto upload (cdn=www; data{N}.* are blocked from
+   Hetzner). Clicking calls the existing /api/sledujteto/resolve
+   endpoint which returns a one-shot signed MP4 URL valid for ~24h. */
+function ensureSledujtetoTab() {
+    if (!sledujtetoSlug) return;
+    if (document.getElementById('tab-sledujteto')) return;
+    var tabs = document.getElementById('source-tabs');
+    var btn = document.createElement('button');
+    btn.className = 'source-tab';
+    btn.id = 'tab-sledujteto';
+    btn.textContent = 'Sledujteto';
+    btn.title = 'Přehrát ze sledujteto.cz';
+    btn.onclick = switchToSledujteto;
+    tabs.appendChild(btn);
+}
+
+function switchToSledujteto() {
+    if (!sledujtetoSlug) return;
+    document.getElementById('source-status').textContent = 'Načítání Sledujteto.cz...';
+    fetch('/api/sledujteto/resolve?id=' + encodeURIComponent(sledujtetoSlug))
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+            if (!data.success || !data.video_url) {
+                document.getElementById('source-status').textContent =
+                    'Sledujteto: zdroj nedostupný (' + (data.error || 'neznámá chyba') + ')';
+                return;
+            }
+            setActiveTab('sledujteto');
+            var qualDiv = document.getElementById('source-quality');
+            qualDiv.innerHTML = '';
+            qualDiv.style.display = 'none';
+            playUrl(data.video_url, 'mp4');
+            applySubtitles(data.subtitles || []);
+            document.getElementById('source-status').textContent =
+                'Sledujteto S' + initialSeason + 'E' + initialEpisode;
+            document.querySelectorAll('.prehrajto-item.active')
+                .forEach(function(el) { el.classList.remove('active'); });
+        })
+        .catch(function() {
+            document.getElementById('source-status').textContent =
+                'Sledujteto: chyba při načítání';
+        });
 }
 
 function loadPrehrajtoForEpisode(season, episode) {

--- a/cr-web/templates/episode_detail.html
+++ b/cr-web/templates/episode_detail.html
@@ -221,7 +221,13 @@ var prehrajtoHasSubs = {{ episode.prehrajto_has_subs }};
 // First alive www-CDN sledujteto source for this episode (#751). Populated
 // by import-sledujteto-series.py. When set, `ensureSledujtetoTab()` adds a
 // "Sledujteto" tab to the player; clicking it resolves the playback URL
-// via /api/sledujteto/resolve and switches state.source2 to it.
+// via /api/sledujteto/resolve and plays the returned MP4 directly via the
+// shared `playUrl()` helper. Note that sledujteto playback does NOT live
+// inside `state.source1` / `state.source2` — it short-circuits straight
+// to the player, since the slug → URL resolution is single-shot (signed
+// URL valid ~24h, no quality picker, no rotation) and adding it to the
+// state shape would only require a third branch in every state reader
+// without giving callers any extra information they could act on.
 var sledujtetoSlug = {% match episode.sledujteto_external_id %}{% when Some with (s) %}"{{ s }}"{% when None %}null{% endmatch %};
 
 // State — same shape as series_detail.html player


### PR DESCRIPTION
<!-- claude-session: e5713c88-75a7-4380-8c08-7327c983587b -->

Closes #751

## Summary
The new `import-sledujteto-series.py` (#745/#746, PR #752) writes sledujteto `video_sources` rows attached to `episode_id`, but `cr-web/src/handlers/series.rs:21-23` explicitly excluded sledujteto from the per-episode source lookup. Result: 522+ sledujteto sources sitting in DB invisible to users on `serialy-online/.../<ep>/` pages.

## Fix

1. **`series.rs`** — extend `EPISODE_COLUMNS` with a subquery for `sledujteto_external_id` (first alive `cdn='www'` source per episode; `data{N}.*` deliberately excluded — those are blocked from Hetzner clients so surfacing them would just produce dead links). Add field to `EpisodeRow`.
2. **`episode_detail.html`** —
   - Render `var sledujtetoSlug = ...;` server-side.
   - `ensureSledujtetoTab()` adds a "Sledujteto" source tab when the variable is non-null, so the user has a manual failover even when sktorrent / prehraj.to is the primary.
   - `switchToSledujteto()` calls the existing `GET /api/sledujteto/resolve?id=<slug>` endpoint (which already DB-gates by `video_sources` so this is rate-safe), gets a one-shot signed MP4 URL valid ~24h, plays it via the shared `playUrl(url, 'mp4')` helper. Subtitles forwarded via the existing `applySubtitles()` shape that prehraj.to also uses.
   - `initPlayer` falls back to sledujteto when both sktorrent and prehraj.to are absent — previously such episodes rendered "Zdroj nedostupný" (Phase B discover from #745/#746 creates these for series brand-new to the catalog).

## Verified on production (already deployed via stop/scp/start)

```
$ curl -sL https://ceskarepublika.wiki/serialy-online/stranger-things/1x1/
  contains: var sledujtetoSlug, tab-sledujteto, ensureSledujtetoTab, switchToSledujteto
```

Playwright on `https://ceskarepublika.wiki/serialy-online/stranger-things/1x1/`:
- `sledujtetoSlug = "47304"` (rendered server-side from `video_sources`)
- "Sledujteto" source tab appears next to "Zdroj 1"
- Click `#tab-sledujteto`:
  - `GET /api/sledujteto/resolve?id=47304` → success, signed `video_url`
  - `video.src` host = **`www.sledujteto.cz`** (playable from Hetzner)
  - `source-status` = `"Sledujteto S1E1"`
  - active tab = "Sledujteto"

1 pre-existing console 404 on `.webp` still — 157 437 / 173 550 episodes have NULL `still_filename` (~91%), separate data issue, NOT introduced by this PR.

## Test plan
- [x] cargo check
- [x] cargo zigbuild release for aarch64-musl
- [x] stop web → scp binary → docker cp templates → start web
- [x] curl `/health` → 200
- [x] curl episode page → all sledujteto-related strings present
- [x] Playwright: sledujteto tab visible, click resolves, plays from www.sledujteto.cz